### PR TITLE
selectを変更したときのみFont Awesome version change ボタンを表示させるように変更

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,7 @@ e.g.
 
 == Changelog ==
 
+[ Specification Change ] Changed to display Font Awesome version change button only when select is changed.
 [ Specification Change ][ Animation(Pro) ] Fix WordPress 6.3 transforms settings.
 
 = 1.60.0 =

--- a/src/utils/font-awesome-new.js
+++ b/src/utils/font-awesome-new.js
@@ -403,19 +403,23 @@ export const FontAwesome = (props) => {
 						onChange={(value) => setVersion(value)}
 						className="mt-1"
 					/>
-					<p className="mt-1">
-						{__(
-							'When you click save button, the window will be reloaded and this setting will be applied.',
-							'vk-blocks-pro'
-						)}
-					</p>
-					<Button
-						isPrimary
-						disabled={isWaiting}
-						onClick={handleUpdateOptions}
-					>
-						{__('Save', 'vk-blocks-pro')}
-					</Button>
+					{version !== currentVersion && (
+						<>
+							<p className="mt-1">
+								{__(
+									'When you click save button, the window will be reloaded and this setting will be applied.',
+									'vk-blocks-pro'
+								)}
+							</p>
+							<Button
+								isPrimary
+								disabled={isWaiting}
+								onClick={handleUpdateOptions}
+							>
+								{__('Save', 'vk-blocks-pro')}
+							</Button>
+						</>
+					)}
 				</>
 			)}
 		</>


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1769

## どういう変更をしたか？

selectを変更したときのみFont Awesome version change ボタン 表示させるように変更

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュー確認方法と同様です。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* selectを変更したときのみFont Awesome version change ボタンが表示させていること確認
*

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
