### PR TITLE
[ 不具合修正 ][ レスポンシブスペーサー ] 余白のカスタム指定不具合修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,7 @@ e.g.
 == Changelog ==
 
 [ Specification Change ][ List ] cope with custom color palette (WordPress 6.2 or higher)
+[ Bug fix ][ Spacer ] Fix custom css variable
 
 = 1.54.0 =
 [ Add Setting ][ margin / spacer ] Add custom value to margin setting

--- a/src/blocks/spacer/index.php
+++ b/src/blocks/spacer/index.php
@@ -149,7 +149,7 @@ function vk_blocks_get_spacer_size_style_all( $options ) {
 		if ( vk_blocks_is_size_print( $options, 'mobile' ) ) {
 			$dynamic_css         .= '
 			@media (max-width: 575.98px) {
-				:root{';
+				:root,body{';
 					$dynamic_css .= ! empty( $options['margin_size']['xs']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'xs', 'mobile', $unit ) );
 					$dynamic_css .= ! empty( $options['margin_size']['sm']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'sm', 'mobile', $unit ) );
 					$dynamic_css .= ! empty( $options['margin_size']['md']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'md', 'mobile', $unit ) );
@@ -162,7 +162,7 @@ function vk_blocks_get_spacer_size_style_all( $options ) {
 		if ( vk_blocks_is_size_print( $options, 'tablet' ) ) {
 			$dynamic_css         .= '
 			@media (min-width: 576px) and (max-width: 991.98px) {
-				:root{';
+				:root,body{';
 					$dynamic_css .= ! empty( $options['margin_size']['xs']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'xs', 'tablet', $unit ) );
 					$dynamic_css .= ! empty( $options['margin_size']['sm']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'sm', 'tablet', $unit ) );
 					$dynamic_css .= ! empty( $options['margin_size']['md']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'md', 'tablet', $unit ) );
@@ -175,7 +175,7 @@ function vk_blocks_get_spacer_size_style_all( $options ) {
 		if ( vk_blocks_is_size_print( $options, 'pc' ) ) {
 			$dynamic_css         .= '
 			@media (min-width: 992px) {
-				:root{';
+				:root,body{';
 					$dynamic_css .= ! empty( $options['margin_size']['xs']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'xs', 'pc', $unit ) );
 					$dynamic_css .= ! empty( $options['margin_size']['sm']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'sm', 'pc', $unit ) );
 					$dynamic_css .= ! empty( $options['margin_size']['md']['custom'] ) ? '' : esc_attr( vk_blocks_get_spacer_size_style( $options, 'md', 'pc', $unit ) );
@@ -194,7 +194,7 @@ function vk_blocks_get_spacer_size_style_all( $options ) {
 		! empty( $options['margin_size']['xl']['custom'] )
 	) {
 		$dynamic_css     .= '
-		:root{';
+		:root,body{';
 			$dynamic_css .= ! empty( $options['margin_size']['xs']['custom'] ) ? esc_attr( vk_blocks_get_spacer_size_style( $options, 'xs', 'custom', $unit ) ) : '';
 			$dynamic_css .= ! empty( $options['margin_size']['sm']['custom'] ) ? esc_attr( vk_blocks_get_spacer_size_style( $options, 'sm', 'custom', $unit ) ) : '';
 			$dynamic_css .= ! empty( $options['margin_size']['md']['custom'] ) ? esc_attr( vk_blocks_get_spacer_size_style( $options, 'md', 'custom', $unit ) ) : '';

--- a/test/phpunit/free/test-spacer.php
+++ b/test/phpunit/free/test-spacer.php
@@ -269,7 +269,7 @@ class VKBSpacerTest extends WP_UnitTestCase {
 					),
 					'margin_unit' => 'rem'
 				),
-				'correct'     => '@media (max-width: 575.98px) {:root{--vk-margin-sm:1rem;--vk-margin-md:1rem;--vk-margin-lg:1rem;--vk-margin-xl:2rem;}}@media (min-width: 576px) and (max-width: 991.98px) {:root{--vk-margin-sm:2rem;--vk-margin-md:2rem;--vk-margin-lg:3rem;--vk-margin-xl:2rem;}}@media (min-width: 992px) {:root{--vk-margin-sm:3rem;--vk-margin-md:2rem;--vk-margin-lg:3rem;--vk-margin-xl:3rem;}}',
+				'correct'     => '@media (max-width: 575.98px) {:root,body{--vk-margin-sm:1rem;--vk-margin-md:1rem;--vk-margin-lg:1rem;--vk-margin-xl:2rem;}}@media (min-width: 576px) and (max-width: 991.98px) {:root,body{--vk-margin-sm:2rem;--vk-margin-md:2rem;--vk-margin-lg:3rem;--vk-margin-xl:2rem;}}@media (min-width: 992px) {:root,body{--vk-margin-sm:3rem;--vk-margin-md:2rem;--vk-margin-lg:3rem;--vk-margin-xl:3rem;}}',
 			),
 			array(
 				'options'     => array(
@@ -307,7 +307,7 @@ class VKBSpacerTest extends WP_UnitTestCase {
 					),
 					'margin_unit' => 'rem'
 				),
-				'correct'     => ':root{--vk-margin-xs:var( --aaa-xs );--vk-margin-sm:var( --aaa-sm );--vk-margin-md:var( --aaa-md );--vk-margin-lg:var( --aaa-lg );--vk-margin-xl:var( --aaa-xl );}',
+				'correct'     => ':root,body{--vk-margin-xs:var( --aaa-xs );--vk-margin-sm:var( --aaa-sm );--vk-margin-md:var( --aaa-md );--vk-margin-lg:var( --aaa-lg );--vk-margin-xl:var( --aaa-xl );}',
 			),
 		);
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

ブロックテーマのCSS変数が :root ではなく body に対して出力されるので、
body 対して出力しないと変数の上書きができないため修正

## どういう変更をしたか？

body にもCSSを出力するようにセレクタを変更

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* X-T9 環境で 段落と段落の間にレスポンシブスペーサーを配置し、スペーサーのサイズを M に指定
* 設定 > VK Blocks 設定 で 共通余白設定のカスタムの M に `var(--wp--custom--spacing--medium)` を入力
* スペーサーの高さが効かなくなって文字がひっつく
* このブランチに切り替えてビルドして再確認
* 高さが効く事を確認
