### PR TITLE
【2人め確認待ち】分割読み込みを有効化かつ旧FAQと新FAQを両方使った時にjsが二重で読み込まれconsoleエラーになる修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ FAQ ] fix faq block js error when load separation mode.
+
 = 1.40.0 =
 [ Improvement ][ hidden extension ] Changed to add common hidden class names to additional CSS classes.
 [ Add Block ][ Page list from ancestors ]

--- a/src/blocks/faq2/index.php
+++ b/src/blocks/faq2/index.php
@@ -14,7 +14,7 @@ function vk_blocks_register_block_faq2() {
 	// Register Style.
 	if ( ! is_admin() ) {
 		wp_register_style(
-			'vk-blocks/faq2',
+			'vk-blocks/faq',
 			VK_BLOCKS_DIR_URL . 'build/faq/style.css',
 			array(),
 			VK_BLOCKS_VERSION
@@ -24,7 +24,7 @@ function vk_blocks_register_block_faq2() {
 	// Register Style.
 	if ( ! is_admin() ) {
 		wp_register_script(
-			'vk-blocks-faq2',
+			'vk-blocks/faq-script',
 			VK_BLOCKS_DIR_URL . 'build/vk-faq2.min.js',
 			array(),
 			VK_BLOCKS_VERSION,
@@ -35,8 +35,8 @@ function vk_blocks_register_block_faq2() {
 	register_block_type(
 		__DIR__,
 		array(
-			'style'         => 'vk-blocks/faq2',
-			'script'        => 'vk-blocks-faq2',
+			'style'         => 'vk-blocks/faq',
+			'script'        => 'vk-blocks/faq-script',
 			'editor_style'  => 'vk-blocks-build-editor-css',
 			'editor_script' => 'vk-blocks-build-js',
 		)


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
分割読み込みを有効化かつ旧FAQと新FAQを両方使った時にjsが二重で読み込まれconsoleエラーになる修正

```エラーメッセージ
Uncaught SyntaxError: Identifier 'vkFaq2Container' has already been declared
```

## どういう変更をしたか？

旧FAQと新FAQの分割読み込み有効化時に読み込むスクリプトのハンドル名を同じにする
CSSも二重で読み込む必要はないのでハンドル名を同じにしました
同じにすれば二つ同時に使用した時でも二重で読み込まれることはない

もしかしたら仕様変更になるかもしれないのでお知らせ必要ですかね？

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

・分割読み込みを有効化かつ旧FAQと新FAQを両方使った時にjsのエラーが出ないか
・分割読み込みを有効化かつ旧FAQを使った時にエラーが出ないか
・分割読み込みを有効化かつ新FAQを使った時にエラーが出ないか
・分割読み込みを無効化の時に影響が出ていないか

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
