### PR TITLE
【2人目確認中】cssをminifyするコードを関数化

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-print-css-variables.php
+++ b/inc/vk-blocks/class-vk-blocks-print-css-variables.php
@@ -57,12 +57,7 @@ class Vk_Blocks_Print_CSS_Variables {
 			--vk-line-height-low: 1.5em;
 			*/
 
-		// delete before after space.
-		$dynamic_css = trim( $dynamic_css );
-		// convert tab and br to space.
-		$dynamic_css = preg_replace( '/[\n\r\t]/', '', $dynamic_css );
-		// Change multiple spaces to single space.
-		$dynamic_css = preg_replace( '/\s(?=\s)/', '', $dynamic_css );
+		$dynamic_css = vk_blocks_minify_css( $dynamic_css );
 		return $dynamic_css;
 	}
 

--- a/inc/vk-blocks/utils/minify-css.php
+++ b/inc/vk-blocks/utils/minify-css.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Minify css
+ *
+ * @package vk-blocks
+ */
+
+/**
+ * Minify Css
+ *
+ * 不要なスペースやタブを削除してcssを最小化する
+ *
+ * @param string $css css to target minimization.
+ *
+ * @return string Minimized css.
+ */
+function vk_blocks_minify_css( $css ) {
+	// delete before after space.
+	$css = trim( $css );
+	// convert tab and br to space.
+	$css = preg_replace( '/[\n\r\t]/', '', $css );
+	// Change multiple spaces to single space.
+	$css = preg_replace( '/\s(?=\s)/', '', $css );
+	return $css;
+}

--- a/inc/vk-blocks/vk-blocks-functions.php
+++ b/inc/vk-blocks/vk-blocks-functions.php
@@ -22,6 +22,7 @@ VK_Blocks_Options::init();
 
 // utils
 require_once dirname( __FILE__ ) . '/utils/array-merge.php';
+require_once dirname( __FILE__ ) . '/utils/minify-css.php';
 
 // VK Blocks の管理画面.
 require_once dirname( __FILE__ ) . '/admin/admin.php';
@@ -161,12 +162,7 @@ function vk_blocks_blocks_assets() {
 
 	$dynamic_css .= vk_blocks_get_spacer_size_style_all( $vk_blocks_options );
 
-	// delete before after space.
-	$dynamic_css = trim( $dynamic_css );
-	// convert tab and br to space.
-	$dynamic_css = preg_replace( '/[\n\r\t]/', '', $dynamic_css );
-	// Change multiple spaces to single space.
-	$dynamic_css = preg_replace( '/\s(?=\s)/', '', $dynamic_css );
+	$dynamic_css = vk_blocks_minify_css( $dynamic_css );
 	wp_add_inline_style( 'vk-blocks-build-css', $dynamic_css );
 	// --vk_image-mask-waveはコアの画像ブロックに依存するのでwp-edit-blocksを追加
 	wp_add_inline_style( 'wp-edit-blocks', $dynamic_css );

--- a/test/phpunit/pro/test-minify-css.php
+++ b/test/phpunit/pro/test-minify-css.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class minifyCssTest
+ *
+ * @package vk-blocks
+ */
+
+class minifyCssTest extends WP_UnitTestCase {
+
+	public function test_vk_blocks_minify_css() {
+		$test_data = array(
+			// delete before after space.
+			array(
+				'css'  => ' .selector { color: white; }', // .selectorの前にスペース
+				'correct' => '.selector { color: white; }',
+			),
+			// convert tab and br to space.
+			array(
+				'css'  => '.selector {
+					color: white;
+				}',
+				'correct' => '.selector {color: white;}',
+			),
+			// multiple spaces to single space
+			array(
+				'css'  => '.selector { color:  white; }', // whiteの前に２つスペース
+				'correct' => '.selector { color: white; }',
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'vk_blocks_minify_css()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+
+			$return  = vk_blocks_minify_css( $test_value['css'] );
+			$correct = $test_value['correct'];
+
+			// print 'return  :';
+			// print PHP_EOL;
+			// var_dump( $return );
+			// print PHP_EOL;
+			// print 'correct  :';
+			// print PHP_EOL;
+			// var_dump( $correct );
+			// print PHP_EOL;
+			$this->assertSame( $correct, $return );
+
+		}
+	}
+}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
cssをminifyしているコードが様々な位置にある、かつ今後も複数の箇所で使う可能性があるので関数化します
#1382

使う予定のあるもの
#1057 #1342

## どういう変更をしたか？
cssをminifyしているコードを関数化

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
ユーザーレベルで変更はないので書いていません
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- 以下のcssが以前と同じcssが出力されること
   - `--vk_flow-arrow`あたりのcss
https://github.com/vektor-inc/vk-blocks-pro/blob/61cba453454fd836b8cd0d12b8c0f0b54358ed3e/inc/vk-blocks/vk-blocks-functions.php#L152-L160
   - 共通余白を保存したときに出力される`spacer_size_style`のcss
https://github.com/vektor-inc/vk-blocks-pro/blob/61cba453454fd836b8cd0d12b8c0f0b54358ed3e/src/blocks/spacer/index.php#L122
   - `Vk_Blocks_Print_CSS_Variables`内のcss(テーマLightning以外の時)
 https://github.com/vektor-inc/vk-blocks-pro/blob/61cba453454fd836b8cd0d12b8c0f0b54358ed3e/inc/vk-blocks/class-vk-blocks-print-css-variables.php#L45-L48

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
