### PR TITLE
【調整中】ExUnit利用時に投稿リストブロックの投稿者名が正常に表示されない不具合修正

### DIFF
--- a/inc/vk-components/package/class-vk-component-posts.php
+++ b/inc/vk-components/package/class-vk-component-posts.php
@@ -650,13 +650,14 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 
 			if ( $options['display_excerpt'] ) {
 				$is_veu_show_sitemap_exists = function_exists( 'veu_show_sitemap' );
+				$remove_result = false;
 				if ( $is_veu_show_sitemap_exists ) {
-					remove_filter( 'the_content', 'veu_show_sitemap', 7 );
+					$remove_result = remove_filter( 'the_content', 'veu_show_sitemap', 7 );
 				}
 				$html .= '<p class="vk_post_excerpt ' . $layout_type . '-text">';
 				$html .= wp_kses_post( nl2br( get_the_excerpt( $post->ID ) ) );
 				$html .= '</p>';
-				if ( $is_veu_show_sitemap_exists ) {
+				if ( $is_veu_show_sitemap_exists && $remove_result ) {
 					add_filter( 'the_content', 'veu_show_sitemap', 7, 1 );
 				}
 			}

--- a/inc/vk-components/package/class-vk-component-posts.php
+++ b/inc/vk-components/package/class-vk-component-posts.php
@@ -649,9 +649,16 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 			}
 
 			if ( $options['display_excerpt'] ) {
+				$is_veu_show_sitemap_exists = function_exists( 'veu_show_sitemap' );
+				if ( $is_veu_show_sitemap_exists ) {
+					remove_filter( 'the_content', 'veu_show_sitemap', 7 );
+				}
 				$html .= '<p class="vk_post_excerpt ' . $layout_type . '-text">';
 				$html .= wp_kses_post( nl2br( get_the_excerpt( $post->ID ) ) );
 				$html .= '</p>';
+				if ( $is_veu_show_sitemap_exists ) {
+					add_filter( 'the_content', 'veu_show_sitemap', 7, 1 );
+				}
 			}
 
 			if ( $options['display_author'] ) {

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,7 @@ e.g.
 [ Specification Change ] Change the style loaded on the options page to a css file.
 [ Bug fix ][ Tree Shaking ] cope with not(***,***)
 [ Bug fix ][ Heading design ] Fix text-align
+[ Bug fix ][ Post List(Pro) ] Fixed a problem with "Post-List" when ExUnit is enabled.
 
 = 1.36.2 =
 [ Specification Change ] allow iframe on post list filter 

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ e.g.
 [ Specification Change ] Change the style loaded on the options page to a css file.
 [ Bug fix ][ Tree Shaking ] cope with not(***,***)
 [ Bug fix ][ Heading design ] Fix text-align
-[ Bug fix ][ Post List(Pro) ] Fixed a problem with "Post-List" when ExUnit is enabled.
+[ Bug fix ][ Post List(Pro) ] Fixed a problem when ExUnit is enabled.
 
 = 1.36.2 =
 [ Specification Change ] allow iframe on post list filter 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1269 

## どういう変更をしたか？

- 抜粋表示ON時に呼ばれる、get_the_excerptがthe_contentが呼び出しますが、ExUnitでthe_contentのフィルターフックにひっかけている veu_show_sitemapの呼び出しでクエリリセットがかかり投稿者名が正しく表示されないため、フィルタをいったんremoveして、get_the_excerpt後に再び add_filterで元に戻すようにしました。
- 該当箇所はCardで抜粋表示をさせるために使われるため、サイトマップを表示させる必要はありません。上記の処理が一番影響が少なく手っ取り早い処理かと思いました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュワー確認方法と同様


## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- developブランチに変更します。
- ExUnitが有効である事を確認してください。
- ユーザーを2人以上作成し、ブログの記事を2個以上異なるユーザーで作成してください。
- 投稿リストブロックを、投稿者名と抜粋表示を両方ONにして作成してください。
- フロント側で投稿者名が正しくないことを確認してください。
- 当ブランチに切り替えて、npm run buildしてください。
- 上記の投稿リストブロックが正しく表示されることを確認してください。
-  ExUnitを無効化しても正しく動くことを確認してください。
- より良い方法が考えられましたら、ぜひ教えて下さい。


---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
