### PR TITLE
[ 見出しのカスタムスタイル ] 背景色が黒の場合に見えなくなる不具合を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,8 @@ e.g.
 
 == Changelog ==
 
+[ Other ][ Heading style ] Cope with dark background color 
+
 = 1.57.0.5 =
 [ Bug Fix ][ Free Version ] Fix display non intentional Licencekey alert message and update become don't work. ( Please delete once VK Blocks 1.57.0.1 and reinstall 1.57.0.4 or higher )
 

--- a/src/extensions/core/heading/style.scss
+++ b/src/extensions/core/heading/style.scss
@@ -363,7 +363,7 @@ $color_key: #337ab7;
 			&::after {
 				content: "";
 				flex-grow: 1;
-				border-bottom: 1px solid #333;
+				border-bottom: 1px solid currentColor;
 				position: unset;
 				width: unset;
 				border-left: unset;
@@ -463,19 +463,18 @@ $color_key: #337ab7;
 			&::before,
 			&::after {
 				@include title_brackets_before_after;
-
-				border-top: solid 1px #333;
-				border-bottom: solid 1px #333;
+				border-top: solid 1px currentColor;
+				border-bottom: solid 1px currentColor;
 				background: unset;
 			}
 
 			&::before {
-				border-left: solid 1px #333;
+				border-left: solid 1px currentColor;
 				left: 0;
 			}
 
 			&::after {
-				border-right: solid 1px #333 !important;
+				border-right: solid 1px currentColor !important;
 				right: 0;
 				left: auto;
 			}

--- a/src/extensions/core/heading/style.scss
+++ b/src/extensions/core/heading/style.scss
@@ -147,7 +147,7 @@ $color_key: #337ab7;
 			@include title_unset;
 
 			border: none;
-			background-color: #efefef;
+			background-color: var(--wp--preset--color--bg-secondary,#efefef );
 			padding: 0.6em 0.7em 0.5em;
 			margin-bottom: 1.2em;
 			border-radius: 4px;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

現状 左右線 など、ラインが黒色指定なので、黒背景だと見えなくなる

![スクリーンショット 2023-06-04 1 53 35](https://github.com/vektor-inc/vk-blocks-pro/assets/3272660/d8460c23-9b82-41fa-b75e-6e1c7ac7bc06)

## どういう変更をしたか？

* 左右線や括弧には文字色が適用されるように変更
* 灰色背景には背景セカンダリ色がテーマで指定されている場合はその色を適用

![スクリーンショット 2023-06-04 1 32 35](https://github.com/vektor-inc/vk-blocks-pro/assets/3272660/3b161795-7624-4b97-a1c1-2b7e5aae96fd)

※ その他の上下線黒 などはもしかしたら線だけ黒で文字色の色を他の色で運用されていたりするかもしれず、変更する事が一概に良いとは言えないので現状まま

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* X-T9 のグローバルスタイルで黒背景に指定
* 見出しを配置して上記３つのスタイルが反映される事を確認

## 確認URL

ローカルで...

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* X-T9 のグローバルスタイルで黒背景に指定
* 見出しを配置して上記３つのスタイルが反映される事を確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
