### PR TITLE
【2人目確認待ち】無料版の get_options のテストで xs と xl が追加されていなくて落ちるので修正

### DIFF
--- a/test/phpunit/free/test-get-options-free.php
+++ b/test/phpunit/free/test-get-options-free.php
@@ -49,6 +49,11 @@ class GetOptionsTestFree extends WP_UnitTestCase {
 					'balloon_border_width' => 2,
 					'margin_unit' => 'px',
 					'margin_size' => array(
+						'xl' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
 						'lg' => array(
 							'mobile' => 1,
 							'tablet' => 2,
@@ -63,6 +68,11 @@ class GetOptionsTestFree extends WP_UnitTestCase {
 							'mobile' => 1,
 							'tablet' => 2,
 							'pc' => 3,
+						),
+						'xs' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
 						),
 					),
 					'load_separate_option' => true,
@@ -71,6 +81,11 @@ class GetOptionsTestFree extends WP_UnitTestCase {
 					'balloon_border_width' => 2,
 					'margin_unit' => 'px',
 					'margin_size' => array(
+						'xl' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
+						),
 						'lg' => array(
 							'mobile' => 1,
 							'tablet' => 2,
@@ -85,6 +100,11 @@ class GetOptionsTestFree extends WP_UnitTestCase {
 							'mobile' => 1,
 							'tablet' => 2,
 							'pc' => 3,
+						),
+						'xs' => array(
+							'mobile' => null,
+							'tablet' => null,
+							'pc' => null,
 						),
 					),
 					'load_separate_option' => true,


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

無料版のテストで xs と xl が追加されていなくて落ちるので修正

## どういう変更をしたか？

テストの返り値に xl と xs を追加

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ → テストコードにつき記載なし
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* 現状プロ版のリポジトリからは直接確認できない
* 無料版のリポジトリの /test/phpunit/free/test-get-options-free.php を、プロ版のリポジトリのファイルで手動で上書き（といっても既に無料版はコミット済み）
* 無料版のリポジトリで npm run phpunit:free

## 確認URL

ローカルで確認

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 無料版のリポジトリの /test/phpunit/free/test-get-options-free.php を、プロ版のリポジトリのファイルで手動で上書き（といっても既に無料版はコミット済み）
* 無料版のリポジトリで npm run phpunit:free

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
