### PR TITLE
［cssの微修正］編集画面でテキスト1カラムが崩れるのを修正

### DIFF
--- a/editor-css/_editor_before_select-post.scss
+++ b/editor-css/_editor_before_select-post.scss
@@ -10,6 +10,14 @@
 		clear: both;
 		.wp-block-vk-blocks-select-post-list-item {
 			margin-top:0; // コアが html :where(.wp-block) { に対して 28px 追加するので打ち消し
+			.alert{ // はみ出し防止
+				box-sizing: border-box;
+			}
+		}
+	}
+	&.vk_posts-layout-postListText { // テキスト1カラムの場合
+		.block-editor-block-list__layout {
+			display: block;
 		}
 	}
 	.wp-block {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-blocks-pro/issues/1669

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

編集画面用のCSSに、テキスト1カラムにした時にフロント画面と同じような見た目になるよう調整しました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

CSSのみの微修正のためreadmeには書いておりません。必要そうであれば書きます！

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

*選択投稿リストブロックをテキスト1カラムで配置して、編集画面で崩れていないことを確認しました。


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

選択投稿リストブロックをテキスト1カラムで配置して、編集画面で崩れていないことを確認してください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
