### PR TITLE
【優先】【2人目レビュー待ち】オプション値の保存処理のrest api を有効化

### DIFF
--- a/inc/vk-blocks-pro/class-vk-blocks-pro-options.php
+++ b/inc/vk-blocks-pro/class-vk-blocks-pro-options.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * VK Blocks Pro Options class.
+ *
+ * @package vk-blocks
+ */
+
+/**
+ * VK_Blocks_Pro_Options
+ */
+class VK_Blocks_Pro_Options {
+
+	/**
+	 * VK Blocks Pro Options schema
+	 *
+	 * @var array
+	 */
+	private $vk_blocks_pro_option_schema = array(
+		'display_vk_block_template' => array(
+			'type'    => 'string',
+			'default' => 'display',
+		),
+		'new_faq_accordion'         => array(
+			'type'    => 'string',
+			'default' => 'disable',
+		),
+	);
+
+	/**
+	 * VK Blocks License Option schema
+	 *
+	 * @var array
+	 */
+	private $license_key_option_scheme = array(
+		'vk_blocks_pro_license_key' => array(
+			'type'    => 'string',
+			'default' => null,
+		),
+	);
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		add_filter( 'vk_blocks_default_options_scheme', array( $this, 'vk_blocks_pro_default_options_scheme' ) );
+	}
+
+	/**
+	 * Initialize
+	 *
+	 * @return VK_Blocks_Pro_Options
+	 */
+	public static function init() {
+		// static 宣言しているので既に定義されている場合は $instance に null は入らずに既存のインスタンスのまま.
+		static $instance                         = null;
+		return $instance ? $instance : $instance = new static();
+	}
+
+	/**
+	 * Pro Option
+	 */
+	public function vk_blocks_pro_default_options_scheme() {
+		$array = $this->vk_blocks_pro_option_schema;
+		if ( vk_blocks_is_license_setting() ) {
+			$array = array_merge( $this->license_key_option_scheme, $this->vk_blocks_pro_option_schema );
+		}
+		return $array;
+	}
+}

--- a/inc/vk-blocks-pro/vk-blocks-pro-functions.php
+++ b/inc/vk-blocks-pro/vk-blocks-pro-functions.php
@@ -8,6 +8,9 @@
 // Pro 用の管理画面を読み込み.
 require_once dirname( __FILE__ ) . '/admin-pro/admin-pro.php';
 
