### PR TITLE
【2人め確認中】スタッフ 編集画面では個別のスクリプトを削除

### DIFF
--- a/src/blocks/staff/index.php
+++ b/src/blocks/staff/index.php
@@ -19,13 +19,6 @@ function vk_blocks_register_block_staff() {
 			array(),
 			VK_BLOCKS_VERSION
 		);
-	} else {
-		wp_register_style(
-			'vk-blocks/staff',
-			VK_BLOCKS_DIR_URL . '/build/staff/style.css',
-			array(),
-			filemtime( VK_BLOCKS_DIR_PATH . 'build/staff/style.css' )
-		);
 	}
 
 	register_block_type(


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
スタッフ 編集画面では個別のCSSを削除
#1382

## どういう変更をしたか？

スタッフブロックで 編集画面で個別のスクリプトを読み込んでいたので削除しました
お手隙のタイミングで確認していただければと思います

実験的なコードが残っていたようです
https://github.com/vektor-inc/vk-blocks-pro/commit/7d801fe89c9cf188a0251db2352d45b6477aa6ba

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
ユーザーレベルで変更はないので書いていません
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

6.0からブロックエディタはis_adminがtrueでは無くなったので6.0では問題なく見えますが
5.9で編集画面でvk-blocks/staffのcssを読み込んでいるが不要なので削除します

・5.9で編集画面で個別のCSSを読み込んでいないか
・5.9、6.0で分割読み込みオン,オフにした時にスタッフブロックで個別の読み込みが今まで通りできているか

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
