### PR TITLE
fix / table : table border left and right on vk-table-border-top-bottom

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,7 @@ e.g.
 == Changelog ==
 
 [ Bug Fix ][ Breadcrumb ] Fix in case of filter search result category & keyword
+[ Bug Fix ][ Table style ] Delete border left and right specified vk-table-border-top-bottom 
 
 = 1.39.1 =
 [ Bug Fix ][ Grid Column Card ] fix bug when aspect retio is empty.

--- a/src/extensions/core/table/style.scss
+++ b/src/extensions/core/table/style.scss
@@ -5,10 +5,14 @@
     }
     &.is-style-vk-table {
         &-border-top-bottom {
-            th,td{
-                border-top: none;
+			table,
+			th,
+			td {
                 border-left: none;
                 border-right: none;
+			}
+            th,td{
+                border-top: none;
                 border-bottom:1px solid var(--vk-color-border-hr);
             }
         }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

テーブルの追加スタイルで「直線上下」を選択した時に左右線が残ったままになってしまうので削除