### PR TITLE
【確認待ち】編集画面のポップアップコントロールに余白がなくなっていたので調整

### DIFF
--- a/editor-css/_editor_common_core.scss
+++ b/editor-css/_editor_common_core.scss
@@ -11,19 +11,7 @@
 		}
 	}
 
-	.vk-blocks-format-popover {
-		// WP5.9でPopoverコンポーネントにpaddingがなくなったため
-		.components-popover__content > div {
-				padding: 20px 18px;
-		}
-
-		// インライン文字サイズを再編集時に選択されたフォントサイズが黒バックの白抜きになるため
-		.components-toggle-group-control > div[data-active=true] {
-			background: rgb(30, 30, 30);
-			border-radius: 2px;
-		}
-	}
-		//他テーマ（Twenty Twenty）上書き用
+	//他テーマ（Twenty Twenty）上書き用
 		.wp-block-image figcaption{
 			display: block;
 		}
@@ -34,3 +22,15 @@
 		}
 }
 
+.vk-blocks-format-popover {
+	// WP5.9でPopoverコンポーネントにpaddingがなくなったため
+	.components-popover__content > div {
+			padding: 20px 18px;
+	}
+
+	// インライン文字サイズを再編集時に選択されたフォントサイズが黒バックの白抜きになるため
+	.components-toggle-group-control > div[data-active=true] {
+		background: rgb(30, 30, 30);
+		border-radius: 2px;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,7 @@ e.g.
 
 [ Specification Change ] Change the style of the options page to Gutenberg components.
 [ Add Function ][ Button ] Enable inline font size and add icon size option.
+[ Bug Fix ] fix editor style in Inline font size and Highlighter.
 
 = 1.39.2 =
 [ Bug Fix ][ Breadcrumb ] Fix in case of filter search result category & keyword


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 [ インライン文字サイズ /ハイライト/ハイライター] サイト編集画面、コントロールポップアップ表示 #1307 

## どういう変更をしたか？
編集画面で Popover コントロールがあるブロックを編集する際に、ポップアップ内の余白がなくなっていたので、適度に追加しました。
具体的には下記に関連があります

- インラインフォントサイズ
- 蛍光マーカー(ハイライター)
- ※ 報告のあったコアのハイライトは関係なし

もともと WP5.9 で余白がなくなった際に popover に `padding: 20px 18px;` を追加しながら、効いてなかった(たぶん途中から？)。
CSS で .editor-styles-wrapper の配下に .vk-blocks-format-popover のスタイルが書かれていた。.vk-blocks-format-popover は .editor-styles-wrapper の配下ではない(Popover だから)ため、記述箇所を移動しました。

## 実装者の確認事項

> サイト編集/普通の編集に共通


実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* インラインフォントを設定する際に表示される Popover コントロールに余白があることを確認
* 蛍光マーカーを設定する際に表示される Popover コントロールに余白があることを確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* インラインフォントを設定する際に表示される Popover コントロールに余白があるか
* 蛍光マーカーを設定する際に表示される Popover コントロールに余白があるか
* scss で .vk-blocks-format-popover の宣言を一段上に移動したので正しいかどうかご確認お願いします 

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