+require_once dirname( __FILE__ ) . '/class-vk-blocks-pro-options.php';
+VK_Blocks_Pro_Options::init();
+
 /**
  * VK Blocks Pro Get Options
  *

--- a/inc/vk-blocks/class-vk-blocks-options.php
+++ b/inc/vk-blocks/class-vk-blocks-options.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * VK Blocks Options class.
+ *
+ * @package vk-blocks
+ */
+
+/**
+ * VK_Blocks_Options
+ */
+class VK_Blocks_Options {
+
+	/**
+	 * Initialize
+	 *
+	 * @return VK_Blocks_Options
+	 */
+	public static function init() {
+		// static 宣言しているので既に定義されている場合は $instance に null は入らずに既存のインスタンスのまま.
+		static $instance                         = null;
+		return $instance ? $instance : $instance = new static();
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		add_action( 'init', array( $this, 'register_setting' ) );
+	}
+
+	/**
+	 * Options scheme
+	 *
+	 * @return number
+	 */
+	public static function options_scheme() {
+		$default_options_schema = array(
+			'balloon_border_width' => array(
+				'type'    => 'number',
+				'default' => 1,
+			),
+			'margin_unit'          => array(
+				'type'    => 'string',
+				'default' => 'rem',
+			),
+			'margin_size'          => array(
+				'type'  => 'object',
+				'items' => array(
+					'lg' => array(
+						'type'  => 'object',
+						'items' => array(
+							'mobile' => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+							'tablet' => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+							'pc'     => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+						),
+					),
+					'md' => array(
+						'type'  => 'object',
+						'items' => array(
+							'mobile' => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+							'tablet' => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+							'pc'     => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+						),
+					),
+					'sm' => array(
+						'type'  => 'object',
+						'items' => array(
+							'mobile' => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+							'tablet' => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+							'pc'     => array(
+								'type'    => 'number',
+								'default' => null,
+							),
+						),
+					),
+				),
+			),
+			'load_separate_option' => array(
+				'type'    => 'boolean',
+				'default' => false,
+			),
+		);
+		$array                  = array_merge( $default_options_schema, apply_filters( 'vk_blocks_default_options_scheme', array() ) );
+		return $array;
+	}
+
+	/**
+	 * 吹き出し数
+	 *
+	 * @return number
+	 */
+	public static function balloon_image_number() {
+		return apply_filters( 'vk_blocks_image_number', 15 );
+	}
+
+	/**
+	 * 吹き出しschema 生成
+	 *
+	 * @return $balloon_meta_schema
+	 */
+	public function balloon_meta_schema() {
+		$number                        = self::balloon_image_number();
+		$return_array                  = array();
+		$return_array['default_icons'] = array(
+			'type' => 'object',
+		);
+		for ( $i = 1; $i <= $number; $i++ ) {
+			$return_array['default_icons']['items'][ $i ] = array(
+				'type'  => 'object',
+				'items' => array(
+					'name' => array(
+						'type'    => 'string',
+						'default' => null,
+					),
+					'src'  => array(
+						'type'    => 'string',
+						'default' => null,
+					),
+				),
+			);
+		};
+		return $return_array;
+	}
+
+	/**
+	 * Get Defaults
+	 *
+	 * @param array $schema option defaults.
+	 *
+	 * @return options
+	 */
+	public static function get_defaults( $schema ) {
+		$default = array();
+		foreach ( $schema as $key => $value ) {
+			$default[ $key ] = 'object' === $value['type'] ? self::get_defaults( $value['items'] ) : $value['default'];
+		}
+		return $default;
+	}
+
+	/**
+	 * Get properties
+	 *
+	 * @param array $schema option schema.
+	 *
+	 * @return options
+	 */
+	public static function get_properties( $schema ) {
+		$properties = array();
+		foreach ( $schema as $key => $value ) {
+			$properties[ $key ] = array(
+				'type' => $value['type'],
+			);
+
+			if ( 'object' === $value['type'] ) {
+				$properties[ $key ]['properties'] = array();
+				foreach ( $value['items'] as $key_1 => $value_1 ) {
+					$properties[ $key ]['properties'][ $key_1 ] = array(
+						'type' => $value_1['type'],
+					);
+
+					if ( 'object' === $value_1['type'] ) {
+						$properties[ $key ]['properties'][ $key_1 ]['properties'] = array();
+						foreach ( $value_1['items'] as $key_2 => $value_2 ) {
+							$properties[ $key ]['properties'][ $key_1 ]['properties'][ $key_2 ] = array(
+								'type' => $value_2['type'],
+							);
+						}
+					}
+				}
+			}
+		}
+		return $properties;
+	}
+
+	/**
+	 * Get Balloon Meta Options
+	 *
+	 * @return options
+	 */
+	public static function get_balloon_meta_options() {
+		$options                   = get_option( 'vk_blocks_balloon_meta' );
+		$number                    = self::balloon_image_number();
+		$defaults                  = array();
+		$defaults['default_icons'] = array();
+		for ( $i = 1; $i <= $number; $i++ ) {
+			$defaults['default_icons'][ $i ] = array(
+				'name' => null,
+				'src'  => null,
+			);
+		};
+		$options = wp_parse_args( $options, $defaults );
+		return $options;
+	}
+
+	/**
+	 * Register Setting
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/register_setting/#comment-5289
+	 */
+	public function register_setting() {
+		register_setting(
+			'vk_blocks_setting',
+			'vk_blocks_options',
+			array(
+				'type'         => 'object',
+				'show_in_rest' => array(
+					'schema' => array(
+						'type'       => 'object',
+						'properties' => self::get_properties( self::options_scheme() ),
+					),
+				),
+				'default'      => self::get_defaults( self::options_scheme() ),
+			)
+		);
+
+		register_setting(
+			'vk_blocks_setting',
+			'vk_blocks_balloon_meta',
+			array(
+				'type'         => 'object',
+				'show_in_rest' => array(
+					'schema' => array(
+						'type'       => 'object',
+						'properties' => self::get_properties( self::balloon_meta_schema() ),
+					),
+				),
+				'default'      => self::get_defaults( $this->balloon_meta_schema() ),
+			)
+		);
+	}
+}

