### PR TITLE
カスタム書式設定のツールバー UI修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,7 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Custom Format Setting (Pro) ] Custom Format Setting WordPress 6.2 UI adjustment.
 [ Add Function ][ Admin screen ] Added block style manager function.
 [ Bug fix ][ Step(Pro) / Time Line(Pro) ] Fix item content overflow
 

--- a/src/extensions/common/custom-format/index.js
+++ b/src/extensions/common/custom-format/index.js
@@ -32,8 +32,15 @@ if (window.vk_blocks_params) {
 				return (
 					<>
 						<RichTextToolbarButton
-							icon={<Icon icon={IconSVG} />}
-							title={<span className={className}>{title}</span>}
+							title={
+								<>
+									<Icon
+										icon={IconSVG}
+										style={{ marginRight: '8px' }}
+									/>
+									<span className={className}>{title}</span>
+								</>
+							}
 							onClick={() => {
 								props.onChange(
 									toggleFormat(value, { type: name })


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1653

## どういう変更をしたか？

WordPress6.2からtitleにJSXが入った場合ツールバーのボタンにhas-textクラスが付かなくなった
https://github.com/WordPress/gutenberg/pull/44198
単純なテキストであればhas-textクラスが付く

RichTextToolbarButtonのicon propsにアイコンを設定するとhas-iconクラスが付きjustify-content: center;が効くため中央寄せになってしまう。

そのためtitleにアイコンを含めUIをコアに寄せることで対応しました。

以下のプルリクで今後も議論が起きそうなのでコアのアップデートごとに注意が必要です
https://github.com/WordPress/gutenberg/pull/44198

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。
レビュー確認方法と同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

カスタム書式設定のツールバーが中央寄せになっていることを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
