### PR TITLE
【2人目確認待ち】JustifyContentControl isAlternateは非推奨になったのでvariant: 'toolbar'に変更

### DIFF
--- a/src/blocks/_pro/button-outer/edit.js
+++ b/src/blocks/_pro/button-outer/edit.js
@@ -79,7 +79,7 @@ export default function ButtonOuterEdit(props) {
 					}
 					popoverProps={{
 						position: 'bottom right',
-						isAlternate: true,
+						variant: 'toolbar',
 					}}
 				/>
 			</BlockControls>

--- a/src/blocks/icon-outer/edit.js
+++ b/src/blocks/icon-outer/edit.js
@@ -80,7 +80,7 @@ export default function IconOuterEdit(props) {
 					onChange={(value) => setAttributes({ iconsJustify: value })}
 					popoverProps={{
 						position: 'bottom right',
-						isAlternate: true,
+						variant: 'toolbar',
 					}}
 				/>
 			</BlockControls>


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
JustifyContentControl isAlternateは非推奨になったのでvariant: 'toolbar'に変更

![console](https://user-images.githubusercontent.com/42362903/228742979-b6984caf-b7a1-4617-b40c-c99af8909574.png)
```
`isAlternate` prop in wp.components.Popover is deprecated since version 6.2. Please use `variant` prop with the `'toolbar'` value instead.
```

## どういう変更をしたか？
JustifyContentControl isAlternateは非推奨になったのでvariant: 'toolbar'に変更
コアのプルリク
https://github.com/WordPress/gutenberg/pull/45137

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
→必要そうであれば言ってください
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* WP6.2 developブランチで横並びボタンと横並びアイコンブロックのJustifyContentControlを使用したときにconsoleにwarningが出ていることを確認
* WP6.2 このブランチでwarningが解消されていることを確認
* WP6.1,WP6.2 developブランチと同様にブロックが使えるか確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
