### PR TITLE
【2人目確認待ち】[ 投稿リストブロック ] クエリを改変できるようにフック追加 

### DIFF
--- a/inc/vk-blocks/view/class-vk-blocks-postlist.php
+++ b/inc/vk-blocks/view/class-vk-blocks-postlist.php
@@ -188,6 +188,7 @@ class Vk_Blocks_PostList {
 		if ( ! empty( $date_query ) ) {
 			$args['date_query'] = $date_query;
 		}
+		$args = apply_filters( 'vk_post_list_query_args', $args, $attributes );
 		return new WP_Query( $args );
 	}
 

--- a/inc/vk-blocks/view/class-vk-blocks-postlist.php
+++ b/inc/vk-blocks/view/class-vk-blocks-postlist.php
@@ -188,7 +188,7 @@ class Vk_Blocks_PostList {
 		if ( ! empty( $date_query ) ) {
 			$args['date_query'] = $date_query;
 		}
-		$args = apply_filters( 'vk_post_list_query_args', $args, $attributes );
+		$args = apply_filters( 'vk_blocks_post_list_query_args', $args, $attributes );
 		return new WP_Query( $args );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -105,7 +105,7 @@ e.g.
 [ Bug fix ][ Balloon ] Fixed word break position.
 [ Bug fix ][ Table of Contents ] Fixed the issue with inner blocks not working correctly.
 [ Add Function ][ Blog Card (Pro) ] Add block variation function.
-[ Add filter ][ Post List (Pro) ] Add vk_post_list_query_args filter hook.
+[ Add filter ][ Post List (Pro) ] Add vk_blocks_post_list_query_args filter hook.
 
 [ Bug fix ][ Outer (Pro) ] Fixed a bug in the initial setting of divider for each device.
 

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ e.g.
 [ Bug fix ][ Balloon ] Fixed word break position.
 [ Bug fix ][ Table of Contents ] Fixed the issue with inner blocks not working correctly.
 [ Add Function ][ Blog Card (Pro) ] Add block variation function.
+[ Add filter ][ Post List (Pro) ] Add vk_post_list_query_args filter hook.
 
 [ Bug fix ][ Outer (Pro) ] Fixed a bug in the initial setting of divider for each device.
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

投稿リストブロックについて、ブロックで用意された条件でしか表示できないので、細かいチューニングができない
https://vws.vektor-inc.co.jp/forums/topic/vk-blocks-list-cat-exclude

## どういう変更をしたか？

投稿リストブロックのクエリを外部から改変できるようにフック追加

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ フィルターフック追加だけで機能面に変更はないため省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* 投稿リストブロックを配置
* テーマの functions.php などに以下を追加して表示件数が1になる（改変が効く）事を確認

```
add_filter(
	'vk_blocks_post_list_query_args',
	function( $args, $attributes ) {
		$args['posts_per_page'] = 1;
		return $args;
	},
	10,
	2
);
```

ちなみに実際には以下のような運用を想定している

```
add_filter(
	'vk_blocks_post_list_query_args',
	function( $args, $attributes ) {
		// strpos は該当文字列が存在しても開始位置で 0 を返したりするので false 指定から迂闊に変更しない事
		if ( strpos( $attributes['className'], 'test-list' ) !== false ) {
			// クラス名に 'test-list'が含まれている場合の処理
			$args['tax_query'][] = array(
				'taxonomy' => 'category',
				'terms'    => array( 2 ),
				'operator' => 'NOT IN',
			);
			$args['posts_per_page'] = 1;
		}
		return $args;
	},
	10,
	2
);
```




## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者に同じ

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
