### PR TITLE
【2人め確認中】vk_blocks_get_optionsユニットテスト 配列の時 指定したキー同士を比べる仕様に調整

### DIFF
--- a/test/phpunit/pro/test-get-options.php
+++ b/test/phpunit/pro/test-get-options.php
@@ -124,27 +124,39 @@ class GetOptionsTest extends WP_UnitTestCase {
 			// 余白の共通サイズ設定 margin_size v1.7.1
 			// https://github.com/vektor-inc/vk-blocks-pro/pull/584/
 			array(
-				'option_check_target' => 'margin_size',
+				'option_check_target' => array(
+					['margin_size','lg','mobile'],
+					['margin_size','lg','tablet'],
+					['margin_size','lg','pc'],
+					['margin_size','md','mobile'],
+					['margin_size','md','tablet'],
+					['margin_size','md','pc'],
+					['margin_size','sm','mobile'],
+					['margin_size','sm','tablet'],
+					['margin_size','sm','pc'],
+				),
 				'option'  => array(
 					'display_vk_block_template' => 'hide',
 					'new_faq_accordion' => 'open',
 					'balloon_border_width' => 2,
 				),
 				'correct' => array(
-					'lg' => array(
-						'mobile' => null,
-						'tablet' => null,
-						'pc' => null,
-					),
-					'md' => array(
-						'mobile' => null,
-						'tablet' => null,
-						'pc' => null,
-					),
-					'sm' => array(
-						'mobile' => null,
-						'tablet' => null,
-						'pc' => null,
+					'margin_size' => array(
+						'lg' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+						'md' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
+						'sm' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
 					),
 				),
 			),
@@ -285,7 +297,23 @@ class GetOptionsTest extends WP_UnitTestCase {
 			// var_dump( $correct );
 			// print PHP_EOL;
 
-			if ( $test_value['option_check_target'] ) {
+			// 配列の時 指定したキー同士を比べる
+			if ( is_array( $test_value['option_check_target'] ) ) {
+				foreach($test_value['option_check_target'] as $keys){
+					$correct_target = $correct;
+					foreach($keys as $value){
+						// VK_Blocks_Options::get_optionsから返ってきた値
+						$return_target  = $return[$value];
+						// $test_dataのcorrectの指定した配列
+						$correct_target = $correct_target[$value];
+					}
+					// var_dump('$return_target');
+					// var_dump($return_target);
+					// var_dump('$correct_target');
+					// var_dump($correct_target);
+					$this->assertSame( $correct_target, $return_target );
+				}
+			} else if ( ! is_array( $test_value['option_check_target'] ) && $test_value['option_check_target'] ) {
 				$this->assertSame( $correct, $return[ $test_value['option_check_target'] ] );
 			} else {
 				$this->assertSame( $correct, $return );

--- a/test/phpunit/pro/test-get-options.php
+++ b/test/phpunit/pro/test-get-options.php
@@ -301,9 +301,10 @@ class GetOptionsTest extends WP_UnitTestCase {
 			if ( is_array( $test_value['option_check_target'] ) ) {
 				foreach($test_value['option_check_target'] as $keys){
 					$correct_target = $correct;
+					$return_target  = $return;
 					foreach($keys as $value){
 						// VK_Blocks_Options::get_optionsから返ってきた値
-						$return_target  = $return[$value];
+						$return_target  = $return_target[$value];
 						// $test_dataのcorrectの指定した配列
 						$correct_target = $correct_target[$value];
 					}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1368 #1355 の準備

## どういう変更をしたか？
phpunitテスト 配列の時 指定したキー同士を比べる仕様に調整

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
テストだけなので書いていないです
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

指定したキー同士を比べる仕様に調整になっているか

余白の余白のオプション値にxsを追加したりして確認お願いします

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
