### PR TITLE
【2人目確認中】使用されていない処理を削除 

### DIFF
--- a/inc/vk-blocks/admin/admin.php
+++ b/inc/vk-blocks/admin/admin.php
@@ -79,45 +79,6 @@ function vk_blocks_setting_page() {
 }
 
 /**
- * VK Blocks Save Option
- */
-function vk_blocks_setting_option_save() {
-	if (
-		isset( $_POST['vk_blocks_balloon_meta'], $_POST['vkb-setting-page'] )
-		&& wp_verify_nonce( sanitize_key( $_POST['vkb-setting-page'] ), 'vkb-nonce-key' )
-	) {
-		if ( check_admin_referer( 'vkb-nonce-key', 'vkb-setting-page' ) ) {
-			// 保存処理.
-			if (
-				isset( $_POST['vk_blocks_balloon_meta'], $_POST['vkb-setting-page'] )
-				&& wp_verify_nonce( sanitize_key( $_POST['vkb-setting-page'] ), 'vkb-nonce-key' )
-			) {
-				$vk_blocks_balloon_meta = sanitize_option( 'vk_blocks_balloon_meta', wp_unslash( $_POST['vk_blocks_balloon_meta'] ) );
-				update_option( 'vk_blocks_balloon_meta', $vk_blocks_balloon_meta );
-			} else {
-				update_option( 'vk_blocks_balloon_meta', '' );
-			}
-		}
-	}
-	if (
-		isset( $_POST['vk_blocks_options'], $_POST['vkb-setting-page'] )
-		&& wp_verify_nonce( sanitize_key( $_POST['vkb-setting-page'] ), 'vkb-nonce-key' )
-	) {
-		if ( check_admin_referer( 'vkb-nonce-key', 'vkb-setting-page' ) ) {
-			if (
-				isset( $_POST['vk_blocks_options'], $_POST['vkb-setting-page'] )
-				&& wp_verify_nonce( sanitize_key( $_POST['vkb-setting-page'] ), 'vkb-nonce-key' )
-			) {
-				update_option( 'vk_blocks_options', sanitize_option( 'vk_blocks_options', wp_unslash( $_POST['vk_blocks_options'] ) ) );
-			} else {
-				update_option( 'vk_blocks_options', '' );
-			}
-		}
-	}
-}
-add_action( 'admin_init', 'vk_blocks_setting_option_save', 10, 2 );
-
-/**
  * VK Blocks add setting link
  *
  * @param array  $links VK Blocks action links.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1321 でREST API経由でオプション値の保存を行なったため $_POST変数が渡ってくることはないので削除します
#1321 で削除することを忘れていました。

## どういう変更をしたか？

使用されていない処理を削除 

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下、レビュー確認方法同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* VK Blocksの管理画面 wp-admin/options-general.php?page=vk_blocks_optionsで今まで通りオプション値が保存できるか
* ほか気になる箇所があれば言ってください
*

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
