### PR TITLE
【確認中】vk_blocks_get_options配列のマージ再帰処理に対応

### DIFF
--- a/inc/vk-blocks/utils/array-merge.php
+++ b/inc/vk-blocks/utils/array-merge.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Array merge
+ *
+ * @package vk-blocks
+ */
+
+/**
+ * Merges user defined arguments into defaults array.
+ *
+ * $argsにキーが存在したらそのまま存在しない時に$defaultsの配列をマージする
+ *
+ * wp_parse_argsの配列処理に再帰処理を追加した関数
+ *
+ * @see https://developer.wordpress.org/reference/functions/wp_parse_args/
+ *
+ * @param array $args Value to merge with $defaults.
+ * @param array $defaults Optional. Array that serves as the defaults.
+ *
+ * @return array Merged user defined values with defaults.
+ */
+function vk_blocks_array_merge( $args, $defaults = array() ) {
+	$parsed_args = $args;
+	foreach ( $defaults as $key => $value ) {
+		if ( empty( $args[ $key ] ) ) {
+			$parsed_args[ $key ] = $value;
+		} elseif ( is_array( $value ) && is_array( $args[ $key ] ) ) {
+			$parsed_args[ $key ] = vk_blocks_array_merge( $args[ $key ], $value );
+		}
+	}
+	return $parsed_args;
+}

--- a/inc/vk-blocks/utils/array-merge.php
+++ b/inc/vk-blocks/utils/array-merge.php
@@ -10,7 +10,7 @@
  *
  * $argsにキーが存在したらそのまま存在しない時に$defaultsの配列をマージする
  *
- * wp_parse_argsの配列処理に再帰処理を追加した関数
+ * wp_parse_args配列のマージに再帰処理を追加した関数
  *
  * @see https://developer.wordpress.org/reference/functions/wp_parse_args/
  *

--- a/inc/vk-blocks/vk-blocks-functions.php
+++ b/inc/vk-blocks/vk-blocks-functions.php
@@ -16,6 +16,9 @@ require_once dirname( __FILE__ ) . '/class-vk-blocks-print-css-variables.php';
 require_once dirname( __FILE__ ) . '/class-vk-blocks-options.php';
 VK_Blocks_Options::init();
 
+// utils
+require_once dirname( __FILE__ ) . '/utils/array-merge.php';
+
 /**
  * スペーサーのサイズの配列
  */
@@ -73,7 +76,7 @@ add_filter(
 function vk_blocks_get_options() {
 	$options  = get_option( 'vk_blocks_options' );
 	$defaults = VK_Blocks_Options::get_defaults( VK_Blocks_Options::options_scheme() );
-	$options  = wp_parse_args( $options, $defaults );
+	$options  = vk_blocks_array_merge( $options, $defaults );
 	return $options;
 }
 /**

--- a/test/phpunit/pro/test-array-merge.php
+++ b/test/phpunit/pro/test-array-merge.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Class ArrayMergeTest
+ *
+ * @package vk-blocks
+ */
+
+class ArrayMergeTest extends WP_UnitTestCase {
+
+	public function test_vk_blocks_array_merge() {
+		/**
+		 * argsとdefaultsをマージしてcorrectになるかテスト
+		 */
+		$test_data = array(
+			// argsに同じキーがあったらそのまま
+			array(
+				'args'  => array(
+					'string' => 'a',
+				),
+				'defaults'  => array(
+					'string' => 'b',
+				),
+				'correct' => array(
+					'string' => 'a',
+				),
+			),
+			// argsの同じキーはそのまま。無いキーはdefaultをマージ
+			array(
+				'args'  => array(
+					'number' => 1,
+				),
+				'defaults'  => array(
+					'number' => 2,
+					'string' => 'a',
+				),
+				'correct' => array(
+					'number' => 1,
+					'string' => 'a',
+				),
+			),
+			// 配列
+			array(
+				'args'  => array(
+					'string' => 'a',
+					'array_1'  => array(
+						'value_1_1',
+						'value_1_2'
+					),
+				),
+				'defaults'  => array(
+					'string' => 'a',
+					'array_1'  => array(
+						'value_defaults_1_1',
+						'value_defaults_1_2'
+					),
+					'array_ 2'  => array(
+						'value_2_1',
+						'value_2_2'
+					),
+				),
+				'correct' => array(
+					'string' => 'a',
+					'array_1'  => array(
+						'value_1_1',
+						'value_1_2'
+					),
+					'array_ 2'  => array(
+						'value_2_1',
+						'value_2_2'
+					),
+				),
+			),
+			// 連想配列
+			array(
+				'args'  => array(
+					'string' => 'a',
+					'array_1'  => array(
+						'array_1_1' => array(
+							'array_key_1_1' => 'array_value_1_1',
+							'array_key_1_2' => 'array_value_1_2',
+						),
+					),
+				),
+				'defaults'  => array(
+					'string' => 'b',
+					'array_1'  => array(
+						'array_1_1' => array(
+							'array_key_1_1' => 'array_value_defaults_1_1',
+							'array_key_1_2' => 'array_value_defaults_1_2',
+						),
+						'array_2_1' => array(
+							'array_key_2_1' => 'array_value_2_1',
+							'array_key_2_2' => 'array_value_2_2',
+						),
+					),
+				),
+				'correct' => array(
+					'string' => 'a',
+					'array_1'  => array(
+						'array_1_1' => array(
+							'array_key_1_1' => 'array_value_1_1',
+							'array_key_1_2' => 'array_value_1_2',
+						),
+						'array_2_1' => array(
+							'array_key_2_1' => 'array_value_2_1',
+							'array_key_2_2' => 'array_value_2_2',
+						),
+					),
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'vk_blocks_array_merge()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+
+			$return  = vk_blocks_array_merge( $test_value['args'], $test_value['defaults'] );
+			$correct = $test_value['correct'];
+
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+
+		}
+	}
+}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1368
#1355 の準備

## どういう変更をしたか？

wp_parse_argsの配列のマージに再帰処理を追加したvk_blocks_array_merge関数を追加
目的は #1355 このブランチで入れ子になった配列のマージするためです

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
ユーザーレベルで変更はないので書いていないです
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

```PHP
npm run phpunit
```
で再帰処理されていることを確認
・php unit testが必要十分か
・他、気になる箇所があったらご指摘お願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
