### PR TITLE
【2人め確認中】highlighter useAnchorRefは非推奨になったのでuseAnchorに変更

### DIFF
--- a/src/extensions/common/highlighter/index.js
+++ b/src/extensions/common/highlighter/index.js
@@ -76,10 +76,10 @@ const HighlighterEdit = (props) => {
 	// NOTE: useAnchorRefが非推奨になったのでフォールバック WP6.0以下をサポートしなくなったら削除すること #1456
 	const existsUseAnchor = typeof useAnchor === 'function';
 	const _useAnchor = existsUseAnchor ? useAnchor : useAnchorRef;
-	const _useAnchorObj = existsUseAnchor
+	const useAnchorObj = existsUseAnchor
 		? { editableContentElement: contentRef.current, value }
 		: { ref: contentRef, value };
-	const anchorRef = _useAnchor(_useAnchorObj);
+	const anchorRef = _useAnchor(useAnchorObj);
 
 	const [isAddingColor, setIsAddingColor] = useState(false);
 

--- a/src/extensions/common/highlighter/index.js
+++ b/src/extensions/common/highlighter/index.js
@@ -8,7 +8,7 @@ import {
 	applyFormat,
 	removeFormat,
 	getActiveFormat,
-	useAnchorRef,
+	useAnchor,
 } from '@wordpress/rich-text';
 import {
 	RichTextToolbarButton,
@@ -71,7 +71,7 @@ const HighlighterEdit = (props) => {
 			background: `linear-gradient(transparent 60%, ${rgbaHeightlightColor} 0)`,
 		};
 	}
-	const anchorRef = useAnchorRef({ ref: contentRef, value });
+	const anchorRef = useAnchor({ ref: contentRef, value });
 	const [isAddingColor, setIsAddingColor] = useState(false);
 
 	const enableIsAddingColor = useCallback(

--- a/src/extensions/common/highlighter/index.js
+++ b/src/extensions/common/highlighter/index.js
@@ -72,9 +72,15 @@ const HighlighterEdit = (props) => {
 			background: `linear-gradient(transparent 60%, ${rgbaHeightlightColor} 0)`,
 		};
 	}
-	const _useAnchor =
-		typeof useAnchor === 'function' ? useAnchor : useAnchorRef;
-	const anchorRef = _useAnchor({ ref: contentRef, value });
+
+	// NOTE: useAnchorRefが非推奨になったのでフォールバック WP6.0以下をサポートしなくなったら削除すること #1456
+	const existsUseAnchor = typeof useAnchor === 'function';
+	const _useAnchor = existsUseAnchor ? useAnchor : useAnchorRef;
+	const _useAnchorObj = existsUseAnchor
+		? { editableContentElement: contentRef.current, value }
+		: { ref: contentRef, value };
+	const anchorRef = _useAnchor(_useAnchorObj);
+
 	const [isAddingColor, setIsAddingColor] = useState(false);
 
 	const enableIsAddingColor = useCallback(

--- a/src/extensions/common/highlighter/index.js
+++ b/src/extensions/common/highlighter/index.js
@@ -8,6 +8,7 @@ import {
 	applyFormat,
 	removeFormat,
 	getActiveFormat,
+	useAnchorRef,
 	useAnchor,
 } from '@wordpress/rich-text';
 import {
@@ -71,7 +72,9 @@ const HighlighterEdit = (props) => {
 			background: `linear-gradient(transparent 60%, ${rgbaHeightlightColor} 0)`,
 		};
 	}
-	const anchorRef = useAnchor({ ref: contentRef, value });
+	const _useAnchor =
+		typeof useAnchor === 'function' ? useAnchor : useAnchorRef;
+	const anchorRef = _useAnchor({ ref: contentRef, value });
 	const [isAddingColor, setIsAddingColor] = useState(false);
 
 	const enableIsAddingColor = useCallback(


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1456

## どういう変更をしたか？
useAnchorRefをuseAnchorに変更
https://github.com/WordPress/gutenberg/blob/caacb0e48c7e6727c1b7431df3e94556464ca2b6/packages/rich-text/README.md#useanchor

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* developブランチでconsoleにHighlighterEditのwarningが出ていることを確認
* このブランチでHighlighterEditのwarningが解消されていることを確認
* developブランチと同様に Highlighterが使えるか確認
* 6.0でもdevelopブランチと同様に Highlighterが使えるか確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
