### PR TITLE
Lightning系以外のテーマでボタンのデフォルト色が当たらないのでデフォルト色を設定

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-print-css-variables.php
+++ b/inc/vk-blocks/class-vk-blocks-print-css-variables.php
@@ -49,7 +49,8 @@ class Vk_Blocks_Print_CSS_Variables {
 		$dynamic_css = '
             :root {
                 --vk-size-text: 16px;
-								/* --vk-color-primary is deprecated. */ --vk-color-primary:#337ab7;
+                /* --vk-color-primary is deprecated. */
+                --vk-color-primary:#337ab7;
             }';
 
 		/*

--- a/inc/vk-blocks/class-vk-blocks-print-css-variables.php
+++ b/inc/vk-blocks/class-vk-blocks-print-css-variables.php
@@ -38,13 +38,18 @@ class Vk_Blocks_Print_CSS_Variables {
 	/**
 	 * 出力するCSSを生成
 	 *
+	 * --vk-color-primaryは非推奨css変数
+	 * cssカスタマイズしているユーザーのために残している
+	 *
+	 * @see https://github.com/vektor-inc/vk-color-palette-manager/pull/19
+	 *
 	 * @return string $dynamic_css 最小化したCSS
 	 */
 	public static function get_print_css() {
 		$dynamic_css = '
             :root {
                 --vk-size-text: 16px;
-				--vk-color-primary:#337ab7;
+								/* --vk-color-primary is deprecated. */ --vk-color-primary:#337ab7;
             }';
 
 		/*

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Button ] Fixed a bug where the default color was not hit in all themes except Lightning.
+
 = 1.46.0 =
 [ Add Function ][ Custom CSS (Pro) ] Add custom css extension in inspector controls.
 [ Specification Change ][ Grid Column (Pro) ] Changed margin setting from 1 to 0.1 separator.

--- a/src/blocks/button/style.scss
+++ b/src/blocks/button/style.scss
@@ -26,7 +26,8 @@ a.vk_button_link {
 :root .editor-styles-wrapper {
 	.has-vk-color-primary-background-color,
 	.has-undefined-background-color {
-		background-color: var(--wp--preset--color--vk-color-primary);
+		// has-vk-color-primary-background-colorクラスはデフォルトで設定される。Lightning以外のテーマに対応するため代替値を設定
+		background-color: var(--wp--preset--color--vk-color-primary,#337ab7);
 	}
 	.has-vk-color-secondary-background-color {
 		background-color: $vk-color-secondary;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/lightning-pro/issues/181
https://github.com/vektor-inc/katawara/issues/222
https://vws.vektor-inc.co.jp/forums/topic/%e3%83%9c%e3%82%bf%e3%83%b3%e9%a1%9e%e3%81%ae%e3%83%87%e3%83%95%e3%82%a9%e3%83%ab%e3%83%88%e3%82%ab%e3%83%a9%e3%83%bc%e3%81%8c%e7%9c%9f%e3%81%a3%e7%99%bd%e3%81%ab%e3%81%aa%e3%81%a3%e3%81%9f#post-71332

## どういう変更をしたか？

* このプルリクで変更した事を記載してください
--wp--preset--color--vk-color-primaryが定義されていないときのデフォルトカラーを設定

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

*
*
*

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

Lightning以外のテーマでボタンのデフォルト色が当たること(TT3とかで確認お願いします)
Lightningではカスタマイザーの色が当たること
katawaraはこのバージョンで対応されているはず
https://github.com/vektor-inc/katawara/pull/223


*
*

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
