### PR TITLE
【調整中】「CSSのみ修正」セクションベースありでコンテンツエリアに合わせる にした場合、コンテンツの幅がおかしくなるのを修正

### DIFF
--- a/src/blocks/_pro/outer/style.scss
+++ b/src/blocks/_pro/outer/style.scss
@@ -91,7 +91,12 @@ $media-xxl-down: 1399.98px;
 .vk_outer-width-full.vk_outer-paddingLR-none {
 	padding-left: calc(50vw - 50%);
 	padding-right: calc(50vw - 50%);
+	.main-section--base--on &{ //セクションベースありの時
+			padding-left: 0;
+			padding-right: 0;
+	}
 }
+
 $padding-none: 1.5em;
 $padding-sm: 2em;
 $padding-md: 2.5em;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-blocks-pro/issues/1404

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

セクションベースありにして、全幅で余白（左右）をコンテンツエリアに合わせる にした場合の左右のpaddingが原因だったので、セクションベースありの時（.main-section--base--on）の左右のpaddingを追加して修正しました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

readmeに書くほどの修正でもない気がしたので書いておりません。必要であればかきますmm


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

*Outerブロックを全幅で配置し、余白（左右）を「コンテンツエリアに合わせる」にする
*セクションを「セクションベースあり」と「セクションベース無し」に変えてて崩れていないことを確認しました
*1カラムや2カラムにしても崩れないことを確認しました


## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*Outerブロックを全幅で配置し、余白（左右）を「コンテンツエリアに合わせる」にします。
*セクションを「セクションベースあり」と「セクションベース無し」に変えてて崩れていないことを確認してください
*1カラムや2カラムにしても崩れないことを確認してください

【追記】
テーマはLightning、プラグインはLightning G3 Pro Unitを使用する

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
