### PR TITLE
【2人目確認中】グリッドカラムカード 編集画面用のCSSを適切な場所に調整

### DIFF
--- a/editor-css/_editor_before.scss
+++ b/editor-css/_editor_before.scss
@@ -127,6 +127,8 @@ button.image-button:not(.button-delete) {
 @import "./editor_before_breadcrumb";
 // slider
 @import "./editor_before_slider";
+// グリッドカラムカード
+@import "./editor_before_gridcolcard";
 
 // VK Outer 編集パネル
 $color-danger: #dd3333;

--- a/editor-css/_editor_before_gridcolcard.scss
+++ b/editor-css/_editor_before_gridcolcard.scss
@@ -40,7 +40,7 @@
 				margin-bottom:0;
 				grid-template-rows : auto 1fr auto;
 			}
-		} 
+		}
 	}
 	.vk_gridcolcard_item_header {
 		min-width:100%;

--- a/editor-css/_editor_before_gridcolcard.scss
+++ b/editor-css/_editor_before_gridcolcard.scss
@@ -40,7 +40,7 @@
 				margin-bottom:0;
 				grid-template-rows : auto 1fr auto;
 			}
-		}
+		} 
 	}
 	.vk_gridcolcard_item_header {
 		min-width:100%;

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ e.g.
 
 == Changelog ==
 
-
+[ Bug Fix ][ Grid Column Card ] Fixed a bug that css for editor was displayed in front.
 [ Bug Fix ][ Select Post List Item ( Pro ) ] Fixed a bug where additional CSS classes were not attached.
 
 = 1.43.0 =


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1399

## どういう変更をしたか？

グリッドカラムカード 編集画面用のCSSを適切な場所に調整しフロントエンドに出力されないようにします

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* developブランチとこのブランチでグリッドカラムカードを配置して編集画面用のCSSが適応されているか確認
グリッドカラムカードのHTML
https://github.com/vektor-inc/vk-blocks-pro/blob/a9e1d53528a908667cbf74982e55139b97a4f49e/test/e2e-tests/fixtures/blocks/vk-blocks__gridcolcard__default.html

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
