### PR TITLE
fix : 無料版デプロイ時に lib 内の vendor も削除してしまいビルドエラーになるので修正

### DIFF
--- a/bin/deploy-free.sh
+++ b/bin/deploy-free.sh
@@ -33,7 +33,7 @@ cd ../
 # -r : 指定ディレクトリ配下をすべて対象
 # -v : コピーファイルの転送情報を出力
 # -c : チェックサムで差分を確認
-rsync -arvc --exclude 'vk-blocks-copy-target/' --exclude 'vendor/' --exclude 'bin/' --exclude 'build/_pro/' --exclude 'src/blocks/_pro/' --exclude 'inc/vk-blocks-pro/' --exclude '.git/' --exclude '.github/' --exclude 'build/block-build.css' --exclude 'inc/vk-blocks-pro-config.php' --exclude 'src/blocks/bundle-pro.js' --exclude '.gitignore' --exclude 'build/*.css' --exclude 'build/*.js' --exclude 'editor-css/*.css' --exclude 'editor-css/*.css.map' --exclude 'vk-blocks-pro.code-workspace' --exclude 'phpunit.xml.dist' ./* ./vk-blocks-copy-target/
+rsync -arvc --exclude 'vk-blocks-copy-target/' --exclude './vendor/' --exclude 'bin/' --exclude 'build/_pro/' --exclude 'src/blocks/_pro/' --exclude 'inc/vk-blocks-pro/' --exclude '.git/' --exclude '.github/' --exclude 'build/block-build.css' --exclude 'inc/vk-blocks-pro-config.php' --exclude 'src/blocks/bundle-pro.js' --exclude '.gitignore' --exclude 'build/*.css' --exclude 'build/*.js' --exclude 'editor-css/*.css' --exclude 'editor-css/*.css.map' --exclude 'vk-blocks-pro.code-workspace' --exclude 'phpunit.xml.dist' ./* ./vk-blocks-copy-target/
 
 # 無料版のディレクトリに移動
 cd ./vk-blocks-copy-target/


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/pull/1381

第一階層を削除していたが、無料版のビルドでコケてしまう問題があった
プロ版のディレクトリを無料版に複製する際、composer の vendor ディレクトリ除外していたが、
第一階層以外の vendor ディレクトリも削除してしまっていたので、本来必要な lib/bootstrap/_scss/vendor/ ディレクトリまで削除されてしまう。

## どういう変更をしたか？

第一階層の vendor 以外は除外しないように変更
