### PR TITLE
[ パンくずリスト ] 編集画面で意図しない余白が発生してしまうため打ち消し追加

### DIFF
--- a/editor-css/_editor_before_breadcrumb.scss
+++ b/editor-css/_editor_before_breadcrumb.scss
@@ -2,10 +2,23 @@
 /* vk_breadcrumb
 /*-------------------------------------------*/
 .editor-styles-wrapper {
+	.is-layout-constrained > .wp-block-vk-blocks-breadcrumb {
+		margin-block-start: 0;
+	}
 	.wp-block-vk-blocks-breadcrumb {
 		font-size: 12px;
+		margin-block-start: 0;
 		.vk_breadcrumb {
 			font-size: inherit;
+		}
+	}
+	.vk_breadcrumb {
+		.vk_breadcrumb_list {
+			margin-block-start: 0;
+			padding:0;
+		}
+		.vk_breadcrumb_list_item {
+			margin:0;
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,7 @@ e.g.
 [ Add Function ][ Animation(Pro) ] Added transforms settings to wrap and unwrap.
 [ Add Alert ][ Slider ] Add loop alert
 [ Bug fix ][ Child page list ]"There are no page." is not displayed on the front page.
+[ Bug fix ][ Breadcrumb ] Delete non intentional margin on editor screen
 
 = 1.56.0 =
 [ Add Block ][ Dynamic Text Block (Pro) ] Add Dynamic text block.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

編集画面内で ol や ul タグに意図しない余白があたってしまう

## どういう変更をしたか？

CSSで打ち消し
