### PR TITLE
【二人目確認中】カスタムCSSを使用していないときに空のスタイルタグを出力しないように修正

### DIFF
--- a/src/extensions/common/custom-css-extension/index.js
+++ b/src/extensions/common/custom-css-extension/index.js
@@ -258,7 +258,12 @@ const withElementsStyles = createHigherOrderComponent(
 		}
 
 		// cssに.editor-styles-wrapperをwrapする
-		cssTag = transformStyles([{ css: cssTag }], '.editor-styles-wrapper');
+		if (cssTag !== '') {
+			cssTag = transformStyles(
+				[{ css: cssTag }],
+				'.editor-styles-wrapper'
+			);
+		}
 
 		return (
 			<>


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1593

## どういう変更をしたか？

#1584 の変更の際に空のcssにtransformStylesをすると空のcssでは無くなってしまうようでした。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [] readme.txt に変更内容は書いたか？
#1584 と同じなので省略しました。
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

・編集画面でカスタムCSSを使用していないときに空のスタイルタグを出力されていないことを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