--- a/inc/vk-blocks/class-vk-blocks-options.php
+++ b/inc/vk-blocks/class-vk-blocks-options.php
@@ -176,21 +176,7 @@ class VK_Blocks_Options {
 			);
 
 			if ( 'object' === $value['type'] ) {
-				$properties[ $key ]['properties'] = array();
-				foreach ( $value['items'] as $key_1 => $value_1 ) {
-					$properties[ $key ]['properties'][ $key_1 ] = array(
-						'type' => $value_1['type'],
-					);
-
-					if ( 'object' === $value_1['type'] ) {
-						$properties[ $key ]['properties'][ $key_1 ]['properties'] = array();
-						foreach ( $value_1['items'] as $key_2 => $value_2 ) {
-							$properties[ $key ]['properties'][ $key_1 ]['properties'][ $key_2 ] = array(
-								'type' => $value_2['type'],
-							);
-						}
-					}
-				}
+				$properties[ $key ]['properties'] = self::get_properties( $value['items'] );
 			}
 		}
 		return $properties;

--- a/inc/vk-blocks/vk-blocks-functions.php
+++ b/inc/vk-blocks/vk-blocks-functions.php
@@ -13,6 +13,8 @@ require_once dirname( __FILE__ ) . '/view/responsive-br.php';
 require_once dirname( __FILE__ ) . '/style/balloon.php';
 require_once dirname( __FILE__ ) . '/style/hidden-extension.php';
 require_once dirname( __FILE__ ) . '/class-vk-blocks-print-css-variables.php';
