### PR TITLE
【２人め確認待ち】WP6.1+TT3のPHPエラー対応

### DIFF
--- a/inc/vk-blocks/style/hidden-extension.php
+++ b/inc/vk-blocks/style/hidden-extension.php
@@ -14,7 +14,7 @@
  */
 function vk_blocks_hidden_extension_filter( $block_content, $block ) {
 	global $vk_blocks_common_attributes;
-	if ( array_key_exists( 'attrs', $block ) ) {
+	if ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) {
 		foreach ( $block['attrs'] as $key => $value ) {
 			$hidden_class     = array(
 				'vk_hidden',

--- a/inc/vk-blocks/style/hidden-extension.php
+++ b/inc/vk-blocks/style/hidden-extension.php
@@ -14,30 +14,32 @@
  */
 function vk_blocks_hidden_extension_filter( $block_content, $block ) {
 	global $vk_blocks_common_attributes;
-	foreach ( $block['attrs'] as $key => $value ) {
-		$hidden_class     = array(
-			'vk_hidden',
-			'vk_hidden-xxl',
-			'vk_hidden-xl-v2',
-			'vk_hidden-xl',
-			'vk_hidden-lg',
-			'vk_hidden-md',
-			'vk_hidden-sm',
-			'vk_hidden-xs',
-		);
-		$class_name       = isset( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
-		$class_name_array = preg_split( '/ /', $class_name );
-		// 分割読み込みをオン
-		if ( VK_Blocks_Block_Loader::should_load_separate_assets() ) {
-			// hidden-extensionがtrueもしくはclassNameにhiddenクラスが含まれていたら
-			if ( in_array( $key, array_keys( $vk_blocks_common_attributes ), true ) || array_intersect( $hidden_class, $class_name_array ) ) {
-				wp_enqueue_style(
-					'vk-hidden-extension',
-					VK_BLOCKS_DIR_URL . 'build/extensions/common/hidden-extension/style.css',
-					array(),
-					VK_BLOCKS_VERSION
-				);
-				break;
+	if  (array_key_exists( 'attrs', $block ) ) {
+		foreach ( $block['attrs'] as $key => $value ) {
+			$hidden_class     = array(
+				'vk_hidden',
+				'vk_hidden-xxl',
+				'vk_hidden-xl-v2',
+				'vk_hidden-xl',
+				'vk_hidden-lg',
+				'vk_hidden-md',
+				'vk_hidden-sm',
+				'vk_hidden-xs',
+			);
+			$class_name       = isset( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
+			$class_name_array = preg_split( '/ /', $class_name );
+			// 分割読み込みがオンの場合
+			if ( VK_Blocks_Block_Loader::should_load_separate_assets() ) {
+				// hidden-extensionがtrueもしくはclassNameにhiddenクラスが含まれていたら
+				if ( in_array( $key, array_keys( $vk_blocks_common_attributes ), true ) || array_intersect( $hidden_class, $class_name_array ) ) {
+					wp_enqueue_style(
+						'vk-hidden-extension',
+						VK_BLOCKS_DIR_URL . 'build/extensions/common/hidden-extension/style.css',
+						array(),
+						VK_BLOCKS_VERSION
+					);
+					break;
+				}
 			}
 		}
 	}

--- a/inc/vk-blocks/style/hidden-extension.php
+++ b/inc/vk-blocks/style/hidden-extension.php
@@ -14,7 +14,7 @@
  */
 function vk_blocks_hidden_extension_filter( $block_content, $block ) {
 	global $vk_blocks_common_attributes;
-	if  (array_key_exists( 'attrs', $block ) ) {
+	if ( array_key_exists( 'attrs', $block ) ) {
 		foreach ( $block['attrs'] as $key => $value ) {
 			$hidden_class     = array(
 				'vk_hidden',


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1450

## どういう変更をしたか？
WP6.1+TT3 だと、$block['attrs'] が設定されないケースがあるので回避。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ エラーの内容的にテストは不要と判断しましたが、こういうテストしたら良いのでは？というのがあれば教えて下さい。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- developブランチ+WordPress6.1+TT3でエラーが出ることを確認
- コードを修正してエラーが出ないことを確認

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

- developブランチ+WordPress6.1+TT3でエラーが出ることを確認
- 本ブランチを適用してエラーが出ないことを確認
- コードチェックで適切な修正かどうか確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
