### PR TITLE
[ ダイナミックテキスト ] 先祖階層の固定ページ名が検索結果ページで取得できずに発生する warning対応

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,7 @@ e.g.
 == Changelog ==
 
 [ Bug fix ][ Dynamic Text (Pro) ] Fix php warning that brought by can't get post type name on search result page.
+[ Bug fix ][ Dynamic Text (Pro) ] Fix php warning that brought by can't get ancestor page on search result page.
 
 = 1.59.0 =
 [ Add Filter Hook ( Pro ) ] Add filter fook of display license key form or not

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -59,11 +59,6 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 		'customFieldName'          => ( isset( $attributes['customFieldName'] ) ) ? wp_kses_post( $attributes['customFieldName'] ) : null,
 	);
 
-	$post = get_post();
-	if ( 'ancestor-page' === $options['displayElement'] && ! ( $post->post_parent ) && $options['ancestorPageHiddenOption'] ) {
-		return;
-	}
-
 	$classes = 'vk_dynamicText';
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes = ' has-text-align-' . $attributes['textAlign'];
@@ -86,6 +81,11 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 		}
 		$block_content .= $post_type_name;
 	} elseif ( 'ancestor-page' === $options['displayElement'] ) {
+		$post = get_post();
+		// 親ページがない（＝先祖階層） && 先祖階層のページを非表示にするオプションが有効の場合は処理を終了
+		if ( empty ( $post->post_parent ) && $options['ancestorPageHiddenOption'] ) {
+			return;
+		}
 		// 先祖階層のページタイトルを取得
 		$ancestor_post_title = '';
 		if ( ! empty( $post ) && ! empty( $post->ancestors ) ) {

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -71,10 +71,10 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 		$block_content .= '<' . $options['tagName'] . ' ' . $wrapper_classes . '>';
 	};
 	if ( 'post-type' === $options['displayElement'] ) {
-		// 投稿タイプの名前取得
+		// 投稿タイプの名前取得.
 		$post_type_info = VkHelpers::get_post_type_info();
 		$post_type_name = '';
-		// * 検索結果ページなどで投稿タイプ情報が取得できない場合があるので空の場合は空文字を返す
+		// * 検索結果ページなどで投稿タイプ情報が取得できない場合があるので空の場合は空文字を返す.
 		// Cope with php warning that brought by can't get post type name on such as the search result page.
 		if ( ! empty( $post_type_info['name'] ) ) {
 			$post_type_name = $post_type_info['name'];
@@ -82,11 +82,11 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 		$block_content .= $post_type_name;
 	} elseif ( 'ancestor-page' === $options['displayElement'] ) {
 		$post = get_post();
-		// 親ページがない（＝先祖階層） && 先祖階層のページを非表示にするオプションが有効の場合は処理を終了
-		if ( empty ( $post->post_parent ) && $options['ancestorPageHiddenOption'] ) {
+		// 親ページがない（＝先祖階層） && 先祖階層のページを非表示にするオプションが有効の場合は処理を終了.
+		if ( empty( $post->post_parent ) && $options['ancestorPageHiddenOption'] ) {
 			return;
 		}
-		// 先祖階層のページタイトルを取得
+		// 先祖階層のページタイトルを取得.
 		$ancestor_post_title = '';
 		if ( ! empty( $post ) && ! empty( $post->ancestors ) ) {
 			foreach ( $post->ancestors as $post_id ) {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/1748

## どういう変更をしたか？

先祖階層を表示するモードの場合のみ該当処理が走るように修正

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ 出力結果自体に変更はないので既存テストからの追加はなし

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* 検索結果ページのテンプレートの投稿ループ外にダイナミックテキストを配置
* 該当ページがないキーワードで検索
* warningがでない事を確認

## 確認URL

ローカルでよろしくお願いいたします...

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

実装者に同じ

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
