### PR TITLE
【2人目確認中】ブログカード 置換する際はURL以外のattributesを削除する

### DIFF
--- a/src/blocks/_pro/blog-card/edit/index.js
+++ b/src/blocks/_pro/blog-card/edit/index.js
@@ -68,6 +68,20 @@ export default function BlogCardWrapperEdit(props) {
 		],
 	});
 
+	// url以外のattributesをundefinedにする
+	function setUndefinedExceptSpecifiedProps(obj, propsToKeep) {
+		const newObj = {};
+		for (const key of Object.keys(obj)) {
+			newObj[key] = propsToKeep.includes(key) ? obj[key] : undefined;
+		}
+		return newObj;
+	}
+	const propertiesToKeep = ['url'];
+	const replaceAttributes = setUndefinedExceptSpecifiedProps(
+		attributes,
+		propertiesToKeep
+	);
+
 	return (
 		<>
 			<BlockControls>
@@ -85,7 +99,7 @@ export default function BlogCardWrapperEdit(props) {
 					<ToolbarGroup className="wp-block-template-part__block-control-group">
 						<ToolbarButton
 							onClick={() => {
-								setAttributes({ style: undefined });
+								setAttributes({ ...replaceAttributes });
 								// innerBlocksを削除する
 								replaceInnerBlocks(clientId, []);
 								setIsStartingBlank(true);


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#749 #1778

今後、ブロックバリエーションをユーザーがカスタマイズできる様な機能を考えています
https://github.com/vektor-inc/vk-blocks-pro/issues/749#issuecomment-1667196744
その際に元の設定が引き継がれると背景を設定していないバリエーションなのに背景が設定されるなどが発生しユーザービリティーが悪いと思いました
そのためURL以外のattributeはundefinedに設定することにします。
ブロックサポートはstyle以外のattributeも存在していたので確認漏れしてました🙇‍♂️🙇‍♂️🙇‍♂️

現時点では置換ボタンを押したらattributesを削除しないとバリエーションの設定ができないため、バリエーション選択画面で元のブロック設定はクリアされる文言で対応しています。
https://github.com/vektor-inc/vk-blocks-pro/issues/749#issuecomment-1698467404

## どういう変更をしたか？
url以外のattributesをundefinedにする様に修正

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
#1778 に書いてあるので
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* レビュー確認方法と同様です。
*

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 以下の様な背景色などを指定したブログカードブロックを設定する
```HTML
<!-- wp:vk-blocks/blog-card {"url":"https://www.vektor-inc.co.jp/","gradient":"electric-grass","style":{"spacing":{"padding":{"top":"1.5rem","right":"1.5rem","bottom":"1.5rem","left":"1.5rem"}},"border":{"color":"#0000001f","width":"1px","radius":"5px"}}} -->
<div class="wp-block-vk-blocks-blog-card has-border-color has-electric-grass-gradient-background has-background" style="border-color:#0000001f;border-width:1px;border-radius:5px;padding-top:1.5rem;padding-right:1.5rem;padding-bottom:1.5rem;padding-left:1.5rem"><!-- wp:vk-blocks/blog-card-featured-image {"style":{"border":{"color":"#0000001f","width":"1px","radius":"5px"}}} /-->

<!-- wp:vk-blocks/blog-card-title /-->

<!-- wp:vk-blocks/blog-card-excerpt /-->

<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
<div class="wp-block-group"><!-- wp:vk-blocks/blog-card-site-logo {"style":{"layout":{"selfStretch":"fixed","flexSize":"15px"}}} /-->

<!-- wp:vk-blocks/blog-card-site-title /--></div>
<!-- /wp:group --></div>
<!-- /wp:vk-blocks/blog-card -->
```
* ツールバーの置換をクリックして他のバリエーションを設定した時に背景色は設定されないことを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