+require_once dirname( __FILE__ ) . '/class-vk-blocks-options.php';
+VK_Blocks_Options::init();
 
 /**
  * スペーサーのサイズの配列

--- a/test/phpunit/free/test-get-options-free.php
+++ b/test/phpunit/free/test-get-options-free.php
@@ -14,6 +14,24 @@ class GetOptionsTestFree extends WP_UnitTestCase {
 				'correct' => array(
 					'balloon_border_width' => 1,
 					'margin_unit' => 'rem',
+					'margin_size' => array(
+						'lg' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+						'md' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+						'sm' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+					),
+					'load_separate_option' => false,
 				),
 			),
 			array(

--- a/test/phpunit/pro/test-get-options.php
+++ b/test/phpunit/pro/test-get-options.php
@@ -16,6 +16,25 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'margin_unit' => 'rem',
 					'display_vk_block_template' => 'display',
 					'new_faq_accordion' => 'disable',
+					'margin_size' => array(
+						'lg' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+						'md' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+						'sm' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+					),
+					'load_separate_option' => false,
+					'vk_blocks_pro_license_key' => null,
 				),
 			),
 			array(

--- a/test/phpunit/pro/test-vk-blocks-options.php
+++ b/test/phpunit/pro/test-vk-blocks-options.php
@@ -1,0 +1,908 @@
+<?php
+/**
+ * Class VKBlocksOptionsTest
+ *
+ * @package vk-blocks
+ */
+
+class VKBlocksOptionsTest extends WP_UnitTestCase {
+
+	public function test_options_scheme() {
+		$test_data = array(
+			// Pro版 マージ
+			array(
+				'option' => array(
+					'vk_blocks_pro_license_key' => array(
+						'type'    => 'string',
+						'default' => null,
+					),
+					'display_vk_block_template' => array(
+						'type'    => 'string',
+						'default' => 'display',
+					),
+					'new_faq_accordion'         => array(
+						'type'    => 'string',
+						'default' => 'disable',
+					),
+				),
+				'correct' => array(
+					'balloon_border_width' => array(
+						'type'    => 'number',
+						'default' => 1,
+					),
+					'margin_unit'          => array(
+						'type'    => 'string',
+						'default' => 'rem',
+					),
+					'margin_size'          => array(
+						'type'  => 'object',
+						'items' => array(
+							'lg' => array(
+								'type'  => 'object',
+								'items' => array(
+									'mobile' => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+									'tablet' => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+									'pc'     => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+								),
+							),
+							'md' => array(
+								'type'  => 'object',
+								'items' => array(
+									'mobile' => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+									'tablet' => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+									'pc'     => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+								),
+							),
+							'sm' => array(
+								'type'  => 'object',
+								'items' => array(
+									'mobile' => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+									'tablet' => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+									'pc'     => array(
+										'type'    => 'number',
+										'default' => null,
+									),
+								),
+							),
+						),
+					),
+					'load_separate_option' => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'vk_blocks_pro_license_key' => array(
+						'type'    => 'string',
+						'default' => null,
+					),
+					'display_vk_block_template' => array(
+						'type'    => 'string',
+						'default' => 'display',
+					),
+					'new_faq_accordion'         => array(
+						'type'    => 'string',
+						'default' => 'disable',
+					),
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'options_scheme()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+			if ( ! empty( $test_value['option'] ) ){
+				$array = isset( $test_value['option'] ) ? $test_value['option'] : null;
+				add_filter(
+					'vk_blocks_default_options_scheme',
+					function() use( $array ) {
+						return $array;
+					}
+				);
+			}
+			$return  = VK_Blocks_Options::options_scheme();
+			$correct = $test_value['correct'];
+
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+
+		}
+	}
+
+	public function test_balloon_image_number() {
+		$test_data = array(
+			array(
+				'option' => null,
+				'correct' => 15,
+			),
+			array(
+				'option' => 5,
+				'correct' => 5,
+			),
+			array(
+				'option' => 20,
+				'correct' => 20,
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'balloon_image_number()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+			if ( ! empty( $test_value['option'] ) ){
+				$number = isset( $test_value['option'] ) ? $test_value['option'] : null;
+				add_filter(
+					'vk_blocks_image_number',
+					function() use ( $number ) {
+						return $number;
+					}
+				);
+			}
+			$return  = VK_Blocks_Options::balloon_image_number();
+			$correct = $test_value['correct'];
+
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+		}
+	}
+
+	// balloon_meta_schemaを作る
+	public function test_balloon_meta_schema() {
+		$test_data = array(
+			// デフォルト
+			array(
+				'option' => null,
+				'correct' => array(
+					'default_icons' => array(
+						'type'  => 'object',
+						'items' => array(
+							'1' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'2' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'3' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'4' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'5' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'6' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'7' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'8' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'9' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'10' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'11' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'12' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'13' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'14' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'15' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+			// 吹き出しの数を変更した時
+			array(
+				'option' => 2,
+				'correct' => array(
+					'default_icons' => array(
+						'type'  => 'object',
+						'items' => array(
+							'1' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+							'2' => array(
+								'type'  => 'object',
+								'items' => array(
+									'name' => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+									'src'  => array(
+										'type'    => 'string',
+										'default' => null,
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'balloon_meta_schema()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+			if ( ! empty( $test_value['option'] ) ){
+				$number = isset( $test_value['option'] ) ? $test_value['option'] : null;
+				add_filter(
+					'vk_blocks_image_number',
+					function() use ( $number ) {
+						return $number;
+					}
+				);
+			}
+			$return  = VK_Blocks_Options::balloon_meta_schema();
+			$correct = $test_value['correct'];
+
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+		}
+	}
+
+	public function test_get_defaults() {
+		$test_data = array(
+			array(
+				'option' => array(
+					'some_bool'  => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'some_int' => array(
+						'type'    => 'integer',
+						'default' => 1,
+					),
+					'some_number' => array(
+						'type'    => 'number',
+						'default' => 1.5,
+					),
+					'some_array' => array(
+						'type'    => 'array',
+						'default' => array(
+							'a',
+							'b',
+							'c'
+						),
+					),
+					'some_object_1' => array(
+						'type'  => 'object',
+						'items' => array(
+							'some_object_1_grand_child_1' => array(
+								'type'    => 'string',
+								'default' => 'some_object_1_grand_child_1_text',
+							),
+							'some_object_1_grand_child_2'  => array(
+								'type'    => 'string',
+								'default' => 'some_object_1_grand_child_2_text',
+							),
+						),
+					),
+					'some_object_2' => array(
+						'type'  => 'object',
+						'items' => array(
+							'some_object_child' => array(
+								'type'  => 'object',
+								'items' => array(
+									'some_object_2_grand_child_1' => array(
+										'type'    => 'string',
+										'default' => 'some_object_2_grand_child_1_text',
+									),
+									'some_object_2_grand_child_2'  => array(
+										'type'    => 'string',
+										'default' => 'some_object_2_grand_child_2_text',
+									),
+								),
+							),
+						),
+					),
+				),
+				'correct' => array(
+					'some_bool'  => false,
+					'some_int'  => 1,
+					'some_number'  => 1.5,
+					'some_array'  => array(
+						'a',
+						'b',
+						'c'
+					),
+					'some_object_1'  => array(
+						'some_object_1_grand_child_1' => 'some_object_1_grand_child_1_text',
+						'some_object_1_grand_child_2' => 'some_object_1_grand_child_2_text',
+					),
+					'some_object_2'  => array(
+						'some_object_child' => array(
+							'some_object_2_grand_child_1' => 'some_object_2_grand_child_1_text',
+							'some_object_2_grand_child_2' => 'some_object_2_grand_child_2_text',
+						)
+					),
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'get_defaults()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+			$return  = VK_Blocks_Options::get_defaults($test_value['option']);
+			$correct = $test_value['correct'];
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+		}
+	}
+
+	public function test_get_properties() {
+		$test_data = array(
+			array(
+				'option' => array(
+					'some_bool'  => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'some_int' => array(
+						'type'    => 'integer',
+						'default' => 1,
+					),
+					'some_number' => array(
+						'type'    => 'number',
+						'default' => 1.5,
+					),
+					'some_array' => array(
+						'type'    => 'array',
+						'default' => array(
+							'a',
+							'b',
+							'c'
+						),
+					),
+					'some_object_1' => array(
+						'type'  => 'object',
+						'items' => array(
+							'some_object_1_grand_child_1' => array(
+								'type'    => 'string',
+								'default' => 'some_object_1_grand_child_1_text',
+							),
+							'some_object_1_grand_child_2'  => array(
+								'type'    => 'string',
+								'default' => 'some_object_1_grand_child_2_text',
+							),
+						),
+					),
+					'some_object_2' => array(
+						'type'  => 'object',
+						'items' => array(
+							'some_object_child' => array(
+								'type'  => 'object',
+								'items' => array(
+									'some_object_2_grand_child_1' => array(
+										'type'    => 'string',
+										'default' => 'some_object_2_grand_child_1_text',
+									),
+									'some_object_2_grand_child_2'  => array(
+										'type'    => 'string',
+										'default' => 'some_object_2_grand_child_2_text',
+									),
+								),
+							),
+						),
+					),
+				),
+				'correct' => array(
+					'some_bool' => array(
+						'type' => 'boolean',
+					),
+					'some_int' => array(
+						'type' => 'integer',
+					),
+					'some_number' => array(
+						'type' => 'number',
+					),
+					'some_array' => array(
+						'type' => 'array',
+					),
+					'some_object_1'  => array(
+						'type' => 'object',
+						'properties' => array(
+							'some_object_1_grand_child_1' => array(
+								'type' => 'string',
+							),
+							'some_object_1_grand_child_2' => array(
+								'type' => 'string',
+							),
+						),
+					),
+					'some_object_2'  => array(
+						'type' => 'object',
+						'properties' => array(
+							'some_object_child' => array(
+								'type' => 'object',
+								'properties' => array(
+									'some_object_2_grand_child_1' => array(
+										'type' => 'string',
+									),
+									'some_object_2_grand_child_2' => array(
+										'type' => 'string',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'get_properties()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+			$return  = VK_Blocks_Options::get_properties($test_value['option']);
+			$correct = $test_value['correct'];
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+		}
+	}
+
+	public function test_get_balloon_meta_options() {
+		$test_data = array(
+			// 初期状態
+			array(
+				'option'  => null,
+				'correct' => array(
+					'default_icons' => array(
+						'1' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'2' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'3' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'4' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'5' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'6' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'7' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'8' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'9' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'10' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'11' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'12' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'13' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'14' => array(
+							'name' => null,
+							'src' => null,
+						),
+						'15' => array(
+							'name' => null,
+							'src' => null,
+						),
+					),
+				),
+			),
+			array(
+				'option'  => array(
+					'default_icons' => array(
+						'type'  => 'object',
+						'items' => array(
+							'1' => array(
+								'name' => '吹き出し名前',
+								'src' => 'https://demo.dev3.biz/lightning-pro/wp-content/uploads/2018/02/agent-18762_1920-200x300.jpg',
+							),
+							'2' => array(
+								'name' => '吹き出し名前',
+								'src' => 'https://demo.dev3.biz/lightning-pro/wp-content/uploads/2018/02/agent-18762_1920-200x300.jpg',
+							),
+							'3' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'4' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'5' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'6' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'7' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'8' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'9' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'10' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'11' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'12' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'13' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'14' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'15' => array(
+								'name' => null,
+								'src' => null,
+							),
+						),
+					),
+				),
+				'correct' => array(
+					'default_icons' => array(
+						'type'  => 'object',
+						'items' => array(
+							'1' => array(
+								'name' => '吹き出し名前',
+								'src' => 'https://demo.dev3.biz/lightning-pro/wp-content/uploads/2018/02/agent-18762_1920-200x300.jpg',
+							),
+							'2' => array(
+								'name' => '吹き出し名前',
+								'src' => 'https://demo.dev3.biz/lightning-pro/wp-content/uploads/2018/02/agent-18762_1920-200x300.jpg',
+							),
+							'3' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'4' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'5' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'6' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'7' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'8' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'9' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'10' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'11' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'12' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'13' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'14' => array(
+								'name' => null,
+								'src' => null,
+							),
+							'15' => array(
+								'name' => null,
+								'src' => null,
+							),
+						),
+					),
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'get_balloon_meta_options()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+			if ( empty( $test_value['option'] ) ){
+				delete_option( 'vk_blocks_balloon_meta' );
+			} else {
+				update_option( 'vk_blocks_balloon_meta', $test_value['option'] );
+			}
+			$return  = VK_Blocks_Options::get_balloon_meta_options();
+			$correct = $test_value['correct'];
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+		}
+	}
+
+}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1057 #901 の事前準備

## どういう変更をしたか？

rest api を有効化します。
変更ファイルが大きいですがこの変更でしたいことは`register_setting`で`show_in_rest`を有効化させたいだけです。
https://developer.wordpress.org/reference/functions/register_setting/

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
ユーザーレベルで変更はないので書いていないです
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* `register_setting`の設定方法があっているか確認
* `npm run phpunit`で記載したテストが通っているか確認
* この変更ではoption値の保存方法などには影響が無いことを確認

もっと良い書き方等あればご指摘お願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
