### PR TITLE
【2人目確認中】[Outer]透過の仕様変更で以前のバージョンに対応

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -65,6 +65,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ] [ Outer ( Pro ) ] Fixed opacity with previous Outer version.
+
 = 1.61.1 =
 [ Bug fix ] Fix error WordPress 6.3 live previewing block themes.
 [ Bug fix ] VK Term color update 0.6.6

--- a/src/blocks/_pro/outer/style.scss
+++ b/src/blocks/_pro/outer/style.scss
@@ -51,6 +51,13 @@ $media-xxl-down: 1399.98px;
 		opacity: 0.5;
 	}
 
+	// 互換性対応 1.60.0 以前のスタイル
+	@for $i from 0 through 10 {
+		.vk_outer-background-area.has-background-dim-#{ $i } {
+			opacity: $i * 0.1;
+		}
+	}
+
 	.vk_outer_container {
 		position: relative;
 		min-height: 24px;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 Outerブロックの背景の透過処理に問題があるっぽい #1800 

## どういう変更をしたか？

*  Outer ブロックの透過設定を小数点以下2桁で設定可能に #1776 (VK Blocks Pro 1.61.0 でリリース)のとき、透過を インラインスタイルで指定するように変更したが、以前に使っていたクラス(.vk_outer-background-area.has-background-dim-XX) がなくなったため、以前の透過の設定が反映されくなっていた
以前に使っていたクラスを css に追加しました

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

1. VK Blocks Pro を 1.61.0 よりも前のブランチにする
2. 投稿に Outer ブロックを設置し、背景の透過を設定(ここでは10段階)し、投稿ページの表示を確認 → 透過が反映される(正常)
3. develop ブランチで、投稿ページの表示を確認 → 透過(旧設定)は反映されずつねに0.5(デフォルト)になるのを確認 (issue の現象)
4. 本ブランチで、投稿ページの表示を確認 → 透過(旧設定)が反映される
5. 念のため、新しい仕様(0.01刻み)の表示も確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 実装者が確認した手順と同じです
* 以前に設置した Outer ブロックが、VK Blocks Pro をアップデートしても正しく表示されるかどうか？の確認になります。
* develop のブランチ以降でいったん編集画面を表示してしまうと、互換が走るため再現しません、旧ブランチで投稿を保存した以降は編集画面を表示させずに、フロントのみで確認してもらえますか
* 動作確認できるブロックをコメント欄に貼ります
---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
