### PR TITLE
【確認待ち】カテゴリーバッジの一部ラベル変更のみ

### DIFF
--- a/src/blocks/_pro/post-category-badge/edit.js
+++ b/src/blocks/_pro/post-category-badge/edit.js
@@ -85,7 +85,7 @@ export default function CategoryBadgeEdit(props) {
 			<InspectorControls>
 				<PanelBody title={__('Setting', 'vk-blocks-pro')}>
 					<ToggleControl
-						label={__('Add Link to Taxonomy Page', 'vk-blocks-pro')}
+						label={__('Enable Term Link', 'vk-blocks-pro')}
 						checked={hasLink}
 						onChange={(checked) =>
 							setAttributes({ hasLink: checked })


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
「Add link to taxonomy page」というラベルがあったが、よく考えるとタームリンクなので、「Enable Term Link」が適切でスマートな表現ではないかと思い、修正します。

## レビュワー確認方法・確認内容など

- ラベルの変更のみ。表現が適切かどうかを判断し、よければマージしてください。
- 一応ビルドして表記が変わっていることを確認してください。

※1人チェックで良いと思います。
