### PR TITLE
【@kurudrive 確認待ち】無料版デプロイ時 incなどのフォルダも削除してからコミットしたい

### DIFF
--- a/bin/deploy-free.sh
+++ b/bin/deploy-free.sh
@@ -29,6 +29,10 @@ rm -rf editor-css/* inc/* lib/* options-css/* src/*
 # プロ版のディレクトリに移動
 cd ../
 # 指定したファイルを除外して、Pro版を無料版（vk-blocks-copy-target）へコピー&上書き
+# -a : archive -rlptgoDとイコール
+# -r : 指定ディレクトリ配下をすべて対象
+# -v : コピーファイルの転送情報を出力
+# -c : チェックサムで差分を確認
 rsync -arvc --exclude 'vk-blocks-copy-target/' --exclude 'vendor/' --exclude 'bin/' --exclude 'build/_pro/' --exclude 'src/blocks/_pro/' --exclude 'inc/vk-blocks-pro/' --exclude '.git/' --exclude '.github/' --exclude 'build/block-build.css' --exclude 'inc/vk-blocks-pro-config.php' --exclude 'src/blocks/bundle-pro.js' --exclude '.gitignore' --exclude 'build/*.css' --exclude 'build/*.js' --exclude 'editor-css/*.css' --exclude 'editor-css/*.css.map' --exclude 'vk-blocks-pro.code-workspace' --exclude 'phpunit.xml.dist' ./* ./vk-blocks-copy-target/
 
 # 無料版のディレクトリに移動

--- a/bin/deploy-free.sh
+++ b/bin/deploy-free.sh
@@ -23,8 +23,8 @@ version=$1
 mv vk-blocks/ vk-blocks-copy-target/
 # Cloneした無料版のディレクトリに移動
 cd ./vk-blocks-copy-target/
-# コピー先の src/ を一旦削除
-rm -rf src/*
+# コピー先の トップディレクトリ を一旦削除
+rm -rf editor-css/* inc/* lib/* options-css/* src/*
 
 # プロ版のディレクトリに移動
 cd ../


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

実際に無料版にデプロイしないと確認が取れないのでチェック項目にチェックは入れていません。

### 背景
incなどのフォルダでは無料版リポジトリーに自動で削除されないので改めてブランチを作らなければいけない
新たにプルリクを作るのは面倒、また忘れる可能性が高いので自動で削除するようにしたい
例：https://github.com/vektor-inc/vk-blocks/pull/119

srcフォルダ内はファイルの削除がされていた
例：吹き出しブロック
https://github.com/vektor-inc/vk-blocks-pro/pull/1346
https://github.com/vektor-inc/vk-blocks/commit/0812b9b99186583f735d70ae93980f4f4a46f201

これはpro版から無料版へpushする際に一度無料版のsrcを削除しているためファイルの削除も反映されている
https://github.com/vektor-inc/vk-blocks-pro/blob/master/bin/deploy-free.sh#L26-L27


## どういう変更をしたか？

`editor-css/* inc/* lib/* options-css/* src/*`のフォルダ以下も削除するように変更

※注意
全てを削除 = rm -rf * した方が全てのファイルを削除するので良いのでは？と思うかもしれないが
.gitignoreなどは無料版とpro版では違うものを使いたいっぽいので全ての削除はしない方が良いのかなと思っています

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

```shell
rm -rf editor-css/* inc/* lib/* options-css/* src/*
```
のコマンドをして
editor-css/* inc/* lib/* options-css/* src/*以下のファイルが削除されることを確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

・stableタグなどを利用して無料版へのアップデートを行う。
・inc内のファイルが削除されていることを確認
例)inc/template-tagsなど
・無料版のプラグインでエラーが出ないか確認
srcフォルダは今まで通りなのでブロックなどには変わりがないと思います。
・もしかするとSVNでファイルの削除を行う必要がある(かも？)

緊急では無いので慎重に行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
