### PR TITLE
カスタムCSS機能におけるフロント側CSSクラス書き換え処理の改修

### DIFF
--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -94,8 +94,7 @@ function vk_blocks_render_custom_css( $block_content, $block ) {
 		$css = preg_replace( '/selector/', '.' . $unique_class, $css );
 
 		// vk_custom_cssをUniqueクラスに変換
-		$block_content = preg_replace( '/(class="[^"]*)vk_custom_css([^"]*")/', '$1'. $unique_class . '$2', $block_content, 1);
-
+		$block_content = preg_replace( '/(class="[^"]*)vk_custom_css([^"]*")/', '$1' . $unique_class . '$2', $block_content, 1 );
 	}
 	$css = vk_blocks_minify_css( $css );
 	if ( function_exists( 'wp_enqueue_block_support_styles' ) ) {

--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -94,19 +94,8 @@ function vk_blocks_render_custom_css( $block_content, $block ) {
 		$css = preg_replace( '/selector/', '.' . $unique_class, $css );
 
 		// vk_custom_cssをUniqueクラスに変換
-		if ( strpos( $block_content, ' vk_custom_css ' ) !== false ) {
-			// vk_custom_cssが途中に付いている e.g.class="hoge vk_custom_css huga"
-			$block_content = preg_replace( '/ vk_custom_css /', ' ' . $unique_class . ' ', $block_content, 1 );
-		} elseif ( strpos( $block_content, '="vk_custom_css ' ) !== false ) {
-			// vk_custom_cssから始まる 複数クラス
-			$block_content = preg_replace( '/="vk_custom_css /', '="' . $unique_class . ' ', $block_content, 1 );
-		} elseif ( strpos( $block_content, ' vk_custom_css"' ) !== false ) {
-			// vk_custom_cssで終わる 複数クラス
-			$block_content = preg_replace( '/ vk_custom_css"/', ' ' . $unique_class . '"', $block_content, 1 );
-		} else {
-			// vk_custom_cssのみ
-			$block_content = preg_replace( '/vk_custom_css/', $unique_class, $block_content, 1 );
-		}
+		$block_content = preg_replace( '/(class="[^"]*)vk_custom_css([^"]*")/', '$1'. $unique_class . '$2', $block_content, 1);
+
 	}
 	$css = vk_blocks_minify_css( $css );
 	if ( function_exists( 'wp_enqueue_block_support_styles' ) ) {

--- a/test/phpunit/pro/test-custom-css-extension.php
+++ b/test/phpunit/pro/test-custom-css-extension.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Class CustomCssExtensionTest
+ *
+ * @package vk-blocks
+ */
+
+class CustomCssExtensionTest extends WP_UnitTestCase {
+
+	public function test_should_load_separate_assets() {
+
+        // ブロックコンテナのCSSクラス内のvk_custom_cssだけを変える。ブロックコンテンツ内のspan class内の vk_custom_cssは変更しないようにする。
+        // correct内 %d の箇所が連番になります。
+		$test_data = array(
+
+            // ブロックCSSクラスの先頭に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
+			array(
+				'block_content' => '<p class="vk_custom_css vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_custom_css_%d vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),
+			array(
+				'block_content' => '<p class="vk_custom_css vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_custom_css_%d vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),  
+			array(
+				'block_content' => '<p class="vk_custom_css vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_custom_css_%d vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),  
+			array(
+				'block_content' => '<p class="vk_custom_css vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_custom_css_%d vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),          
+            
+            // ブロックCSSクラスの真ん中に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
+			array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),
+
+			array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),            
+
+			array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),            
+
+			array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),   
+
+            // ブロックCSSクラスの最後に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
+			array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),
+            array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),	           
+            array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),
+            array(
+				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
+			),	            	                               	
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'vk_blocks_render_custom_css()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+        $block = array(
+            'blockName' => 'core/paragraph',
+            'attrs' => array(
+                'vkbCustomCss' => 'selector { color: red; }'
+            )
+        );
+        $count = 1;
+		foreach ( $test_data as $test_value ) {
+            $correct = sprintf($test_value['correct'], $count);
+			$return  = vk_blocks_render_custom_css($test_value['block_content'], $block);
+			$this->assertSame( $correct, $return );
+            $count++;
+		}
+	}
+}

--- a/test/phpunit/pro/test-custom-css-extension.php
+++ b/test/phpunit/pro/test-custom-css-extension.php
@@ -7,7 +7,7 @@
 
 class CustomCssExtensionTest extends WP_UnitTestCase {
 
-	public function test_should_load_separate_assets() {
+	public function test_block_content_preg_replace() {
 
         // ブロックコンテナのCSSクラス内のvk_custom_cssだけを変える。ブロックコンテンツ内のspan class内の vk_custom_cssは変更しないようにする。
         // correct内 %d の箇所が連番になります。


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
カスタムCSSでフロント側でCSSクラスの書き換えを行う際に、ブロックコンテンツ内に" vk_custom_css "の文字列があるとCSSが効かなくなるケースを防ぐようにしました。

https://github.com/vektor-inc/vk-blocks-pro/pull/1512#issuecomment-1342250637

テストを先に作って実装しましたので、テストも追加しております。


## どういう変更をしたか？
- フロント側出力時の置換処理の変更
- PHPUnitテストの追加

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュワー確認方法・確認内容と同じです。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

- developブランチでコードエディタにして以下の内容を貼り付けて、カスタムCSSが正常に動作しないことを確認してください。
```
<!-- wp:paragraph {"vkbCustomCss":"selector {\n    background: #f5f5f5;\n}\nselector::before {\n    content: \u0022要素の直前にコンテンツを追加\u0022;\n    color: # ff0000;\n}","className":"vk_custom_css vk_test_1 vk_test_2"} -->
<p class="vk_custom_css vk_test_1 vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur</span> adipisci elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.&nbsp;</p>
<!-- /wp:paragraph -->
```
続けて、当ブランチに変更して、正常に動作することを確認してください。
- 「CSSクラス」に適当なクラス名を追加して、カスタムCSSが正常に動くか判断してください。
- PHPユニットテストが通っていることを確認してください。
- custom-css-extension.phpの正規表現の部分は以下のようなことをしています。 
<img width="585" alt="image" src="https://user-images.githubusercontent.com/1535140/206663788-55dba053-a1ad-4bf4-8470-f6b29e87079a.png">
不足している条件などあればご指摘ください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
