### PR TITLE
【2人め確認中】[ ボタン ]背景色をクリアしたとき、primary に変換

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,7 @@ e.g.
 == Changelog ==
 
 [ Bug Fix ][ highlighter ] cope with color palette with alpha.
+[ Bug Fix ][ button ] buttonColorCustom clear convert to primary.
 
 = 1.41.1 =
 [ Bug Fix ] Fix don't display Admin screen in case of spacific option value

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -75,6 +75,7 @@ export default function ButtonEdit(props) {
 			setAttributes({ buttonUrl: undefined });
 		}
 		if (buttonColorCustom === undefined) {
+			setAttributes({ buttonColor: 'primary' });
 			setAttributes({ buttonTextColorCustom: undefined });
 		}
 		if (
@@ -147,6 +148,10 @@ export default function ButtonEdit(props) {
 	useEffect(() => {
 		if (buttonColorCustom !== undefined) {
 			updateBlockAttributes(clientId, { buttonColor: 'custom' });
+		}
+		else{
+			// 背景色がクリアされたらデフォルトに戻す
+//			updateBlockAttributes(clientId, { buttonColor: 'primary' });
 		}
 	}, [buttonColorCustom]);
 

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -75,7 +75,6 @@ export default function ButtonEdit(props) {
 			setAttributes({ buttonUrl: undefined });
 		}
 		if (buttonColorCustom === undefined) {
-			setAttributes({ buttonColor: 'primary' });
 			setAttributes({ buttonTextColorCustom: undefined });
 		}
 		if (
@@ -148,10 +147,9 @@ export default function ButtonEdit(props) {
 	useEffect(() => {
 		if (buttonColorCustom !== undefined) {
 			updateBlockAttributes(clientId, { buttonColor: 'custom' });
-		}
-		else{
-			// 背景色がクリアされたらデフォルトに戻す
-//			updateBlockAttributes(clientId, { buttonColor: 'primary' });
+		} else if (buttonColor === 'custom') {
+			// 背景色クリアされたらデフォルトに戻す
+			updateBlockAttributes(clientId, { buttonColor: 'primary' });
 		}
 	}, [buttonColorCustom]);
 

--- a/src/blocks/button/style.scss
+++ b/src/blocks/button/style.scss
@@ -404,3 +404,9 @@ $xxl-min: 1400px;
 		display: inline-block;
 	}
 }
+
+// 背景色が不明の場合
+ .has-background,
+.editor-styles-wrapper .has-background {
+	background-color: var(--vk-color-primary);
+}	

--- a/src/blocks/button/style.scss
+++ b/src/blocks/button/style.scss
@@ -20,7 +20,8 @@ $xxl-min: 1400px;
 
 :root,
 :root .editor-styles-wrapper {
-	.has-vk-color-primary-background-color {
+	.has-vk-color-primary-background-color,
+	.has-undefined-background-color {
 		background-color: var(--vk-color-primary);
 	}
 	.has-vk-color-secondary-background-color {
@@ -367,6 +368,8 @@ $xxl-min: 1400px;
 			user-select: text;
 			text-decoration: none;
 			font-size: calc( var(--vk-size-text) * 1 );
+
+			
 		}
 		&.btn-lg{
 			font-size:calc( var(--vk-size-text) * 1.25 );
@@ -404,9 +407,3 @@ $xxl-min: 1400px;
 		display: inline-block;
 	}
 }
-
-// 背景色が不明の場合
- .has-background,
-.editor-styles-wrapper .has-background {
-	background-color: var(--vk-color-primary);
-}	


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 [ ボタン ]背景色をクリアすると見えなくなる #1240 

## どういう変更をしたか？

* ボタンの背景色をクリアすると クラス has-undefined-background-color があたって背景色なし(透明)になっていたので、クリアされたときは has-vk-color-primary-background-color になるよう修正
* 以前のブロックで has-undefined-background-color になっている場合は、primary の色が表示されるようにした

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* develop ブランチでvk ボタンを挿入、背景色をクリア(いったんパレットから色を選択して、クリアボタンを押した際に再現する)した状態で保存。このときボタンは透明になっているのでフロント、編集画面では見えない。
* 当ブランチにしたとき上記ブロックがフロント、編集画面ともprimary の色で表示されることを確認
* 当ブランチでvk ボタンを挿入し背景色をクリアしたとき、primary に設定されることを確認


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* develop ブランチでvk ボタンを挿入し、背景色をクリア(いったんパレットから色を選択して、クリアボタンを押した際に再現する)した状態で保存。このときボタンは透明になっているのでフロント、編集画面では見えない。
   * コメント欄に【サンプルデータ】あり
* 当ブランチにしたとき上記ブロックがフロント、編集画面ともprimary の色で表示されるか
   * 以前に作成したブロックでフロント側に has-undefined-background-color が残っている場合は、primary の色を当てています
* 当ブランチでvk ボタンを挿入し背景色をクリアしたとき、primary に設定されるか
* なお、他のテーマのパレット色が指定されている場合にボタンが見えない(透明)問題は以前から残るが、今回は対応しませんでした。Vk blocks のパレット、他のテーマ(Lightning以外)のパレット、bootstrap のcss の優先順が複雑でむずかしいため

---

## レビュワー向け
 

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
