### PR TITLE
【確認中】オプション画面とブロックエディターで読み込むファイルを分けるためにエントリポイントをオブジェクトに変更

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -17,7 +17,7 @@
 	<exclude-pattern type="relative">^inc/vk-customize-helpers/package/*</exclude-pattern>
 	<exclude-pattern type="relative">^inc/vk-admin/package/*</exclude-pattern>
 	<exclude-pattern type="relative">^inc/term-color/package/*</exclude-pattern>
-	<exclude-pattern type="relative">^inc/vk-blocks/build/block-build.asset.php</exclude-pattern>
+	<exclude-pattern type="relative">^inc/vk-blocks/build/*/index-build.asset.php</exclude-pattern>
 	<exclude-pattern type="relative">^test/phpunit/*</exclude-pattern>
 	<exclude-pattern type="relative">^.git/*</exclude-pattern>
 	<exclude-pattern type="relative">^build/*</exclude-pattern>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -17,7 +17,8 @@
 	<exclude-pattern type="relative">^inc/vk-customize-helpers/package/*</exclude-pattern>
 	<exclude-pattern type="relative">^inc/vk-admin/package/*</exclude-pattern>
 	<exclude-pattern type="relative">^inc/term-color/package/*</exclude-pattern>
-	<exclude-pattern type="relative">^inc/vk-blocks/build/*/index-build.asset.php</exclude-pattern>
+	<exclude-pattern type="relative">^inc/vk-blocks/build/block-build.asset.php</exclude-pattern>
+	<exclude-pattern type="relative">^inc/vk-blocks/build/admin-build.asset.php</exclude-pattern>
 	<exclude-pattern type="relative">^test/phpunit/*</exclude-pattern>
 	<exclude-pattern type="relative">^.git/*</exclude-pattern>
 	<exclude-pattern type="relative">^build/*</exclude-pattern>

--- a/inc/vk-blocks/admin/admin-license.php
+++ b/inc/vk-blocks/admin/admin-license.php
@@ -19,9 +19,3 @@ $vk_blocks_options = vk_blocks_get_options();
 
 	<?php submit_button(); ?>
 </section>
-<script>
-	const licenseKeyElem = document.getElementById('vk-blocks-pro-license-key');
-	licenseKeyElem.addEventListener('blur', (e) => {
-		 licenseKeyElem.value = licenseKeyElem.value.trim();
-	});
-</script>

--- a/inc/vk-blocks/admin/admin.php
+++ b/inc/vk-blocks/admin/admin.php
@@ -161,6 +161,17 @@ function vk_blocks_options_enqueue_scripts( $hook_suffix ) {
 		return;
 	}
 
+	$asset = include VK_BLOCKS_DIR_PATH . 'inc/vk-blocks/build/admin/index-build.asset.php';
+	if ( vk_blocks_is_license_setting() ) {
+		wp_enqueue_script(
+			'vk-blocks-admin-js',
+			VK_BLOCKS_DIR_URL . 'inc/vk-blocks/build/admin/index-build.js',
+			$asset['dependencies'],
+			$asset['version'],
+			true
+		);
+	}
+
 	wp_enqueue_style(
 		'vk_blocks_options-style',
 		VK_BLOCKS_DIR_URL . 'build/vk_blocks_options.css',

--- a/inc/vk-blocks/admin/admin.php
+++ b/inc/vk-blocks/admin/admin.php
@@ -161,16 +161,14 @@ function vk_blocks_options_enqueue_scripts( $hook_suffix ) {
 		return;
 	}
 
-	$asset = include VK_BLOCKS_DIR_PATH . 'inc/vk-blocks/build/admin/index-build.asset.php';
-	if ( vk_blocks_is_license_setting() ) {
-		wp_enqueue_script(
-			'vk-blocks-admin-js',
-			VK_BLOCKS_DIR_URL . 'inc/vk-blocks/build/admin/index-build.js',
-			$asset['dependencies'],
-			$asset['version'],
-			true
-		);
-	}
+	$asset = include VK_BLOCKS_DIR_PATH . 'inc/vk-blocks/build/admin-build.asset.php';
+	wp_enqueue_script(
+		'vk-blocks-admin-js',
+		VK_BLOCKS_DIR_URL . 'inc/vk-blocks/build/admin-build.js',
+		$asset['dependencies'],
+		$asset['version'],
+		true
+	);
 
 	wp_enqueue_style(
 		'vk_blocks_options-style',

--- a/inc/vk-blocks/class-vk-blocks-block-loader.php
+++ b/inc/vk-blocks/class-vk-blocks-block-loader.php
@@ -176,7 +176,7 @@ class VK_Blocks_Block_Loader {
 	 * Register Blocks Assets
 	 */
 	public function register_blocks_assets() {
-		$asset_file = include $this->assets_build_path . 'block-build.asset.php';
+		$asset_file = include VK_BLOCKS_DIR_PATH . 'inc/vk-blocks/build/blocks/index-build.asset.php';
 
 		// 結合CSSを登録.
 		if ( self::should_load_separate_assets() && ! is_admin() ) {
@@ -197,7 +197,7 @@ class VK_Blocks_Block_Loader {
 		// 編集画面のjs登録 : 設定に関わらず結合JSを登録 -> 各ブロックのindex.phpから呼び出される
 		wp_register_script(
 			'vk-blocks-build-js',
-			$this->assets_build_url . 'block-build.js',
+			VK_BLOCKS_DIR_URL . 'inc/vk-blocks/build/blocks/index-build.js',
 			$asset_file['dependencies'],
 			VK_BLOCKS_VERSION,
 			true

--- a/inc/vk-blocks/class-vk-blocks-block-loader.php
+++ b/inc/vk-blocks/class-vk-blocks-block-loader.php
@@ -176,7 +176,7 @@ class VK_Blocks_Block_Loader {
 	 * Register Blocks Assets
 	 */
 	public function register_blocks_assets() {
-		$asset_file = include VK_BLOCKS_DIR_PATH . 'inc/vk-blocks/build/blocks/index-build.asset.php';
+		$asset_file = include $this->assets_build_path . 'block-build.asset.php';
 
 		// 結合CSSを登録.
 		if ( self::should_load_separate_assets() && ! is_admin() ) {
@@ -197,7 +197,7 @@ class VK_Blocks_Block_Loader {
 		// 編集画面のjs登録 : 設定に関わらず結合JSを登録 -> 各ブロックのindex.phpから呼び出される
 		wp_register_script(
 			'vk-blocks-build-js',
-			VK_BLOCKS_DIR_URL . 'inc/vk-blocks/build/blocks/index-build.js',
+			$this->assets_build_url . 'block-build.js',
 			$asset_file['dependencies'],
 			VK_BLOCKS_VERSION,
 			true

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification Change ] Change the script loaded on the options page to a script file.
+[ Specification Change ][ Dev ] change build script file.
 [ Specification Change ] License key remove space.
 
 = 1.38.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -65,7 +65,6 @@ e.g.
 == Changelog ==
 
 [ Specification Change ] Change the script loaded on the options page to a script file.
-[ Specification Change ][ Dev ] change build script file.
 [ Specification Change ] License key remove space.
 
 = 1.38.0 =

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,0 +1,4 @@
+const licenseKeyElem = document.getElementById('vk-blocks-pro-license-key');
+licenseKeyElem.addEventListener('blur', () => {
+	licenseKeyElem.value = licenseKeyElem.value.trim();
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ defaultConfig.module.rules.splice(0, 1) // JSをトランスパイルするル�
 const path = require( 'path' );
 
 let entries = {
-  'blocks/index': __dirname + '/src/blocks/index.js',
-  'admin/index': __dirname + '/src/admin/index.js',
+  'block': __dirname + '/src/blocks/index.js',
+  'admin': __dirname + '/src/admin/index.js',
 };
 
 module.exports = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,17 @@ let defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 defaultConfig.module.rules.splice(0, 1) // JSをトランスパイルするルールを削除。下の独自ルールでPOTファイルを上書きして空にしてしまう。
 const path = require( 'path' );
 
+let entries = {
+  'blocks/index': __dirname + '/src/blocks/index.js',
+  'admin/index': __dirname + '/src/admin/index.js',
+};
+
 module.exports = {
 	...defaultConfig,
-	entry: __dirname + '/src/blocks/index.js',
+	entry: entries,
 	output: {
 		path: __dirname + '/inc/vk-blocks/build/',
-		filename: 'block-build.js',
+		filename: '[name]-build.js',
 	},
 	resolve: {
 		...defaultConfig.resolve,


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#1284 #1285 リファクタリング
#1057 #901 の事前準備

## どういう変更をしたか？

オプション画面とブロックエディターで読み込むファイルを分けるためにエントリポイントをオブジェクトに変更
それに伴ってブロック用のファイル名が変わったので調整

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

#1285 この変更でテストは書いてある

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- /wp-admin/options-general.php?page=vk_blocks_options
でvk-blocks-admin-jsが読み込まれていることを確認

- ライセンスキーが要らないkatawaraではvk-blocks-admin-jsが読み込まれないことを確認

- テストコマンドで確認
`npm run phpunit`
`npm run test:e2e ./test/e2e-tests/specs/vk_blocks_options.test.js`

- ブロックエディタで通常通りブロックを追加できるか確認

ビルド後のファイル名を本来は変えたくはなかったのですが、ビルドするファイル名と合わせる方法しかわからなかったのでこの方法にしました。
もっと良い書き方等あればご指摘お願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
