### PR TITLE
【2人め確認中】Remove unwrap from transforms and add ungroup to animation blocks 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification Change ][ Animation(Pro) ] Fix WordPress 6.3 transforms settings.
+
 = 1.60.0 =
 [ Add Function ] Add Font Awesome icon custom list function.
 [ Add Function ][ Dynamic Text Block (Pro) ] URL support for custom fields.

--- a/src/blocks/_pro/animation/transforms.js
+++ b/src/blocks/_pro/animation/transforms.js
@@ -9,7 +9,16 @@ import { createBlock } from '@wordpress/blocks';
 import compareVersions from 'compare-versions';
 
 // WP6.3以上か NOTE: WP6.2以下をサポートしなくなったら削除すること
-const isLargerThanWp63 = compareVersions(window.wpVersion, '6.3') >= 0;
+const isLargerThanWp63 = () => {
+	if (
+		window.wpVersion !== undefined &&
+		window.wpVersion !== null &&
+		compareVersions(window.wpVersion, '6.3') < 0
+	) {
+		return false;
+	}
+	return true;
+};
 
 const transforms = {
 	from: [
@@ -35,10 +44,10 @@ const transforms = {
 			},
 		},
 	],
-	ungroup: isLargerThanWp63
+	ungroup: isLargerThanWp63()
 		? (attributes, innerBlocks) => innerBlocks
 		: undefined,
-	to: !isLargerThanWp63
+	to: !isLargerThanWp63()
 		? [
 				{
 					type: 'block',

--- a/src/blocks/_pro/animation/transforms.js
+++ b/src/blocks/_pro/animation/transforms.js
@@ -3,6 +3,14 @@
  */
 import { createBlock } from '@wordpress/blocks';
 
+/**
+ * External dependencies
+ */
+import compareVersions from 'compare-versions';
+
+// WP6.3以上か NOTE: WP6.2以下をサポートしなくなったら削除すること
+const isLargerThanWp63 = compareVersions(window.wpVersion, '6.3') >= 0;
+
 const transforms = {
 	from: [
 		{
@@ -27,13 +35,18 @@ const transforms = {
 			},
 		},
 	],
-	to: [
-		{
-			type: 'block',
-			blocks: ['*'],
-			transform: (attributes, innerBlocks) => innerBlocks,
-		},
-	],
+	ungroup: isLargerThanWp63
+		? (attributes, innerBlocks) => innerBlocks
+		: undefined,
+	to: !isLargerThanWp63
+		? [
+				{
+					type: 'block',
+					blocks: ['*'],
+					transform: (attributes, innerBlocks) => innerBlocks,
+				},
+		  ]
+		: undefined,
 };
 
 export default transforms;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/WordPress/gutenberg/pull/50385

## どういう変更をしたか？

* 6.3からtransformsのtoが削除されungroupに変更されたので調整

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 6.2で今まで通りラップアンラップが使える
* 6.3でungroupからブロックの変換が出来る
*

WP6.2

https://github.com/vektor-inc/vk-blocks-pro/assets/42362903/6af2547e-8278-44ed-b6e5-bf363fd8d408

WP6.3

https://github.com/vektor-inc/vk-blocks-pro/assets/42362903/5b266db2-66a4-4e58-9f9e-42d4b34400e7



---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
