### PR TITLE
【確認中】vk_blocks_array_merge多次元配列に対応

### DIFF
--- a/inc/vk-blocks/utils/array-merge.php
+++ b/inc/vk-blocks/utils/array-merge.php
@@ -24,9 +24,7 @@
 function vk_blocks_array_merge( $args, $defaults ) {
 	$merged = $defaults;
 	foreach ( $args as $key => $value ) {
-		if ( ! is_array( $value ) && array_key_exists( $key, $defaults ) ) {
-			$merged[ $key ] = $value;
-		} elseif ( is_array( $value ) && isset( $defaults[ $key ] ) && is_array( $defaults[ $key ] ) ) {
+		if ( is_array( $value ) && isset( $defaults[ $key ] ) && is_array( $defaults[ $key ] ) ) {
 			$merged[ $key ] = vk_blocks_array_merge( $value, $defaults[ $key ] );
 		} else {
 			$merged[ $key ] = $value;

--- a/inc/vk-blocks/utils/array-merge.php
+++ b/inc/vk-blocks/utils/array-merge.php
@@ -26,8 +26,10 @@ function vk_blocks_array_merge( $args, $defaults ) {
 	foreach ( $args as $key => $value ) {
 		if ( ! is_array( $value ) && array_key_exists( $key, $defaults ) ) {
 			$merged[ $key ] = $value;
-		} elseif ( is_array( $value ) && is_array( $defaults[ $key ] ) ) {
+		} elseif ( is_array( $value ) && isset( $defaults[ $key ] ) && is_array( $defaults[ $key ] ) ) {
 			$merged[ $key ] = vk_blocks_array_merge( $value, $defaults[ $key ] );
+		} else {
+			$merged[ $key ] = $value;
 		}
 	}
 	return $merged;

--- a/test/phpunit/pro/test-array-merge.php
+++ b/test/phpunit/pro/test-array-merge.php
@@ -116,6 +116,71 @@ class ArrayMergeTest extends WP_UnitTestCase {
 					),
 				),
 			),
+			// 配列 argsにキーが無ければdefaultsをマージ
+			array(
+				'args'  => array(
+					'string' => 'b',
+				),
+				'defaults'  => array(
+					'string' => 'a',
+					'array_key' => array(
+						array(
+							'array_key_1' => 'array_defaults_value_1_1',
+							'array_key_2' => 'array_defaults_value_1_2',
+							'array_key_3' => 'array_defaults_value_1_3',
+						),
+					),
+				),
+				'correct' => array(
+					'string' => 'b',
+					'array_key' => array(
+						array(
+							'array_key_1' => 'array_defaults_value_1_1',
+							'array_key_2' => 'array_defaults_value_1_2',
+							'array_key_3' => 'array_defaults_value_1_3',
+						),
+					),
+				),
+			),
+			// 多次元配列 キーが無ければdefaultsをマージ
+			array(
+				'args'  => array(
+					'array_key' => array(
+						array(
+							'array_key_1' => 'array_value_1_1',
+							'array_key_2' => 'array_value_1_2',
+						),
+						array(
+							'array_key_1' => 'array_value_2_1',
+							'array_key_2' => 'array_value_2_2',
+							'array_key_3' => 'array_value_2_3',
+						),
+					),
+				),
+				'defaults'  => array(
+					'array_key' => array(
+						array(
+							'array_key_1' => 'array_defaults_value_1_1',
+							'array_key_2' => 'array_defaults_value_1_2',
+							'array_key_3' => 'array_defaults_value_1_3',
+						),
+					),
+				),
+				'correct' => array(
+					'array_key' => array(
+						array(
+							'array_key_1' => 'array_value_1_1',
+							'array_key_2' => 'array_value_1_2',
+							'array_key_3' => 'array_defaults_value_1_3',
+						),
+						array(
+							'array_key_1' => 'array_value_2_1',
+							'array_key_2' => 'array_value_2_2',
+							'array_key_3' => 'array_value_2_3',
+						),
+					),
+				),
+			),
 		);
 		print PHP_EOL;
 		print '------------------------------------' . PHP_EOL;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1057 の事前準備
#1367 の為の配列のmerge処理を別ブランチにします

## どういう変更をしたか？

$defaults[ $key ]がセットされている時に回帰処理を実行する条件を追加
多次元配列に対応

特に急ぎでは無いので、お手隙のタイミングで確認していただければと思います

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

・PHPUnitテストの内容が十分か
・もう少し良い書き方などあれば言っていただければと思います🙇‍♂️

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
