### PR TITLE
6.1対応 : fontAwesomeアイコンリストの崩れ対応

### DIFF
--- a/editor-css/_editor_before_icon_list.scss
+++ b/editor-css/_editor_before_icon_list.scss
@@ -14,6 +14,7 @@
 				flex-wrap: wrap;
 				flex-direction: row;
 				gap: 0;
+				justify-content: left;
 				.components-radio-control__option {
 					border: 1px solid #666;
 					width: 38px;

--- a/editor-css/_editor_before_icon_list.scss
+++ b/editor-css/_editor_before_icon_list.scss
@@ -17,8 +17,8 @@
 				justify-content: left;
 				.components-radio-control__option {
 					border: 1px solid #666;
-					width: 38px;
-					height: 38px;
+					width: 36px;
+					height: 36px;
 					border-radius: 3px;
 					margin-right: 7px;
 					position: relative;

--- a/editor-css/_editor_before_icon_list.scss
+++ b/editor-css/_editor_before_icon_list.scss
@@ -8,9 +8,12 @@
 		padding: 20px 15px;
 		.vk_icon_list {
 			margin-top: 5px;
-			.components-base-control__field {
+			.components-base-control__field,
+			.components-flex {
 				display: flex;
 				flex-wrap: wrap;
+				flex-direction: row;
+				gap: 0;
 				.components-radio-control__option {
 					border: 1px solid #666;
 					width: 38px;
@@ -30,6 +33,9 @@
 						transform: translateY(-50%) translateX(-50%);
 					}
 				}
+				.components-radio-control__option:not(:last-child) {
+					margin-bottom: 4px;
+				}					
 			}
 		}
 	}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1431 

## どういう変更をしたか？
- FontAwesomeのアイコンリストが、RadioControl コンポーネントのDOM構造が変わったことによって崩れてしまうため、CSSの調整を行いました。 

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？ 
→CSSのみの変更なのでテストは作成していません。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

- アイコンブロック・見出しブロックで fontAwesomeのアイコン選択欄を表示し目視確認を6.0/6.1 それぞれで行いました。

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

- fontAwesomeのアイコン選択欄を表示し、6.0以前 と 6.1 それぞれで動作確認を行ってください。
- 修正が適切かどうかコードチェックをお願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
