### PR TITLE
【2人目確認待ち】VK Component をアップデート（ inc/VK_Helpers 廃止に向けた調整版 ）

### DIFF
--- a/inc/vk-components/package/class-vk-component-button.php
+++ b/inc/vk-components/package/class-vk-component-button.php
@@ -100,6 +100,54 @@ if ( ! class_exists( 'VK_Components_Button' ) ) {
 		}
 
 		/**
+		 * Color_mode_check
+		 * VK_Helpers::color_mode_check( $input ); と同じだが、
+		 * Composer版以外の VK_Helpers を削除していきたいので内包
+		 *
+		 * @param string $input input color code.
+		 */
+		public static function color_mode_check( $input = '#ffffff' ) {
+			$color['input'] = $input;
+			// delete #.
+			$color['input'] = preg_replace( '/#/', '', $color['input'] );
+
+			$color_len = strlen( $color['input'] );
+
+			// Only 3 character.
+			if ( 3 === $color_len ) {
+				$color_red   = substr( $color['input'], 0, 1 ) . substr( $color['input'], 0, 1 );
+				$color_green = substr( $color['input'], 1, 1 ) . substr( $color['input'], 1, 1 );
+				$color_blue  = substr( $color['input'], 2, 1 ) . substr( $color['input'], 2, 1 );
+			} elseif ( 6 === $color_len ) {
+				$color_red   = substr( $color['input'], 0, 2 );
+				$color_green = substr( $color['input'], 2, 2 );
+				$color_blue  = substr( $color['input'], 4, 2 );
+			} else {
+				$color_red   = 'ff';
+				$color_green = 'ff';
+				$color_blue  = 'ff';
+			}
+
+			// change 16 to 10 number.
+			$color['color_red']   = hexdec( $color_red );
+			$color['color_green'] = hexdec( $color_green );
+			$color['color_blue']  = hexdec( $color_blue );
+
+			$color['number_sum'] = $color['color_red'] + $color['color_green'] + $color['color_blue'];
+
+			$color['brightness'] = 0.00130718954 * $color['number_sum'];
+
+			if ( $color['brightness'] < 0.5 ) {
+				$color['mode'] = 'dark';
+			} else {
+				$color['mode'] = 'bright';
+			}
+
+			return $color;
+
+		}
+
+		/**
 		 * ボタンの文字色のスタイルを出力する
 		 *
 		 * @param  [type] $options [description]
@@ -115,7 +163,7 @@ if ( ! class_exists( 'VK_Components_Button' ) ) {
 				// ボタンの初期状態の文字色が白なので指定する必要がない
 				$style_text = 'color:#fff;';
 
-				$color = VK_Helpers::color_mode_check( $options['btn_color_bg'] );
+				$color = self::color_mode_check( $options['btn_color_bg'] );
 				if ( $color['brightness'] > 0.8 ) {
 					$style_text = 'color:#000;';
 				}
@@ -145,7 +193,7 @@ if ( ! class_exists( 'VK_Components_Button' ) ) {
 
 			// ゴーストだろうが塗りだろうが、ホバー時は背景塗りにするのでゴーストかどうかの条件分岐は関係ない
 
-			$color = VK_Helpers::color_mode_check( $options['btn_color_bg'] );
+			$color = self::color_mode_check( $options['btn_color_bg'] );
 			if ( $color['brightness'] > 0.8 ) {
 				$style_text_hover = 'color:#000;';
 			} else {
@@ -193,7 +241,7 @@ if ( ! class_exists( 'VK_Components_Button' ) ) {
 
 			} elseif ( ! $options['btn_ghost'] ) {
 
-				$style_bg_hover = 'background-color:' . VK_Helpers::color_auto_modifi( $options['btn_color_bg'], 1.2 ) . ';';
+				$style_bg_hover = 'filter: brightness(1.2) saturate(2);';
 			}
 			return $style_bg_hover;
 		}
@@ -222,14 +270,10 @@ if ( ! class_exists( 'VK_Components_Button' ) ) {
 		 * @return [type]          [description]
 		 */
 		public static function get_style_border_hover( $options ) {
-			$options            = self::get_options( $options );
-			$style_border_hover = '';
-
-			if ( $options['btn_ghost'] ) {
-				$style_border_hover = 'border-color:' . $options['btn_color_bg'] . ';';
-			} else {
-				$style_border_hover = 'border-color:' . VK_Helpers::color_auto_modifi( $options['btn_color_bg'], 1.2 ) . ';';
-			}
+			$options = self::get_options( $options );
+			// 通常の塗りボタンもゴーストボタンも共通
+			// （ hover 時は css filter で色を明るくするようになったので、ホバー時の枠線の色も通常のボタン背景色と同じ指定でよい ）
+			$style_border_hover = 'border-color:' . $options['btn_color_bg'] . ';';
 			return $style_border_hover;
 		}
 

--- a/inc/vk-components/package/class-vk-component-posts.php
+++ b/inc/vk-components/package/class-vk-component-posts.php
@@ -3,7 +3,7 @@
  * VK Components Posts
  *
  * @package VK Component
- * @version 1.3.1
+ * @version 1.5.0
  *
  * *********************** CAUTION ***********************
  * The original of this file is located at:
@@ -52,9 +52,10 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 				'display_btn'                => false,
 				'image_default_url'          => false,
 				'overlay'                    => false,
-				'btn_text'                   => __( 'Read more', 'vk-blocks-pro' ),
+				'title_tag'                  => 'h5',
+				'btn_text'                   => __( 'Read more', 'vk-blocks' ),
 				'btn_align'                  => 'text-right',
