### PR TITLE
【2人目確認中】URLInput: Deprecate bottom margin

### DIFF
--- a/editor-css/_editor_common_core.scss
+++ b/editor-css/_editor_common_core.scss
@@ -34,3 +34,8 @@
 		border-radius: 2px;
 	}
 }
+
+.vk-block-editor-url-input-wrapper {
+	display: flex;
+	margin-bottom: 8px;
+}

--- a/src/blocks/_pro/gridcolcard-item/edit.js
+++ b/src/blocks/_pro/gridcolcard-item/edit.js
@@ -224,15 +224,15 @@ export default function Edit(props) {
 						}}
 						renderContent={(params) => {
 							return (
-								<div className="block-editor-url-input__button block-editor-link-control">
-									<form
-										className="block-editor-link-control__search-input-wrapper"
-										onSubmit={() => {
-											params.onClose();
-										}}
-									>
-										<div className="block-editor-link-control__search-input">
+								<form
+									onSubmit={() => {
+										params.onClose();
+									}}
+								>
+									<div className="vk-block-editor-url-input-wrapper">
+										<div className="block-editor-url-input">
 											<URLInput
+												__nextHasNoMarginBottom
 												value={url}
 												onChange={(value) => {
 													setAttributes({
@@ -240,28 +240,26 @@ export default function Edit(props) {
 													});
 												}}
 											/>
-											<CheckboxControl
-												label={__(
-													'Open link new tab.',
-													'vk-blocks'
-												)}
-												checked={urlOpenType}
-												onChange={(checked) =>
-													setAttributes({
-														urlOpenType: checked,
-													})
-												}
-											/>
-											<div className="block-editor-link-control__search-actions">
-												<Button
-													icon={keyboardReturn}
-													label={__('Submit')}
-													type="submit"
-												/>
-											</div>
 										</div>
-									</form>
-								</div>
+										<Button
+											icon={keyboardReturn}
+											label={__('Submit')}
+											type="submit"
+										/>
+									</div>
+									<CheckboxControl
+										label={__(
+											'Open link new tab.',
+											'vk-blocks'
+										)}
+										checked={urlOpenType}
+										onChange={(checked) =>
+											setAttributes({
+												urlOpenType: checked,
+											})
+										}
+									/>
+								</form>
 							);
 						}}
 					/>

--- a/src/blocks/_pro/select-post-list-item/edit.js
+++ b/src/blocks/_pro/select-post-list-item/edit.js
@@ -75,37 +75,34 @@ export default function SelectPostListItemEdit(props) {
 						}}
 						renderContent={(params) => {
 							return (
-								<div className="block-editor-url-input__button block-editor-link-control">
-									<form
-										className="block-editor-link-control__search-input-wrapper"
-										onSubmit={() => {
-											if (url.indexOf(homeUrl) === -1) {
-												setAttributes({ url: '' });
-											}
-											params.onClose();
-										}}
-									>
-										<div className="block-editor-link-control__search-input">
-											<URLInput
-												value={url}
-												onChange={(v, post) => {
-													setAttributes({ url: v });
-													if (post && post.title) {
-														// select post
-														params.onClose();
-													}
-												}}
-											/>
-											<div className="block-editor-link-control__search-actions">
-												<Button
-													icon={keyboardReturn}
-													label={__('Submit')}
-													type="submit"
-												/>
-											</div>
-										</div>
-									</form>
-								</div>
+								<form
+									className="block-editor-url-popover__link-editor"
+									onSubmit={() => {
+										if (url.indexOf(homeUrl) === -1) {
+											setAttributes({ url: '' });
+										}
+										params.onClose();
+									}}
+								>
+									<div className="block-editor-url-input">
+										<URLInput
+											__nextHasNoMarginBottom
+											value={url}
+											onChange={(v, post) => {
+												setAttributes({ url: v });
+												if (post && post.title) {
+													// select post
+													params.onClose();
+												}
+											}}
+										/>
+									</div>
+									<Button
+										icon={keyboardReturn}
+										label={__('Submit')}
+										type="submit"
+									/>
+								</form>
 							);
 						}}
 					/>

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -243,44 +243,40 @@ export default function ButtonEdit(props) {
 						}}
 						renderContent={(params) => {
 							return (
-								<div className="block-editor-url-input__button block-editor-link-control">
-									<form
-										className="block-editor-link-control__search-input-wrapper"
-										onSubmit={() => {
-											params.onClose();
-										}}
-									>
-										<div className="block-editor-link-control__search-input">
-											<URLInput
-												value={buttonUrl}
-												onChange={(value) => {
-													setAttributes({
-														buttonUrl: value,
-													});
-												}}
-											/>
-											<CheckboxControl
-												label={__(
-													'Open link new tab.',
-													'vk-blocks'
-												)}
-												checked={buttonTarget}
-												onChange={(checked) =>
-													setAttributes({
-														buttonTarget: checked,
-													})
-												}
-											/>
-											<div className="block-editor-link-control__search-actions">
-												<Button
-													icon={keyboardReturn}
-													label={__('Submit')}
-													type="submit"
-												/>
-											</div>
-										</div>
-									</form>
-								</div>
+								<form
+									onSubmit={() => {
+										params.onClose();
+									}}
+								>
+									<div className="vk-block-editor-url-input-wrapper">
+										<URLInput
+											__nextHasNoMarginBottom
+											value={buttonUrl}
+											onChange={(value) => {
+												setAttributes({
+													buttonUrl: value,
+												});
+											}}
+										/>
+										<Button
+											icon={keyboardReturn}
+											label={__('Submit')}
+											type="submit"
+										/>
+									</div>
+									<CheckboxControl
+										label={__(
+											'Open link new tab.',
+											'vk-blocks'
+										)}
+										checked={buttonTarget}
+										onChange={(checked) =>
+											setAttributes({
+												buttonTarget: checked,
+											})
+										}
+									/>
+								</form>
 							);
 						}}
 					/>


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1566

## どういう変更をしたか？

URLInputに__nextHasNoMarginBottomを追加し、スタイルを調整

ベースはコアのsocial-linkブロックをベースにしました
https://github.com/WordPress/gutenberg/blob/7cfbdfdff1b94ce9794ed738db55c0e38040456d/packages/block-library/src/social-link/edit.js#L37-L60

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
必要そうであれば言ってください
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

対象のブロック
gridcolcard-item
select-post-list-item
button

* WP6.2Betaでdevelopブランチで対象のブロックでURLInputを使ったときに#1566のwarningが出ていることを確認
* WP6.2Betaでこのブランチでwarningが解消されていることを確認
* WP6.1でこのブランチで対象のブロックでdevelopと同じようにURLInputが使えることを確認

WP 6.2 Beta
"core": "https://wordpress.org/wordpress-6.2-beta1.zip",

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
