### PR TITLE
【石川確認中】get_optionsデフォルト値の取得方法調整

### DIFF
--- a/inc/vk-blocks-pro/vk-blocks-pro-functions.php
+++ b/inc/vk-blocks-pro/vk-blocks-pro-functions.php
@@ -12,22 +12,6 @@ require_once dirname( __FILE__ ) . '/class-vk-blocks-pro-options.php';
 VK_Blocks_Pro_Options::init();
 
 /**
- * VK Blocks Pro Get Options
- *
- * デフォルトのオプション
- *
- * @param array $defaults defaults.
- */
-function vk_blocks_pro_get_options( $defaults ) {
-	$defaults = array(
-		'display_vk_block_template' => 'display',
-		'new_faq_accordion'         => 'disable',
-	);
-	return $defaults;
-}
-add_filter( 'vk_blocks_default_options', 'vk_blocks_pro_get_options' );
-
-/**
  * Pro 専用のスクリプトの読み込み
  */
 function vk_blocks_pro_load_scripts() {

--- a/inc/vk-blocks/vk-blocks-functions.php
+++ b/inc/vk-blocks/vk-blocks-functions.php
@@ -72,11 +72,7 @@ add_filter(
  */
 function vk_blocks_get_options() {
 	$options  = get_option( 'vk_blocks_options' );
-	$defaults = array(
-		'balloon_border_width' => 1,
-		'margin_unit'          => 'rem',
-	);
-	$defaults = array_merge( $defaults, apply_filters( 'vk_blocks_default_options', array() ) );
+	$defaults = VK_Blocks_Options::get_defaults( VK_Blocks_Options::options_scheme() );
 	$options  = wp_parse_args( $options, $defaults );
 	return $options;
 }

--- a/test/phpunit/pro/test-get-options.php
+++ b/test/phpunit/pro/test-get-options.php
@@ -14,8 +14,6 @@ class GetOptionsTest extends WP_UnitTestCase {
 				'correct' => array(
 					'balloon_border_width' => 1,
 					'margin_unit' => 'rem',
-					'display_vk_block_template' => 'display',
-					'new_faq_accordion' => 'disable',
 					'margin_size' => array(
 						'lg' => array(
 							'mobile' => null,
@@ -35,14 +33,14 @@ class GetOptionsTest extends WP_UnitTestCase {
 					),
 					'load_separate_option' => false,
 					'vk_blocks_pro_license_key' => null,
+					'display_vk_block_template' => 'display',
+					'new_faq_accordion' => 'disable',
 				),
 			),
 			array(
 				'option'  => array(
 					'balloon_border_width' => 2,
 					'margin_unit' => 'px',
-					'display_vk_block_template' => 'display',
-					'new_faq_accordion' => 'open',
 					'margin_size' => array(
 						'lg' => array(
 							'mobile' => 1,
@@ -61,12 +59,13 @@ class GetOptionsTest extends WP_UnitTestCase {
 						),
 					),
 					'load_separate_option' => true,
+					'vk_blocks_pro_license_key' => 'test_license_key',
+					'display_vk_block_template' => 'display',
+					'new_faq_accordion' => 'open',
 				),
 				'correct' => array(
 					'balloon_border_width' => 2,
 					'margin_unit' => 'px',
-					'display_vk_block_template' => 'display',
-					'new_faq_accordion' => 'open',
 					'margin_size' => array(
 						'lg' => array(
 							'mobile' => 1,
@@ -85,6 +84,9 @@ class GetOptionsTest extends WP_UnitTestCase {
 						),
 					),
 					'load_separate_option' => true,
+					'vk_blocks_pro_license_key' => 'test_license_key',
+					'display_vk_block_template' => 'display',
+					'new_faq_accordion' => 'open',
 				),
 			),
 		);
@@ -103,14 +105,14 @@ class GetOptionsTest extends WP_UnitTestCase {
 			$return  = vk_blocks_get_options();
 			$correct = $test_value['correct'];
 
-			print 'return  :';
-			print PHP_EOL;
-			var_dump( $return );
-			print PHP_EOL;
-			print 'correct  :';
-			print PHP_EOL;
-			var_dump( $correct );
-			print PHP_EOL;
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
 			$this->assertSame( $correct, $return );
 
 		}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
事前準備
#1057

## どういう変更をしたか？

option値のデフォルト値を設定する箇所が２箇所に別れていたため、見通しが悪いかつミスを起こしやすいので調整します

デフォルト値を取得するメソッドは #1300 このブランチで作成ずみ

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
ユーザーレベルで変更はないので書いていないです
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

・テストコマンドで確認
```
npm run phpunit
```
```
npm run test:e2e ./test/e2e-tests/specs/vk_blocks_options.test.js
```

・管理画面でdevelopブランチと同様の動作,保存がされるか確認
・他、気になる箇所や影響がありそうなところなどあったらご指摘お願いします。


メモ
e2eテストは初期にoption値があると通らないと思うのでoption値を消す必要があります
以下のコードをvk-blocks.phpにはって一度無効化したらoption値が消えると思います
```PHP
if ( function_exists( 'register_deactivation_hook' ) ) {
	register_deactivation_hook( __FILE__, 'vk_blocks_uninstall_function' );
}
function vk_blocks_uninstall_function() {
	delete_option( 'vk_blocks_options' );
	delete_option( 'vk_blocks_balloon_meta' );
}
```

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
