### PR TITLE
[ グリッドカラムカード ] 編集画面で背景色が飛び出す不具合を修正

### DIFF
--- a/editor-css/_editor_before_grid-column.scss
+++ b/editor-css/_editor_before_grid-column.scss
@@ -206,6 +206,12 @@
 }//.wp-block-vk-blocks-grid-column 
 
 .wp-block-vk-blocks-grid-column  {
+	&-item {
+		.vk_gridColumn_item_inner {
+			// 編集画面で背景色がはみ出すのを防ぐ
+			box-sizing: border-box;
+		}
+	}
 	div[data-type="vk-blocks/grid-column-item"]{
 		// これがないとカラムのセルが潰れて中に何もいれられない
 		min-height:30px;

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,7 @@ e.g.
 [ Add Function ][ Custom CSS ( Pro ) ] Add custom css extension in inspector controls.
 [ Specification Change ][ Grid Column ( Pro ) ] Changed margin setting from 1 to 0.1 separator.
 [ Bug fix ][ Step(Pro) / Time line(Pro) ] Fix margin of WordPress 6.1 
+[ Bug fix ][ GridColumn(Pro) ] Fix bg color overflow bug on edit screen.
 
 = 1.45.0 =
 [ Other ] Cope with WordPress 6.1

--- a/src/blocks/_pro/grid-column-item/edit.js
+++ b/src/blocks/_pro/grid-column-item/edit.js
@@ -47,14 +47,14 @@ export default function GridColumnItemEdit(props) {
 	const columStyle = {
 		color:
 			textColor !== null &&
-				textColor !== undefined &&
-				isHexColor(textColor)
+			textColor !== undefined &&
+			isHexColor(textColor)
 				? textColor
 				: undefined,
 		background:
 			backgroundColor !== null &&
-				backgroundColor !== undefined &&
-				isHexColor(backgroundColor)
+			backgroundColor !== undefined &&
+			isHexColor(backgroundColor)
 				? backgroundColor
 				: undefined,
 		paddingTop:


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

![スクリーンショット 2022-11-10 1 20 38](https://user-images.githubusercontent.com/3272660/200884244-8781272f-aa5a-4c86-ad27-54021022d0bd.png)

## どういう変更をしたか？

![スクリーンショット 2022-11-10 1 24 32](https://user-images.githubusercontent.com/3272660/200885098-f7b37bf4-c6f5-4e09-ae72-e07a23cb98e0.png)
