### PR TITLE
 【マージ待ち】[ アイコンブロック ] アイコンサイズと余白の指定に小数点が入るように

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,7 @@ e.g.
 == Changelog ==
 
 [ Bug Fix ][ Breadcrumb ] Fix in case of filter search result category & keyword
+[ Specification Change ][ icon ] enable float value at icon size and margin
 
 = 1.39.1 =
 [ Bug Fix ][ Grid Column Card ] fix bug when aspect retio is empty.

--- a/src/blocks/icon-outer/edit.js
+++ b/src/blocks/icon-outer/edit.js
@@ -62,6 +62,10 @@ export default function IconOuterEdit(props) {
 
 	const TEMPLATE = [['vk-blocks/icon'], ['vk-blocks/icon']];
 
+	// 空白チェック
+	const defaultIconSize = 'px' === iconSizeUnit ? 36 : 1;
+	const defaultIconMargin = 'px' === iconMarginUnit ? 22 : 1;
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -87,9 +91,13 @@ export default function IconOuterEdit(props) {
 						<TextControl
 							className={`vk_icon_custombox_number`}
 							value={iconSize}
-							onChange={(value) =>
-								setAttributes({ iconSize: parseFloat(value) })
-							}
+							onChange={(value) => {
+								setAttributes({
+									iconSize: value
+										? parseFloat(value)
+										: defaultIconSize,
+								});
+							}}
 							type={'number'}
 						/>
 						<SelectControl
@@ -134,9 +142,13 @@ export default function IconOuterEdit(props) {
 						<TextControl
 							className={`vk_icon_custombox_number`}
 							value={iconMargin}
-							onChange={(value) =>
-								setAttributes({ iconMargin: parseFloat(value) })
-							}
+							onChange={(value) => {
+								setAttributes({
+									iconMargin: value
+										? parseFloat(value)
+										: defaultIconMargin,
+								});
+							}}
 							type={'number'}
 						/>
 						<SelectControl

--- a/src/blocks/icon-outer/edit.js
+++ b/src/blocks/icon-outer/edit.js
@@ -98,7 +98,7 @@ export default function IconOuterEdit(props) {
 									? parseFloat(value)
 									: defaultIconSize;
 								if ('px' === iconSizeUnit) {
-									newIconSize = parseInt(value);
+									newIconSize = parseInt(newIconSize);
 								}
 								setAttributes({ iconSize: newIconSize });
 							}}
@@ -158,7 +158,7 @@ export default function IconOuterEdit(props) {
 									? parseFloat(value)
 									: defaultIconMargin;
 								if ('px' === iconMarginUnit) {
-									newIconMargin = parseInt(value);
+									newIconMargin = parseInt(newIconMargin);
 								}
 								setAttributes({ iconMargin: newIconMargin });
 							}}

--- a/src/blocks/icon-outer/edit.js
+++ b/src/blocks/icon-outer/edit.js
@@ -88,7 +88,7 @@ export default function IconOuterEdit(props) {
 							className={`vk_icon_custombox_number`}
 							value={iconSize}
 							onChange={(value) =>
-								setAttributes({ iconSize: parseInt(value) })
+								setAttributes({ iconSize: parseFloat(value) })
 							}
 							type={'number'}
 						/>
@@ -135,7 +135,7 @@ export default function IconOuterEdit(props) {
 							className={`vk_icon_custombox_number`}
 							value={iconMargin}
 							onChange={(value) =>
-								setAttributes({ iconMargin: parseInt(value) })
+								setAttributes({ iconMargin: parseFloat(value) })
 							}
 							type={'number'}
 						/>

--- a/src/blocks/icon-outer/edit.js
+++ b/src/blocks/icon-outer/edit.js
@@ -91,12 +91,16 @@ export default function IconOuterEdit(props) {
 						<TextControl
 							className={`vk_icon_custombox_number`}
 							value={iconSize}
+							step={'px' === iconSizeUnit ? 1 : 0.1}
+							min={0}
 							onChange={(value) => {
-								setAttributes({
-									iconSize: value
-										? parseFloat(value)
-										: defaultIconSize,
-								});
+								let newIconSize = value
+									? parseFloat(value)
+									: defaultIconSize;
+								if ('px' === iconSizeUnit) {
+									newIconSize = parseInt(value);
+								}
+								setAttributes({ iconSize: newIconSize });
 							}}
 							type={'number'}
 						/>
@@ -105,6 +109,11 @@ export default function IconOuterEdit(props) {
 							value={iconSizeUnit}
 							onChange={(value) => {
 								setAttributes({ iconSizeUnit: value });
+								if ('px' === value) {
+									setAttributes({
+										iconSize: parseInt(iconSize),
+									});
+								}
 							}}
 							options={[
 								{
@@ -142,12 +151,16 @@ export default function IconOuterEdit(props) {
 						<TextControl
 							className={`vk_icon_custombox_number`}
 							value={iconMargin}
+							step={'px' === iconMarginUnit ? 1 : 0.1}
+							min={0}
 							onChange={(value) => {
-								setAttributes({
-									iconMargin: value
-										? parseFloat(value)
-										: defaultIconMargin,
-								});
+								let newIconMargin = value
+									? parseFloat(value)
+									: defaultIconMargin;
+								if ('px' === iconMarginUnit) {
+									newIconMargin = parseInt(value);
+								}
+								setAttributes({ iconMargin: newIconMargin });
 							}}
 							type={'number'}
 						/>
@@ -156,6 +169,11 @@ export default function IconOuterEdit(props) {
 							value={iconMarginUnit}
 							onChange={(value) => {
 								setAttributes({ iconMarginUnit: value });
+								if ('px' === value) {
+									setAttributes({
+										iconMargin: parseInt(iconMargin),
+									});
+								}
 							}}
 							options={[
 								{

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -67,6 +67,10 @@ export default function IconEdit(props) {
 		);
 	}
 
+	// 空白チェック
+	const defaultIconSize = 'px' === iconSizeUnit ? 36 : 1;
+	const defaultIconMargin = 'px' === iconMarginUnit ? 22 : 1;
+
 	/**
 	 * 親ブロックが vk-blocks/icon-outer でなければ設定項目を追加
 	 */
@@ -79,9 +83,13 @@ export default function IconEdit(props) {
 					<TextControl
 						className={`vk_icon_custombox_number`}
 						value={iconSize}
-						onChange={(value) =>
-							setAttributes({ iconSize: parseFloat(value) })
-						}
+						onChange={(value) => {
+							setAttributes({
+								iconSize: value
+									? parseFloat(value)
+									: defaultIconSize,
+							});
+						}}
 						type={'number'}
 					/>
 					<SelectControl
@@ -126,9 +134,13 @@ export default function IconEdit(props) {
 					<TextControl
 						className={`vk_icon_custombox_number`}
 						value={iconMargin}
-						onChange={(value) =>
-							setAttributes({ iconMargin: parseFloat(value) })
-						}
+						onChange={(value) => {
+							setAttributes({
+								iconMargin: value
+									? parseFloat(value)
+									: defaultIconMargin,
+							});
+						}}
 						type={'number'}
 					/>
 					<SelectControl

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -90,7 +90,7 @@ export default function IconEdit(props) {
 								? parseFloat(value)
 								: defaultIconSize;
 							if ('px' === iconSizeUnit) {
-								newIconSize = parseInt(value);
+								newIconSize = parseInt(newIconSize);
 							}
 							setAttributes({ iconSize: newIconSize });
 						}}
@@ -148,7 +148,7 @@ export default function IconEdit(props) {
 								? parseFloat(value)
 								: defaultIconMargin;
 							if ('px' === iconMarginUnit) {
-								newIconMargin = parseInt(value);
+								newIconMargin = parseInt(newIconMargin);
 							}
 							setAttributes({ iconMargin: newIconMargin });
 						}}

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -80,7 +80,7 @@ export default function IconEdit(props) {
 						className={`vk_icon_custombox_number`}
 						value={iconSize}
 						onChange={(value) =>
-							setAttributes({ iconSize: parseInt(value) })
+							setAttributes({ iconSize: parseFloat(value) })
 						}
 						type={'number'}
 					/>
@@ -127,7 +127,7 @@ export default function IconEdit(props) {
 						className={`vk_icon_custombox_number`}
 						value={iconMargin}
 						onChange={(value) =>
-							setAttributes({ iconMargin: parseInt(value) })
+							setAttributes({ iconMargin: parseFloat(value) })
 						}
 						type={'number'}
 					/>

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -83,12 +83,16 @@ export default function IconEdit(props) {
 					<TextControl
 						className={`vk_icon_custombox_number`}
 						value={iconSize}
+						step={'px' === iconSizeUnit ? 1 : 0.1}
+						min={0}
 						onChange={(value) => {
-							setAttributes({
-								iconSize: value
-									? parseFloat(value)
-									: defaultIconSize,
-							});
+							let newIconSize = value
+								? parseFloat(value)
+								: defaultIconSize;
+							if ('px' === iconSizeUnit) {
+								newIconSize = parseInt(value);
+							}
+							setAttributes({ iconSize: newIconSize });
 						}}
 						type={'number'}
 					/>
@@ -97,6 +101,9 @@ export default function IconEdit(props) {
 						value={iconSizeUnit}
 						onChange={(value) => {
 							setAttributes({ iconSizeUnit: value });
+							if ('px' === value) {
+								setAttributes({ iconSize: parseInt(iconSize) });
+							}
 						}}
 						options={[
 							{
@@ -134,12 +141,16 @@ export default function IconEdit(props) {
 					<TextControl
 						className={`vk_icon_custombox_number`}
 						value={iconMargin}
+						step={'px' === iconMarginUnit ? 1 : 0.1}
+						min={0}
 						onChange={(value) => {
-							setAttributes({
-								iconMargin: value
-									? parseFloat(value)
-									: defaultIconMargin,
-							});
+							let newIconMargin = value
+								? parseFloat(value)
+								: defaultIconMargin;
+							if ('px' === iconMarginUnit) {
+								newIconMargin = parseInt(value);
+							}
+							setAttributes({ iconMargin: newIconMargin });
 						}}
 						type={'number'}
 					/>
@@ -148,6 +159,11 @@ export default function IconEdit(props) {
 						value={iconMarginUnit}
 						onChange={(value) => {
 							setAttributes({ iconMarginUnit: value });
+							if ('px' === value) {
+								setAttributes({
+									iconMargin: parseInt(iconMargin),
+								});
+							}
 						}}
 						options={[
 							{

--- a/src/blocks/icon/style.scss
+++ b/src/blocks/icon/style.scss
@@ -76,13 +76,8 @@
 			}
 		}
 	}
-	// <<< END
 }
 
-
-.wp-block-vk-blocks-icon {
-
-}
 
 // デフォルトのカラー
 .wp-block-vk-blocks-icon {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 [ アイコンブロック ] rem,em,vw指定の時に小数点が入るようになると使いやすいかもしれない #1305 

## どういう変更をしたか？

* アイコンのサイズと余白の指定がいままはで整数のみだったのを、単位がpx以外に限り小数点を入力できるようにしました
* 数値のステップ(アイコンサイズ、余白とも)単位pxでは1刻み、それ以外単位では0.1刻みにしました
* 単位がpxに変更になったタイミングで小数点以下を切り捨てています
* 横並びアイコン共通設定に同様に修正しました
*アイコンサイズと余白を空白に設定すると次回の編集でブロックのリカバリーが出る #1314  件を修正


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* アイコンのサイズに、単位 px 以外に限り小数点を指定し、表示されることを確認
* アイコンの余白に、単位 px 以外に限り小数点を指定し、表示されることを確認
* アイコンサイズ、余白とも、数値のステップは単位 px では 1 刻み、それ以外の単位では 0.1 刻みになることを確認
* アイコンサイズ、余白とも、数値のステップは単位 px に変更になったタイミングで小数点以下が切り捨てられることを確認
* 横並びアイコン共通設定のサイズに、単位 px 以外に限り小数点を指定し、表示されることを確認
* 横並びアイコン共通設定の余白に、単位が px 以外に限り小数点を指定し、表示されることを確認
* 横並びアイコン共通設定のアイコンサイズ、余白とも、数値のステップ単位 px では 1 刻み、それ以外の単位では 0.1 刻みになることを確認
* 横並びアイコン共通設定のアイコンサイズ、余白とも、単位 px に変更になったタイミングで小数点以下が切り捨てられることを確認
* アイコンサイズと余白を空白に設定すると次回の編集でブロックのリカバリーが出る #1314  件を修正
    * アイコンサイズが空白の場合、単位  px ならば 36 を、それ以外の単位ならば 1 が設定されることを確認
    * 余白が空白の場合、単位  px ならば 22 を、それ以外の単位ならば 1 が設定されることを確認


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。



* アイコンのサイズに、単位 px 以外に限り小数点を指定し、表示されるか
* アイコンの余白に、単位 px 以外に限り小数点を指定し、表示されるか
* アイコンサイズ、余白とも、数値のステップは単位 px では 1 刻み、それ以外の単位では 0.1 刻みになるか
* アイコンサイズ、余白とも、数値のステップは単位 px に変更になったタイミングで小数点以下が切り捨てられるか(※この仕様が適切か？も確認お願いします)
* 横並びアイコン共通設定のサイズに、単位 px 以外に限り小数点を指定し、表示されるか
* 横並びアイコン共通設定の余白に、単位が px 以外に限り小数点を指定し、表示されるか
* 横並びアイコン共通設定のアイコンサイズ、余白とも、数値のステップ単位 px では 1 刻み、それ以外の単位では 0.1 刻みになるか(※この仕様が適切か？も確認お願いします)
* 横並びアイコン共通設定のアイコンサイズ、余白とも、単位 px に変更になったタイミングで小数点以下が切り捨てられるか
* アイコンサイズと余白を空白に設定すると次回の編集でブロックのリカバリーが出る #1314  件を修正
    * アイコンサイズが空白の場合、単位  px ならば 36 を、それ以外の単位ならば 1 が設定されるか
    * 余白が空白の場合、単位  px ならば 22 を、それ以外の単位ならば 1 が設定されるか


---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
