### PR TITLE
【2人目確認中】CSS における長さ（高さ）の単位を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification Change ] Add multiple length units.
+
 = 1.51.0 =
 [ Improvement ][ Balloon ] Improvement to allow any number of registrations in admin.
 [ Bug fix ][ Step/timeline ] Fix title align center

--- a/src/admin/margin.js
+++ b/src/admin/margin.js
@@ -7,7 +7,7 @@ import {
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
-import unitOptions from '@vkblocks/utils/unit-options';
+import { hightUnitOptions } from '@vkblocks/utils/unit-options';
 
 /**
  * Internal dependencies
@@ -79,7 +79,7 @@ export default function AdminMargin() {
 								margin_unit: newValue,
 							});
 						}}
-						options={unitOptions}
+						options={hightUnitOptions}
 					/>
 				</div>
 				<ul className="no-style spacer-input">

--- a/src/admin/margin.js
+++ b/src/admin/margin.js
@@ -7,6 +7,7 @@ import {
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
+import unitOptions from '@vkblocks/utils/unit-options';
 
 /**
  * Internal dependencies
@@ -78,20 +79,7 @@ export default function AdminMargin() {
 								margin_unit: newValue,
 							});
 						}}
-						options={[
-							{
-								label: __('px', 'vk-blocks'),
-								value: 'px',
-							},
-							{
-								label: __('em', 'vk-blocks'),
-								value: 'em',
-							},
-							{
-								label: __('rem', 'vk-blocks'),
-								value: 'rem',
-							},
-						]}
+						options={unitOptions}
 					/>
 				</div>
 				<ul className="no-style spacer-input">

--- a/src/components/advanced-unit-control/index.js
+++ b/src/components/advanced-unit-control/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
-import unitOptions from '@vkblocks/utils/unit-options';
+import { hightUnitOptions } from '@vkblocks/utils/unit-options';
 
 const AdvancedUnitControl = (props) => {
 	const { attributes, setAttributes } = props;
@@ -13,7 +13,7 @@ const AdvancedUnitControl = (props) => {
 			label={__('Unit Type', 'vk-blocks')}
 			value={unit}
 			onChange={(value) => setAttributes({ unit: value })}
-			options={unitOptions}
+			options={hightUnitOptions}
 		/>
 	);
 };

--- a/src/components/advanced-unit-control/index.js
+++ b/src/components/advanced-unit-control/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
+import unitOptions from '@vkblocks/utils/unit-options';
 
 const AdvancedUnitControl = (props) => {
 	const { attributes, setAttributes } = props;
@@ -12,24 +13,7 @@ const AdvancedUnitControl = (props) => {
 			label={__('Unit Type', 'vk-blocks')}
 			value={unit}
 			onChange={(value) => setAttributes({ unit: value })}
-			options={[
-				{
-					value: 'px',
-					label: __('px', 'vk-blocks'),
-				},
-				{
-					value: 'em',
-					label: __('em', 'vk-blocks'),
-				},
-				{
-					value: 'rem',
-					label: __('rem', 'vk-blocks'),
-				},
-				{
-					value: 'vw',
-					label: __('vw', 'vk-blocks'),
-				},
-			]}
+			options={unitOptions}
 		/>
 	);
 };

--- a/src/utils/unit-options.js
+++ b/src/utils/unit-options.js
@@ -1,0 +1,86 @@
+import { __ } from '@wordpress/i18n';
+
+const unitOption = [
+	{
+		value: 'px',
+		label: __('px', 'vk-blocks'),
+	},
+	{
+		value: 'em',
+		label: __('em', 'vk-blocks'),
+	},
+	{
+		value: 'rem',
+		label: __('rem', 'vk-blocks'),
+	},
+	{
+		value: 'vw',
+		label: __('vw', 'vk-blocks'),
+	},
+	{
+		value: 'svw',
+		label: __('svw', 'vk-blocks'),
+	},
+	{
+		value: 'lvw',
+		label: __('lvw', 'vk-blocks'),
+	},
+	{
+		value: 'dvw',
+		label: __('dvw', 'vk-blocks'),
+	},
+	{
+		value: 'vh',
+		label: __('vh', 'vk-blocks'),
+	},
+	{
+		value: 'svh',
+		label: __('svh', 'vk-blocks'),
+	},
+	{
+		value: 'lvh',
+		label: __('lvh', 'vk-blocks'),
+	},
+	{
+		value: 'dvh',
+		label: __('dvh', 'vk-blocks'),
+	},
+	{
+		value: 'vmin',
+		label: __('vmin', 'vk-blocks'),
+	},
+	{
+		value: 'svmin',
+		label: __('svmin', 'vk-blocks'),
+	},
+	{
+		value: 'lvmin',
+		label: __('lvmin', 'vk-blocks'),
+	},
+	{
+		value: 'dvmin',
+		label: __('dvmin', 'vk-blocks'),
+	},
+
+	{
+		value: 'vmax',
+		label: __('vmax', 'vk-blocks'),
+	},
+
+	{
+		value: 'svmax',
+		label: __('svmax', 'vk-blocks'),
+	},
+
+	{
+		value: 'lvmax',
+		label: __('lvmax', 'vk-blocks'),
+	},
+
+	{
+		value: 'dvmax',
+		label: __('dvmax', 'vk-blocks'),
+	},
+];
+
+export default unitOption;

--- a/src/utils/unit-options.js
+++ b/src/utils/unit-options.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
-const unitOption = [
+export const hightUnitOptions = [
 	{
 		value: 'px',
 		label: __('px', 'vk-blocks'),
@@ -18,18 +18,6 @@ const unitOption = [
 		label: __('vw', 'vk-blocks'),
 	},
 	{
-		value: 'svw',
-		label: __('svw', 'vk-blocks'),
-	},
-	{
-		value: 'lvw',
-		label: __('lvw', 'vk-blocks'),
-	},
-	{
-		value: 'dvw',
-		label: __('dvw', 'vk-blocks'),
-	},
-	{
 		value: 'vh',
 		label: __('vh', 'vk-blocks'),
 	},
@@ -45,42 +33,4 @@ const unitOption = [
 		value: 'dvh',
 		label: __('dvh', 'vk-blocks'),
 	},
-	{
-		value: 'vmin',
-		label: __('vmin', 'vk-blocks'),
-	},
-	{
-		value: 'svmin',
-		label: __('svmin', 'vk-blocks'),
-	},
-	{
-		value: 'lvmin',
-		label: __('lvmin', 'vk-blocks'),
-	},
-	{
-		value: 'dvmin',
-		label: __('dvmin', 'vk-blocks'),
-	},
-
-	{
-		value: 'vmax',
-		label: __('vmax', 'vk-blocks'),
-	},
-
-	{
-		value: 'svmax',
-		label: __('svmax', 'vk-blocks'),
-	},
-
-	{
-		value: 'lvmax',
-		label: __('lvmax', 'vk-blocks'),
-	},
-
-	{
-		value: 'dvmax',
-		label: __('dvmax', 'vk-blocks'),
-	},
 ];
-
-export default unitOption;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-blocks-pro/issues/1573

## どういう変更をしたか？

- レスポンシブスペーサーのカスタムで使える長さ（高さ）の単位を追加 （ AdvancedUnitControl ）
- 共通余白も上記と同様
- カード（非推奨）の画像の高さにも影響
- スライダーの（画像の）高さにも影響（ AdvancedUnitControl ）


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
⇒一応書きました。
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
⇒編集画面における長さの単位の選択肢を追加しただけなので省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- レスポンシブスペーサーのカスタムで使える長さ（高さ）
- 共通余白
- カード（非推奨）の画像の高さ
- スライダーの（画像の）高さ

上記で使える単位が増えている＆同じものが使えるのを確認しました。

## 確認URL

ローカル環境にて

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュアーには CSS に詳しそうな人 or git を使えるパターンに関わっている人を選んでいます。

- レスポンシブスペーサーのカスタムで使える長さ（高さ）
- 共通余白
- カード（非推奨）の画像の高さ
- スライダーの（画像の）高さ

上記で使える単位が増えている＆同じものが使えるのを確認お願いします。

不要と思ったものは `src/utils/unit-options.js` の中身をコメントアウトで編集してください。

---

## 気になること

- Outer の「コンテナ内側のスペース設定」
- グリッドカラムの「カラム下部余白設定」
- グリッドカラムアイテムの「アイテム内の余白設定」
- （横並び）アイコンのサイズと余白

上記も統一したほうが良いような気がしました。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
