### PR TITLE
【確認待ち】[スライダー]数値を空白に設定すると次回の編集でブロックのリカバリーが出るのを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,7 @@ e.g.
 [ Bug fix ][ Custom CSS (Pro) ] Fixed bug in not replacing all selector strings.
 [ Add Function ][ Custom Format Setting (Pro) ] Add Custom Format Setting extension in admin.
 [ Specification Change ][ Animation(Pro) ] add setting option Animation only the first view.
+[ Specification Change ][ Slider ] enable float value at Slide Height.
 
 = 1.47.1 =
 [ Bug fix ][ Slider ] Stick out background image on setting panel of site editor

--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Slider ] Set default value for unset time and speed.
+
 = 1.48.0 =
 [ Add Function ][ Admin screen ] Added block manager function.
 [ Add Function ][ Custom Format Setting (Pro) ] Add Custom Format Setting extension in admin.

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -23,7 +23,6 @@ import { isParentReusableBlock } from '@vkblocks/utils/is-parent-reusable-block'
 export default function SliderEdit(props) {
 	const { attributes, setAttributes, clientId } = props;
 	const {
-		unit,
 		pc,
 		tablet,
 		mobile,
@@ -224,14 +223,9 @@ export default function SliderEdit(props) {
 						<RangeControl
 							label={__('PC', 'vk-blocks')}
 							value={pc}
-							onChange={(value) => {
-								let newValue = value ? parseFloat(value) : 0;
-								if ('px' === unit) {
-									newValue = parseInt(newValue);
-								}
-								setAttributes({ pc: newValue });
-							}}
-							step={'px' === unit ? 1 : 0.1}
+							onChange={(value) =>
+								setAttributes({ pc: parseFloat(value) })
+							}
 							min={0}
 							max={1000}
 							allowReset={true}
@@ -240,14 +234,9 @@ export default function SliderEdit(props) {
 						<RangeControl
 							label={__('Tablet', 'vk-blocks')}
 							value={tablet}
-							onChange={(value) => {
-								let newValue = value ? parseFloat(value) : 0;
-								if ('px' === unit) {
-									newValue = parseInt(newValue);
-								}
-								setAttributes({ tablet: newValue });
-							}}
-							step={'px' === unit ? 1 : 0.1}
+							onChange={(value) =>
+								setAttributes({ tablet: parseFloat(value) })
+							}
 							min={0}
 							max={1000}
 							allowReset={true}
@@ -256,14 +245,9 @@ export default function SliderEdit(props) {
 						<RangeControl
 							label={__('Mobile', 'vk-blocks')}
 							value={mobile}
-							onChange={(value) => {
-								let newValue = value ? parseFloat(value) : 0;
-								if ('px' === unit) {
-									newValue = parseInt(newValue);
-								}
-								setAttributes({ mobile: newValue });
-							}}
-							step={'px' === unit ? 1 : 0.1}
+							onChange={(value) =>
+								setAttributes({ mobile: parseFloat(value) })
+							}
 							min={0}
 							max={1000}
 							allowReset={true}

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -225,13 +225,11 @@ export default function SliderEdit(props) {
 							label={__('PC', 'vk-blocks')}
 							value={pc}
 							onChange={(value) => {
-								let newValue = value
-									? parseFloat(value)
-									: 0;
+								let newValue = value ? parseFloat(value) : 0;
 								if ('px' === unit) {
 									newValue = parseInt(newValue);
 								}
-								setAttributes({ pc: newValue })
+								setAttributes({ pc: newValue });
 							}}
 							step={'px' === unit ? 1 : 0.1}
 							min={0}
@@ -243,13 +241,11 @@ export default function SliderEdit(props) {
 							label={__('Tablet', 'vk-blocks')}
 							value={tablet}
 							onChange={(value) => {
-								let newValue = value
-									? parseFloat(value)
-									: 0;
+								let newValue = value ? parseFloat(value) : 0;
 								if ('px' === unit) {
 									newValue = parseInt(newValue);
 								}
-								setAttributes({ tablet: newValue })
+								setAttributes({ tablet: newValue });
 							}}
 							step={'px' === unit ? 1 : 0.1}
 							min={0}
@@ -261,13 +257,11 @@ export default function SliderEdit(props) {
 							label={__('Mobile', 'vk-blocks')}
 							value={mobile}
 							onChange={(value) => {
-								let newValue = value
-									? parseFloat(value)
-									: 0;
+								let newValue = value ? parseFloat(value) : 0;
 								if ('px' === unit) {
 									newValue = parseInt(newValue);
 								}
-								setAttributes({ mobile: newValue })
+								setAttributes({ mobile: newValue });
 							}}
 							step={'px' === unit ? 1 : 0.1}
 							min={0}
@@ -340,8 +334,13 @@ export default function SliderEdit(props) {
 							value={autoPlayDelay}
 							onChange={(value) => {
 								setAttributes({
-									autoPlayDelay : value === undefined || value === null || value === '' ? 2500 : parseInt(value, 10),
-								})
+									autoPlayDelay:
+										value === undefined ||
+										value === null ||
+										value === ''
+											? 2500
+											: parseInt(value, 10),
+								});
 							}}
 							type={'number'}
 						/>
@@ -354,7 +353,12 @@ export default function SliderEdit(props) {
 							value={speed}
 							onChange={(value) =>
 								setAttributes({
-									speed : value === undefined || value === null || value === '' ? 500 : parseInt(value, 10),
+									speed:
+										value === undefined ||
+										value === null ||
+										value === ''
+											? 500
+											: parseInt(value, 10),
 								})
 							}
 							type={'number'}

--- a/src/blocks/slider/edit.js
+++ b/src/blocks/slider/edit.js
@@ -23,6 +23,7 @@ import { isParentReusableBlock } from '@vkblocks/utils/is-parent-reusable-block'
 export default function SliderEdit(props) {
 	const { attributes, setAttributes, clientId } = props;
 	const {
+		unit,
 		pc,
 		tablet,
 		mobile,
@@ -223,9 +224,16 @@ export default function SliderEdit(props) {
 						<RangeControl
 							label={__('PC', 'vk-blocks')}
 							value={pc}
-							onChange={(value) =>
-								setAttributes({ pc: parseFloat(value) })
-							}
+							onChange={(value) => {
+								let newValue = value
+									? parseFloat(value)
+									: 0;
+								if ('px' === unit) {
+									newValue = parseInt(newValue);
+								}
+								setAttributes({ pc: newValue })
+							}}
+							step={'px' === unit ? 1 : 0.1}
 							min={0}
 							max={1000}
 							allowReset={true}
@@ -234,9 +242,16 @@ export default function SliderEdit(props) {
 						<RangeControl
 							label={__('Tablet', 'vk-blocks')}
 							value={tablet}
-							onChange={(value) =>
-								setAttributes({ tablet: parseFloat(value) })
-							}
+							onChange={(value) => {
+								let newValue = value
+									? parseFloat(value)
+									: 0;
+								if ('px' === unit) {
+									newValue = parseInt(newValue);
+								}
+								setAttributes({ tablet: newValue })
+							}}
+							step={'px' === unit ? 1 : 0.1}
 							min={0}
 							max={1000}
 							allowReset={true}
@@ -245,9 +260,16 @@ export default function SliderEdit(props) {
 						<RangeControl
 							label={__('Mobile', 'vk-blocks')}
 							value={mobile}
-							onChange={(value) =>
-								setAttributes({ mobile: parseFloat(value) })
-							}
+							onChange={(value) => {
+								let newValue = value
+									? parseFloat(value)
+									: 0;
+								if ('px' === unit) {
+									newValue = parseInt(newValue);
+								}
+								setAttributes({ mobile: newValue })
+							}}
+							step={'px' === unit ? 1 : 0.1}
 							min={0}
 							max={1000}
 							allowReset={true}
@@ -316,11 +338,11 @@ export default function SliderEdit(props) {
 					>
 						<TextControl
 							value={autoPlayDelay}
-							onChange={(value) =>
+							onChange={(value) => {
 								setAttributes({
-									autoPlayDelay: parseInt(value, 10),
+									autoPlayDelay : value === undefined || value === null || value === '' ? 2500 : parseInt(value, 10),
 								})
-							}
+							}}
 							type={'number'}
 						/>
 					</BaseControl>
@@ -332,7 +354,7 @@ export default function SliderEdit(props) {
 							value={speed}
 							onChange={(value) =>
 								setAttributes({
-									speed: parseInt(value, 10),
+									speed : value === undefined || value === null || value === '' ? 500 : parseInt(value, 10),
 								})
 							}
 							type={'number'}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 [スライダー][アイコン]数値を空白に設定すると次回の編集でブロックのリカバリーが出る #1314 

## どういう変更をしたか？

* スライダーの設定[表示時間][切り替え時間]が空白の場合は、デフォルト値を設定する用に修正
  * これにより、null が保存されるのを防ぐ
* ~~スライダーの高さで単位が  em rem vm の場合は小数点を入力できるように修正(修正箇所が近いため)~~ 


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？ ~~→ 修正箇所が近いため、ふたつの修正を行いました、過去の[アイコン]の修正と同様です~~ 
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* スライダーの設定[表示時間][切り替え時間]が空白の場合は、デフォルト値が設定される
  * デフォルト値は、表示時間は2500、切り替え時間は500
  * これにより、null が保存されることがなくなる
* ~~スライダーの高さで単位が  em rem vm の場合は小数点を入力できる~~ 
  * ~~ただし、ここではAdvancedUnitControl  を使っているため、途中で単位が変わった場合に小数点の制限はできない~~ 
  * ~~5.5 pxというように [小数点 + px] が保存されるのは レスポンシブスペーサーでも同様なので、今回はこのまま~~ 

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 実装者が確認した手順と同じ

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
