### PR TITLE
[ Step / Time line ] 6.1 でコアがつける余白に負けるので暫定対応

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Step(Pro) / Time line(Pro) ] Fix margin of WordPress 6.1 
+
 = 1.45.0 =
 [ Other ] Cope with WordPress 6.1
 [ Specification Change ] Color palette manager use wp_theme_json_data_default filter.

--- a/src/blocks/_pro/step-item/style.scss
+++ b/src/blocks/_pro/step-item/style.scss
@@ -6,7 +6,10 @@
 }
 
 .vk_step {
-	margin: 2em auto;
+	// 6.1 から body .is-layout-flow > * に対して margin-block-start/end ともに 0 がつくので暫定的な上書き処理
+	body .container .is-layout-flow > & {
+		margin: 2em auto; 
+	}
 	.vk_step_item {
 		position: relative;
 		padding:0 0 0 calc(var(--vk-size-text) * 4.5 );

--- a/src/blocks/_pro/timeline-item/style.scss
+++ b/src/blocks/_pro/timeline-item/style.scss
@@ -2,7 +2,10 @@
 /* CSS
 /*-------------------------------------------*/
 .vk_timeline {
-	margin: 2em auto;
+	// 6.1 から body .is-layout-flow > * に対して margin-block-start/end ともに 0 がつくので暫定的な上書き処理
+	body .container .is-layout-flow > & {
+		margin: 2em auto; 
+	}
 	.vk_timeline_item {
 		position: relative;
 		padding: 0 0 2.4em 1.8em;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/1471

ステップブロック/ タイムラインブロックがデフォルトで付与するマージンが、6.1 コアのcssに打ち消されてしまう。

```
body .is-layout-flow > * {
    margin-block-start: 0;
    margin-block-end: 0;
}
```

これを打ち消すCSSを書くよりも本当はユーザーに直接指定してもらって、ブロック側の指定は削除したいところだが、
とりあえず暫定対応

## どういう変更をしたか？

body .container .is-layout-flow > 指定を追加

```
	// 6.1 から body .is-layout-flow > * に対して margin-block-start/end ともに 0 がつくので暫定的な上書き処理
	body .container .is-layout-flow > & {
		margin: 2em auto; 
	}
```


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* 6.1 環境で ステップブロック / タイムラインブロック の上下に余白 2em が追加される事を確認

## 確認URL

なし

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 6.1 環境で ステップブロック / タイムラインブロック の上下に余白 2em が追加される事を確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
