### PR TITLE
【2人目確認待ち】develop で動的ブロックに余白指定のUIが出なくなる不具合を修正

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -56,7 +56,9 @@ jobs:
     # ローカルで以下のコマンドで test/e2e/ 内のテストをすべて実行する
     # npx playwright test --trace on --project=chromium
     - name: Run Playwright
-      run: npx playwright test --trace on --project=chromium test/e2e/login.spec.ts
+      run: |
+        npx playwright test --trace on --project=chromium test/e2e/login.spec.ts
+        npx playwright test --trace on --project=chromium test/e2e/common-margin.spec.ts
     - uses: actions/upload-artifact@v3
       if: always()
       with:

--- a/languages/vk-blocks-pro.pot
+++ b/languages/vk-blocks-pro.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-05-30T05:58:39+00:00\n"
+"POT-Creation-Date: 2023-05-31T07:28:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: vk-blocks-pro\n"
@@ -3111,8 +3111,8 @@ msgstr ""
 
 #. translators:
 #: dist/vk-blocks-pro/inc/vk-blocks/build/blocks/_pro/taxonomy/index.php:187
-#: inc/vk-blocks/build/blocks/_pro/taxonomy/index.php:187
-#: src/blocks/_pro/taxonomy/index.php:187
+#: inc/vk-blocks/build/blocks/_pro/taxonomy/index.php:186
+#: src/blocks/_pro/taxonomy/index.php:186
 msgid "All of %s"
 msgstr ""
 

--- a/src/extensions/common/custom-css-extension/index.js
+++ b/src/extensions/common/custom-css-extension/index.js
@@ -33,7 +33,7 @@ export const hasCustomCssSupport = (blockName) => {
 		return false;
 	}
 
-	const allowed = ['core', 'vk-blocks-pro'];
+	const allowed = ['core', 'vk-blocks'];
 	let returnBool =
 		allowed.find((item) => inString(blockName, item)) !== undefined;
 

--- a/src/extensions/common/hidden-extension/index.js
+++ b/src/extensions/common/hidden-extension/index.js
@@ -30,7 +30,7 @@ export const in_string = (str, keyword) => {
 // eslint-disable-next-line camelcase
 export const is_hidden = (blockName) => {
 	// Target of hidden function active
-	const allowed = ['core', 'vk-blocks-pro'];
+	const allowed = ['core', 'vk-blocks'];
 	// name には allowed の項目が一つずつ入る
 	// 判断中のブロック名の中にname( core or vk-blocks )がある（ undefinedじゃない ）場合
 	// true を返す

--- a/src/utils/is-excludes-blocks.js
+++ b/src/utils/is-excludes-blocks.js
@@ -12,7 +12,7 @@ export const inString = (str, keyword) => {
 // The checking block is hidden function target or not
 export const isExcludesBlocks = ({ blockName, addExclude }) => {
 	// Target of hidden function active
-	const allowed = ['core', 'vk-blocks-pro'];
+	const allowed = ['core', 'vk-blocks'];
 	// name には allowed の項目が一つずつ入る
 	// 判断中のブロック名の中にname( core or vk-blocks )がある（ undefinedじゃない ）場合
 	// true を返す

--- a/test/e2e/common-margin.spec.ts
+++ b/test/e2e/common-margin.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test('Common margin', async ({ page }) => {
+	await page.goto('http://localhost:8889/wp-login.php');
+	await page.getByLabel('Username or Email Address').click();
+	await page.getByLabel('Username or Email Address').fill('admin');
+	await page.getByLabel('Username or Email Address').press('Tab');
+	await page.getByLabel('Password', { exact: true }).fill('password');
+	await page.getByRole('button', { name: 'Log In' }).click();
+	await page.goto('http://localhost:8889/wp-admin/post-new.php');
+	await page.getByRole('button', { name: 'Toggle block inserter' }).click();
+	await page.getByPlaceholder('Search').fill('breadcrumb');
+	await page.getByRole('option', { name: 'Breadcrumb', exact: true }).click();
+	await page.getByRole('button', { name: 'Margin the block' }).click();
+	await page.getByRole('menuitem', { name: 'Top XL' }).click();
+
+	// パンくず要素を取得
+	const element = await page.$('div.wp-block-vk-blocks-breadcrumb');
+	if (element !== null) {
+		const classAttribute = await element.getAttribute('class');
+		if (classAttribute !== null) {
+			// パンくず要素に vk_block-margin-xl--margin-top クラスが付与されているか確認
+			const hasClass = classAttribute.includes('vk_block-margin-xl--margin-top');
+			expect(hasClass).toBeTruthy();
+		} else {
+			throw new Error('classAttribute is null');
+		}
+	} else {
+		throw new Error('Element not found');
+	}
+});

--- a/test/e2e/common-margin.spec.ts
+++ b/test/e2e/common-margin.spec.ts
@@ -8,6 +8,15 @@ test('Common margin', async ({ page }) => {
 	await page.getByLabel('Password', { exact: true }).fill('password');
 	await page.getByRole('button', { name: 'Log In' }).click();
 	await page.goto('http://localhost:8889/wp-admin/post-new.php');
+
+	// Check if the modal is visible
+	const isModalVisible = await page.isVisible('.components-modal__frame');
+
+	// If the modal is visible, click the close button
+	if (isModalVisible) {
+		await page.click('button[aria-label="Close"]');
+	}
+
 	await page.getByRole('button', { name: 'Toggle block inserter' }).click();
 	await page.getByPlaceholder('Search').fill('breadcrumb');
 	await page.getByRole('option', { name: 'Breadcrumb', exact: true }).click();


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/1692

## どういう変更をしたか？

https://github.com/vektor-inc/vk-blocks-pro/pull/1690#pullrequestreview-1452357341 

↑ のプルリクで テキストドメインを vk-blocks から vk-blocks-pro  に変更したが、テキストドメインじゃない部分まで vk-blocks-pro に変更されてしまっていて今回の不具合を引き起こしていた。

該当部分を置換して修正


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
→ 前回の master のあとで発生している不具合に対する修正なので不要
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* パンくずリストブロックを配置
* 共通余白設定が表示される事を確認

`npx playwright test --project=chromium --trace on`

## 確認URL

ローカルで...

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* パンくずリストブロックを配置
* 共通余白設定が表示される事を確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
