### PR TITLE
【確認待ち】load_separate_optionがbooleanでfalseが入っていた時の条件を修正

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-block-loader.php
+++ b/inc/vk-blocks/class-vk-blocks-block-loader.php
@@ -313,7 +313,7 @@ class VK_Blocks_Block_Loader {
 	 */
 	public static function should_load_separate_assets() {
 		$vk_blocks_options = get_option( 'vk_blocks_options' );
-		if ( function_exists( 'wp_should_load_separate_core_block_assets' ) && isset( $vk_blocks_options['load_separate_option'] ) ) {
+		if ( function_exists( 'wp_should_load_separate_core_block_assets' ) && isset( $vk_blocks_options['load_separate_option'] ) && $vk_blocks_options['load_separate_option'] ) {
 			$bool = true;
 		} else {
 			$bool = false;

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ] Fix initial load separate option
+
 = 1.39.2 =
 [ Bug Fix ][ Breadcrumb ] Fix in case of filter search result category & keyword
 [ Bug Fix ][ Table style ] Delete border left and right specified vk-table-border-top-bottom 

--- a/test/phpunit/pro/test-block-loader.php
+++ b/test/phpunit/pro/test-block-loader.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Class BlockLoaderTest
+ *
+ * @package vk-blocks
+ */
+
+class BlockLoaderTest extends WP_UnitTestCase {
+
+	public function test_should_load_separate_assets() {
+		$test_data = array(
+			array(
+				'option'  => array(
+					'load_separate_option' => null,
+				),
+				'correct' => array(
+					'load_separate_option' => false,
+				),
+			),
+			array(
+				'option'  => array(
+					'load_separate_option' => 'true',
+				),
+				'correct' => array(
+					'load_separate_option' => true,
+				),
+			),
+			array(
+				'option'  => array(
+					'load_separate_option' => false,
+				),
+				'correct' => array(
+					'load_separate_option' => false,
+				),
+			),
+			array(
+				'option'  => array(
+					'load_separate_option' => true,
+				),
+				'correct' => array(
+					'load_separate_option' => true,
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'VK_Blocks_Block_Loader::should_load_separate_assets()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+			if ( empty( $test_value['option'] ) ){
+				delete_option( 'vk_blocks_options' );
+			} else {
+				update_option( 'vk_blocks_options', $test_value['option'] );
+			}
+
+			$return  = VK_Blocks_Block_Loader::should_load_separate_assets();
+			$correct = $test_value['correct']['load_separate_option'];
+
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+		}
+	}
+}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1325

## どういう変更をしたか？

load_separate_optionがbooleanでfalseが入っていた時の条件を修正
もともと、trueの文字列と空(null)が保存される設定であったが #1300 この変更でbooleanで保存するようにした。
そのためvk-blocksを初期インストールしたときにboolenaでfalseが入るようになったので条件文を調整しました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。


* vk blocksを初期インストール時(オプション値がない時)に分割読み込みがオフになることを確認
*  テストコマンド `npm run phpunit`で確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
