### PR TITLE
Remove unneeded block.json name-only imports

### DIFF
--- a/src/blocks/button/transforms.js
+++ b/src/blocks/button/transforms.js
@@ -3,11 +3,6 @@
  */
 import { createBlock } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import { name } from './block.json';
-
 const transforms = {
 	from: [
 		{
@@ -21,7 +16,7 @@ const transforms = {
 				const link = div.querySelector('a');
 				const url = link?.getAttribute('href');
 				const target = link?.getAttribute('target') ? true : false;
-				return createBlock(name, {
+				return createBlock('vk-blocks/button', {
 					content: text,
 					buttonUrl: url,
 					buttonTarget: target,


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
`npm run build`した時のwarinig対応

## どういう変更をしたか？

Remove unneeded block.json name-only imports
参考：https://github.com/WordPress/gutenberg/pull/53677

block.jsonからnameをimportすることは非推奨になった様です。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* レビュー確認方法と同様です。
*
*

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* developブランチで`npm run build`した時に以下のようなwarinigが出ていることを確認
![warinig](https://github.com/vektor-inc/vk-blocks-pro/assets/42362903/d093b0ec-a4e9-4564-877e-d6da29752d3a)
* このブランチに切り替えてnpm run buildした時にwarinigが解消されていることを確認
* developブランチと同じよう段落ブロックからvk-blocksのボタンブロックへ変換ができることを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