-				'new_text'                   => __( 'New!!', 'vk-blocks-pro' ),
+				'new_text'                   => __( 'New!!', 'vk-blocks' ),
 				'new_date'                   => 7,
 				'textlink'                   => true,
 				'class_outer'                => '',
@@ -265,7 +266,7 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 		public static function get_archive_link_btn( $wp_query, $args = array() ) {
 
 			$default = array(
-				'btn_text'        => __( 'More', 'vk-blocks-pro' ),
+				'btn_text'        => __( 'More', 'vk-blocks' ),
 				'btn_position'    => 'right',
 				'btn_style'       => 'normal', // text / normal
 				'btn_icon_before' => '<i class="far fa-arrow-alt-circle-right"></i>',
@@ -301,10 +302,10 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 					'mid_size'           => 1, // get_loop では loop_options のデフォルト値で上書きされる.
 					'prev_text'          => '&laquo;',
 					'next_text'          => '&raquo;',
-					'screen_reader_text' => __( 'Posts navigation', 'vk-blocks-pro' ),
-					'aria_label'         => __( 'Posts', 'vk-blocks-pro' ),
+					'screen_reader_text' => __( 'Posts navigation', 'vk-blocks' ),
+					'aria_label'         => __( 'Posts', 'vk-blocks' ),
 					'class'              => 'pagination',
-					'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'vk-blocks-pro' ) . ' </span>',
+					'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'vk-blocks' ) . ' </span>',
 					'type'               => 'list',
 				)
 			);
@@ -632,7 +633,7 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 				$html .= $options['body_prepend'];
 			}
 
-			$html .= '<h5 class="vk_post_title ' . $layout_type . '-title">';
+			$html .= '<' . $options['title_tag'] . ' class="vk_post_title ' . $layout_type . '-title">';
 
 			/*
 			カードインテキストの場合、リンクの中にリンクがあるとブラウザでDOMが書き換えられるので
@@ -661,7 +662,7 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 				$html .= '</a>';
 			}
 
-			$html .= '</h5>';
+			$html .= '</' . $options['title_tag'] . '>';
 
 			if ( $options['display_date'] ) {
 				$html .= '<div class="vk_post_date ' . $layout_type . '-date published">';
@@ -765,27 +766,27 @@ if ( ! class_exists( 'VK_Component_Posts' ) ) {
 		public static function get_patterns() {
 			$patterns = array(
 				'card'            => array(
-					'label'             => __( 'Card', 'vk-blocks-pro' ),
+					'label'             => __( 'Card', 'vk-blocks' ),
 					'class_posts_outer' => '',
 				),
 				'card-noborder'   => array(
-					'label'             => __( 'Card Noborder', 'vk-blocks-pro' ),
+					'label'             => __( 'Card Noborder', 'vk-blocks' ),
 					'class_posts_outer' => '',
 				),
 				'card-intext'     => array(
-					'label'             => __( 'Card Intext', 'vk-blocks-pro' ),
+					'label'             => __( 'Card Intext', 'vk-blocks' ),
 					'class_posts_outer' => '',
 				),
 				'card-horizontal' => array(
-					'label'             => __( 'Card Horizontal', 'vk-blocks-pro' ),
+					'label'             => __( 'Card Horizontal', 'vk-blocks' ),
 					'class_posts_outer' => '',
 				),
 				'media'           => array(
-					'label'             => __( 'Media', 'vk-blocks-pro' ),
+					'label'             => __( 'Media', 'vk-blocks' ),
 					'class_posts_outer' => 'media-outer',
 				),
 				'postListText'    => array(
-					'label'             => _x( 'Text 1 Column', 'post list type', 'vk-blocks-pro' ),
+					'label'             => _x( 'Text 1 Column', 'post list type', 'vk-blocks' ),
 					'class_posts_outer' => 'postListText-outer',
 				),
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,7 @@ e.g.
 [ Other ][ Heading style ] Cope with dark background color
 [ Other ] Update VK Admin 0.4.0 ( Cope with English information )
 [ Add Function ][ Admin screen ] Added import export tool.
+[ Specification Change ] Update VK Component 1.5.0 ( Remove dependency on VK_Helpers )
 
 = 1.57.1 =
 [ Bug fix ] Update option value Modify API authority


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

* inc/vk-helpers が PHP8.2 でエラーを引き起こす 問題がある  
※ とは言え VK Blocks では使っていないメソッドなので VK Blocks Pro 単体では発生しない
* inc/vk-helpers を使用しているのは VK Component Posts のみ
* VK Component Post でも inc/vk-helpers はごく一部の古い処理でしか使っていないので、  
その処理だけ VK Component 内に複製したバージョンにアップデート

→ inc/vk-helpers を事実上不要状態に（使う場合は Composer 版の vendor/vektor-inc/VK_Helpers/VkHelpers を使う）

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
→ 内部リファクタリングなので省略
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ VK Blocks の挙動に変更はなく、既存のテストがコケなければ問題ないので省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* VK Blocks Pro だけの状態の環境で投稿リストブロックを配置
* エラーが発生しない事を確認
* 表示タイプ（カード/カード（線なし）など）が翻訳があたっている事を確認  

## 確認URL

ローカルでよろしくお願いいたします。

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

VK Blocks Pro だけの状態の環境で投稿リストブロックを配置
エラーが発生しない事を確認
表示タイプ（カード/カード（線なし）など）が翻訳があたっている事を確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
