### PR TITLE
vk_blocks_array_merge 配列の順番はdefaultsに合わせる仕様に調整

### DIFF
--- a/inc/vk-blocks/utils/array-merge.php
+++ b/inc/vk-blocks/utils/array-merge.php
@@ -6,6 +6,26 @@
  */
 
 /**
+ * 順番を揃える
+ *
+ * @param array $args Value to merge with $defaults.
+ * @param array $defaults Array that serves as the defaults.
+ *
+ * @return array Array with aligned order.
+ */
+function vk_blocks_merge_order( $args, $defaults ) {
+	$merged = $defaults;
+	foreach ( $args as $key => $value ) {
+		if ( ! is_array( $value ) && array_key_exists( $key, $defaults ) ) {
+			$merged[ $key ] = $value;
+		} elseif ( is_array( $value ) && is_array( $defaults[ $key ] ) ) {
+			$merged[ $key ] = vk_blocks_merge_order( $value, $defaults[ $key ] );
+		}
+	}
+	return $merged;
+}
+
+/**
  * Merges user defined arguments into defaults array.
  *
  * $argsにキーが存在したらそのまま存在しない時に$defaultsの配列をマージする
@@ -19,14 +39,28 @@
  *
  * @return array Merged user defined values with defaults.
  */
-function vk_blocks_array_merge( $args, $defaults = array() ) {
-	$parsed_args = $args;
+function vk_blocks_merge_value( $args, $defaults ) {
+	$merged = $args;
 	foreach ( $defaults as $key => $value ) {
 		if ( empty( $args[ $key ] ) ) {
-			$parsed_args[ $key ] = $value;
+			$merged[ $key ] = $value;
 		} elseif ( is_array( $value ) && is_array( $args[ $key ] ) ) {
-			$parsed_args[ $key ] = vk_blocks_array_merge( $args[ $key ], $value );
+			$merged[ $key ] = vk_blocks_merge_value( $args[ $key ], $value );
 		}
 	}
+	return $merged;
+}
+
+/**
+ * 順番と値をマージする関数を呼び出す関数
+ *
+ * @param array $args Value to merge with $defaults.
+ * @param array $defaults Optional. Array that serves as the defaults.
+ *
+ * @return array Merged user defined values with defaults.
+ */
+function vk_blocks_array_merge( $args, $defaults = array() ) {
+	$order       = vk_blocks_merge_order( $args, $defaults );
+	$parsed_args = vk_blocks_merge_value( $order, $defaults );
 	return $parsed_args;
 }

--- a/inc/vk-blocks/utils/array-merge.php
+++ b/inc/vk-blocks/utils/array-merge.php
@@ -6,29 +6,11 @@
  */
 
 /**
- * 順番を揃える
- *
- * @param array $args Value to merge with $defaults.
- * @param array $defaults Array that serves as the defaults.
- *
- * @return array Array with aligned order.
- */
-function vk_blocks_merge_order( $args, $defaults ) {
-	$merged = $defaults;
-	foreach ( $args as $key => $value ) {
-		if ( ! is_array( $value ) && array_key_exists( $key, $defaults ) ) {
-			$merged[ $key ] = $value;
-		} elseif ( is_array( $value ) && is_array( $defaults[ $key ] ) ) {
-			$merged[ $key ] = vk_blocks_merge_order( $value, $defaults[ $key ] );
-		}
-	}
-	return $merged;
-}
-
-/**
  * Merges user defined arguments into defaults array.
  *
  * $argsにキーが存在したらそのまま存在しない時に$defaultsの配列をマージする
+ *
+ * 順番はdefaultsに合わせる
  *
  * wp_parse_args配列のマージに再帰処理を追加した関数
  *
@@ -39,28 +21,14 @@ function vk_blocks_merge_order( $args, $defaults ) {
  *
  * @return array Merged user defined values with defaults.
  */
-function vk_blocks_merge_value( $args, $defaults ) {
-	$merged = $args;
-	foreach ( $defaults as $key => $value ) {
-		if ( empty( $args[ $key ] ) ) {
+function vk_blocks_array_merge( $args, $defaults ) {
+	$merged = $defaults;
+	foreach ( $args as $key => $value ) {
+		if ( ! is_array( $value ) && array_key_exists( $key, $defaults ) ) {
 			$merged[ $key ] = $value;
-		} elseif ( is_array( $value ) && is_array( $args[ $key ] ) ) {
-			$merged[ $key ] = vk_blocks_merge_value( $args[ $key ], $value );
+		} elseif ( is_array( $value ) && is_array( $defaults[ $key ] ) ) {
+			$merged[ $key ] = vk_blocks_array_merge( $value, $defaults[ $key ] );
 		}
 	}
 	return $merged;
-}
-
-/**
- * 順番と値をマージする関数を呼び出す関数
- *
- * @param array $args Value to merge with $defaults.
- * @param array $defaults Optional. Array that serves as the defaults.
- *
- * @return array Merged user defined values with defaults.
- */
-function vk_blocks_array_merge( $args, $defaults = array() ) {
-	$order       = vk_blocks_merge_order( $args, $defaults );
-	$parsed_args = vk_blocks_merge_value( $order, $defaults );
-	return $parsed_args;
 }

--- a/test/phpunit/pro/test-array-merge.php
+++ b/test/phpunit/pro/test-array-merge.php
@@ -70,7 +70,7 @@ class ArrayMergeTest extends WP_UnitTestCase {
 					),
 				),
 			),
-			// 連想配列
+			// 連想配列 順番はdefaultsに合わせる
 			array(
 				'args'  => array(
 					'string' => 'a',
@@ -84,6 +84,10 @@ class ArrayMergeTest extends WP_UnitTestCase {
 				'defaults'  => array(
 					'string' => 'b',
 					'array_1'  => array(
+						'array_0_1' => array(
+							'array_key_0_1' => 'array_value_0_1',
+							'array_key_0_2' => 'array_value_0_1',
+						),
 						'array_1_1' => array(
 							'array_key_1_1' => 'array_value_defaults_1_1',
 							'array_key_1_2' => 'array_value_defaults_1_2',
@@ -97,6 +101,10 @@ class ArrayMergeTest extends WP_UnitTestCase {
 				'correct' => array(
 					'string' => 'a',
 					'array_1'  => array(
+						'array_0_1' => array(
+							'array_key_0_1' => 'array_value_0_1',
+							'array_key_0_2' => 'array_value_0_1',
+						),
 						'array_1_1' => array(
 							'array_key_1_1' => 'array_value_1_1',
 							'array_key_1_2' => 'array_value_1_2',


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1368

## どういう変更をしたか？

vk_blocks_array_merge 配列の順番は$defaultsに合わせる仕様に調整

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
ユーザーレベルで変更はないので書いていないです
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

・php unit testで配列の順番はdefaultsに合っているか確認
・順番を揃えるために新しく関数を増やすなど、ややまどろっこしい書き方になっているのですが他に良い書き方などあったらアドバイスいただきたいです。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
