### PR TITLE
【確認待ち】共通余白設定等で生成される CSS が分割読み込みの有無に関わらず反映されるように

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-print-css-variables.php
+++ b/inc/vk-blocks/class-vk-blocks-print-css-variables.php
@@ -31,7 +31,11 @@ class Vk_Blocks_Print_CSS_Variables {
 	public static function print_css() {
 		if ( ! vk_blocks_is_lightning() ) {
 			$dynamic_css = self::get_print_css();
-			wp_add_inline_style( 'vk-blocks-build-css', $dynamic_css );
+			if ( ! VK_Blocks_Block_Loader::should_load_separate_assets() ) {
+				wp_add_inline_style( 'vk-blocks-build-css', $dynamic_css );
+			} else {
+				wp_add_inline_style( 'vk-blocks-utils-common-css', $dynamic_css );
+			}
 		}
 	}
 

--- a/inc/vk-blocks/style/balloon.php
+++ b/inc/vk-blocks/style/balloon.php
@@ -29,7 +29,7 @@ function vk_blocks_balloon_style() {
 	} else {
 		wp_add_inline_style( 'vk-blocks-utils-common-css', $dynamic_css );
 	}
-	
+
 	if ( is_admin() && class_exists( 'WP_Screen' ) && WP_Screen::get()->is_block_editor() ) {
 		wp_add_inline_style( 'vk-blocks-build-editor-css', $dynamic_css );
 	}

--- a/inc/vk-blocks/style/balloon.php
+++ b/inc/vk-blocks/style/balloon.php
@@ -24,7 +24,12 @@ function vk_blocks_balloon_style() {
 	}
 	';
 
-	wp_add_inline_style( 'vk-blocks-build-css', $dynamic_css );
+	if ( ! VK_Blocks_Block_Loader::should_load_separate_assets() ) {
+		wp_add_inline_style( 'vk-blocks-build-css', $dynamic_css );
+	} else {
+		wp_add_inline_style( 'vk-blocks-utils-common-css', $dynamic_css );
+	}
+	
 	if ( is_admin() && class_exists( 'WP_Screen' ) && WP_Screen::get()->is_block_editor() ) {
 		wp_add_inline_style( 'vk-blocks-build-editor-css', $dynamic_css );
 	}

--- a/inc/vk-blocks/vk-blocks-functions.php
+++ b/inc/vk-blocks/vk-blocks-functions.php
@@ -156,7 +156,11 @@ function vk_blocks_blocks_assets() {
 	}
 
 	$dynamic_css = vk_blocks_minify_css( $dynamic_css );
-	wp_add_inline_style( 'vk-blocks-build-css', $dynamic_css );
+	if ( ! VK_Blocks_Block_Loader::should_load_separate_assets() ) {
+		wp_add_inline_style( 'vk-blocks-build-css', $dynamic_css );
+	} else {
+		wp_add_inline_style( 'vk-blocks-utils-common-css', $dynamic_css );
+	}
 	// --vk_image-mask-waveはコアの画像ブロックに依存するのでwp-edit-blocksを追加
 	wp_add_inline_style( 'wp-edit-blocks', $dynamic_css );
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/1343

## どういう変更をしたか？

- 分割読み込み時には統合 CSS は読み込まれないのでそれに引っかかってる CSS も描画されない
⇒ 分割読み込み時に必ず読み込まれるであろう CSS を探してそれに引っ掛け直した。


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
⇒ CSS がひっかかるかひっかからないかの問題なので省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- 分割読み込みの ON / OFF を切り替えても引っ掛けるべき CSS が出力されているのを確認しました。

## 確認URL

ローカル観葉

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- 分割読み込みの ON / OFF を切り替えても引っ掛けるべき CSS が出力されているのを確認願います。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
