### PR TITLE
PHPUnitテスト set_current_user を共通化

### DIFF
--- a/test/phpunit/bootstrap.php
+++ b/test/phpunit/bootstrap.php
@@ -46,11 +46,7 @@ function _manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-/**
- *  utils、custom_assertを読み込み
- */
-require_once dirname( __FILE__ ) . '/utils.php';
-require_once dirname( __FILE__ ) . '/custom-assert.php';
+
 /**
  * Adds a wp_die handler for use during tests.
  *
@@ -80,6 +76,13 @@ $GLOBALS['wp_tests_options'] = array(
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+/**
+ *  utils、custom_assertを読み込み
+ */
+require_once dirname( __FILE__ ) . '/utils.php';
+require_once dirname( __FILE__ ) . '/custom-assert.php';
+require_once dirname( __FILE__ ) . '/vk-unit-test-case.php';
 
 // Use existing behavior for wp_die during actual test execution.
 remove_filter( 'wp_die_handler', 'fail_if_died' );

--- a/test/phpunit/free/test-page-content.php
+++ b/test/phpunit/free/test-page-content.php
@@ -8,7 +8,7 @@
 /**
  * Page Content block test case.
  */
-class PageContentBlockTest extends WP_UnitTestCase {
+class PageContentBlockTest extends VK_UnitTestCase {
 
 	/**
 	 * PageContentブロックで表示する固定ページ
@@ -60,24 +60,4 @@ class PageContentBlockTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
-
-	/**
-	 * Add user and set the user as current user.
-	 *
-	 * @param  string $role administrator, editor, author, contributor ...
-	 * @return void
-	 */
-	public function set_current_user( $role ) {
-		$user = $this->factory()->user->create_and_get(
-			array(
-				'role' => $role,
-			)
-		);
-
-		/*
-			* Set $user as current user
-			*/
-		wp_set_current_user( $user->ID, $user->user_login );
-	}
-
 };

--- a/test/phpunit/free/test-spacer.php
+++ b/test/phpunit/free/test-spacer.php
@@ -8,7 +8,7 @@
 /**
  * Post List block test case.
  */
-class VKBSpacerTest extends WP_UnitTestCase {
+class VKBSpacerTest extends VK_UnitTestCase {
 
 	/**
 	 * Undocumented function

--- a/test/phpunit/free/test-vk-block-is-pro.php
+++ b/test/phpunit/free/test-vk-block-is-pro.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class TestVKBlocksIsPro extends WP_UnitTestCase {
+class TestVKBlocksIsPro extends VK_UnitTestCase {
 
 	public function test_vk_blocks_minify_css() {
         $path = dirname( dirname( dirname( dirname( __FILE__ ) ) ) );

--- a/test/phpunit/pro/test-ancestor-page-list.php
+++ b/test/phpunit/pro/test-ancestor-page-list.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-blocks-pro
  */
 
-class AncestorPageListTest extends WP_UnitTestCase {
+class AncestorPageListTest extends VK_UnitTestCase {
 
 	/**
 	 * Test Title

--- a/test/phpunit/pro/test-archive-list.php
+++ b/test/phpunit/pro/test-archive-list.php
@@ -10,7 +10,7 @@
 /**
  * ArchiveList block test case.
  */
-class ArchiveList extends WP_UnitTestCase {
+class ArchiveList extends VK_UnitTestCase {
 
 	public function test_vk_blocks_archive_list_render_callback(){
 

--- a/test/phpunit/pro/test-archive-list.php
+++ b/test/phpunit/pro/test-archive-list.php
@@ -5,15 +5,26 @@
  * @package Vk_Blocks_Pro
  */
 
- use VK_WP_Unit_Test_Tools\VkWpUnitTestHelpers;
+use VK_WP_Unit_Test_Tools\VkWpUnitTestHelpers;
 
 /**
  * ArchiveList block test case.
  */
 class ArchiveList extends VK_UnitTestCase {
 
-	public function test_vk_blocks_archive_list_render_callback(){
+	public function set_up(): void {
+		parent::set_up();
+		add_filter('locale', function($locale) {
+			return 'en_US';
+		}); 
+	}
 
+	public function tear_down(): void {
+		parent::tear_down();
+		remove_filter('locale', 10); 
+	}	
+
+	public function test_vk_blocks_archive_list_render_callback(){
 		print PHP_EOL;
 		print '------------------------------------' . PHP_EOL;
 		print 'vk_blocks_archive_list_render_callback' . PHP_EOL;

--- a/test/phpunit/pro/test-array-merge.php
+++ b/test/phpunit/pro/test-array-merge.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class ArrayMergeTest extends WP_UnitTestCase {
+class ArrayMergeTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_array_merge() {
 		/**

--- a/test/phpunit/pro/test-block-loader.php
+++ b/test/phpunit/pro/test-block-loader.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class BlockLoaderTest extends WP_UnitTestCase {
+class BlockLoaderTest extends VK_UnitTestCase {
 
 	public function test_should_load_separate_assets() {
 		$test_data = array(

--- a/test/phpunit/pro/test-blog-card.php
+++ b/test/phpunit/pro/test-blog-card.php
@@ -8,7 +8,7 @@
 /**
  * BlogCard block test case.
  */
-class BlogCard extends WP_UnitTestCase {
+class BlogCard extends VK_UnitTestCase {
 	/**
 	 * Post object.
 	 *

--- a/test/phpunit/pro/test-breadcrumb.php
+++ b/test/phpunit/pro/test-breadcrumb.php
@@ -8,7 +8,7 @@
 /**
  * Breadcrumb block test case.
  */
-class Breadcrumb extends WP_UnitTestCase {
+class Breadcrumb extends VK_UnitTestCase {
 
 	/**
 	 * Breadcrumbブロックを挿入する投稿
@@ -100,25 +100,6 @@ class Breadcrumb extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $actual );
 
-	}
-
-	/**
-	 * Add user and set the user as current user.
-	 *
-	 * @param  string $role administrator, editor, author, contributor ...
-	 * @return void
-	 */
-	public function set_current_user( $role ) : void {
-		$user = $this->factory()->user->create_and_get(
-			array(
-				'role' => $role,
-			)
-		);
-
-		/*
-			* Set $user as current user
-			*/
-		wp_set_current_user( $user->ID, $user->user_login );
 	}
 
 };

--- a/test/phpunit/pro/test-child-page.php
+++ b/test/phpunit/pro/test-child-page.php
@@ -8,7 +8,7 @@
 /**
  * Child Page block test case.
  */
-class ChildPageBlockTest extends WP_UnitTestCase {
+class ChildPageBlockTest extends VK_UnitTestCase {
 
 	/**
 	 * 親ページID
@@ -110,25 +110,6 @@ class ChildPageBlockTest extends WP_UnitTestCase {
 		$expected = vk_blocks_unescape_html( '<div class=\"vk_posts vk_posts-postType-page vk_posts-layout-card-horizontal vk_childPage \"><div id=\"post-' . intval( $this->child_page_id ) . '\" class=\"vk_post vk_post-postType-page card card-post card-horizontal vk_post-col-xs-12 vk_post-col-sm-6 vk_post-col-md-6 vk_post-col-lg-6 vk_post-col-xl-6 vk_post-col-xxl-6 vk_post-btn-display post-' . intval( $this->child_page_id ) . ' page type-page status-publish hentry\"><div class=\"card-horizontal-inner-row\"><div class=\"vk_post-col-5 col-5 card-img-outer\"><div class=\"vk_post_imgOuter\" style=\"background-image:url(' . home_url() . '\/wp-content\/plugins\/vk-blocks-pro\/inc\/vk-blocks\/images\/no-image.png)\"><a href=\"' . home_url() . '\/?page_id=' . intval( $this->child_page_id ) . '\"><div class=\"card-img-overlay\"><\/div><img src=\"' . home_url() . '\/wp-content\/plugins\/vk-blocks-pro\/inc\/vk-blocks\/images\/no-image.png\" alt=\"\" class=\"vk_post_imgOuter_img card-img card-img-use-bg\" loading=\"lazy\" \/><\/a><\/div><!-- [ \/.vk_post_imgOuter ] --><\/div><!-- \/.col --><div class=\"vk_post-col-7 col-7\"><div class=\"vk_post_body card-body\"><h5 class=\"vk_post_title card-title\"><a href=\"' . home_url() . '\/?page_id=' . intval( $this->child_page_id ) . '\">Child Title<\/a><\/h5><p class=\"vk_post_excerpt card-text\">This is my child page<\/p><div class=\"vk_post_btnOuter text-right\"><a class=\"btn btn-sm btn-primary vk_post_btn\" href=\"' . home_url() . '\/?page_id=' . intval( $this->child_page_id ) . '\">Read more<\/a><\/div><\/div><!-- [ \/.card-body ] --><\/div><!-- \/.col --><\/div><!-- [ \/.row ] --><\/div><!-- [ \/.card ] --><\/div>' );
 
 		$this->assertEquals( $expected, $actual );
-	}
-
-	/**
-	 * Add user and set the user as current user.
-	 *
-	 * @param  string $role administrator, editor, author, contributor ...
-	 * @return void
-	 */
-	public function set_current_user( $role ) {
-		$user = $this->factory()->user->create_and_get(
-			array(
-				'role' => $role,
-			)
-		);
-
-		/*
-			* Set $user as current user
-			*/
-		wp_set_current_user( $user->ID, $user->user_login );
 	}
 
 };

--- a/test/phpunit/pro/test-color-slug-to-color-code.php
+++ b/test/phpunit/pro/test-color-slug-to-color-code.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class colorSlugToClorCodeTest extends WP_UnitTestCase {
+class colorSlugToClorCodeTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_get_color_code() {
 		$test_data = array(

--- a/test/phpunit/pro/test-custom-css-extension.php
+++ b/test/phpunit/pro/test-custom-css-extension.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class CustomCssExtensionTest extends WP_UnitTestCase {
+class CustomCssExtensionTest extends VK_UnitTestCase {
 
 	public function test_block_content_preg_replace() {
 

--- a/test/phpunit/pro/test-dynamic-text.php
+++ b/test/phpunit/pro/test-dynamic-text.php
@@ -20,7 +20,7 @@ class BlockObject {
 /**
  * DynamicText block test case.
  */
-class DynamicText extends WP_UnitTestCase {
+class DynamicText extends VK_UnitTestCase {
 
 	/**
 	 * Test Block

--- a/test/phpunit/pro/test-format-inline-css.php
+++ b/test/phpunit/pro/test-format-inline-css.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class FormatCssTest extends WP_UnitTestCase {
+class FormatCssTest extends VK_UnitTestCase {
 
 	/**
 	 * よく使う書式設定のインラインCSSテスト

--- a/test/phpunit/pro/test-get-options.php
+++ b/test/phpunit/pro/test-get-options.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class GetOptionsTest extends WP_UnitTestCase {
+class GetOptionsTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_get_options() {
 		/**

--- a/test/phpunit/pro/test-hex-to-rgba.php
+++ b/test/phpunit/pro/test-hex-to-rgba.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class GetHexToRgbaTest extends WP_UnitTestCase {
+class GetHexToRgbaTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_get_hex_to_rgba() {
 		$test_data = array(

--- a/test/phpunit/pro/test-license-check.php
+++ b/test/phpunit/pro/test-license-check.php
@@ -6,7 +6,7 @@
  */
 
 
-class LicenseCheckerTest extends WP_UnitTestCase {
+class LicenseCheckerTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_license_check() {
 

--- a/test/phpunit/pro/test-license-setting.php
+++ b/test/phpunit/pro/test-license-setting.php
@@ -6,7 +6,7 @@
  */
 
 
-class LicenseSettingTest extends WP_UnitTestCase {
+class LicenseSettingTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_is_license_setting() {
 

--- a/test/phpunit/pro/test-license.php
+++ b/test/phpunit/pro/test-license.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class LicenseTest extends WP_UnitTestCase {
+class LicenseTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_get_license_check_query_arg() {
 		$test_data = array(

--- a/test/phpunit/pro/test-minify-css.php
+++ b/test/phpunit/pro/test-minify-css.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class minifyCssTest extends WP_UnitTestCase {
+class minifyCssTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_minify_css() {
 		$test_data = array(

--- a/test/phpunit/pro/test-post-category-badge.php
+++ b/test/phpunit/pro/test-post-category-badge.php
@@ -10,7 +10,7 @@
 /**
  * PostCategoryBadgeTest block test case.
  */
-class PostCategoryBadgeTest extends WP_UnitTestCase {
+class PostCategoryBadgeTest extends VK_UnitTestCase {
 
     // テスト用タクソノミー（各テスト共通）
     private $test_taxonomies = array(
@@ -278,16 +278,5 @@ class PostCategoryBadgeTest extends WP_UnitTestCase {
             $this->assertEquals($test['correct'], $return);
         }
 	}
-
-    private function set_current_user( $role ) {
-        $user = $this->factory()->user->create_and_get( array(
-            'role' => $role,
-        ) );
-
-        /*
-         * Set $user as the current user
-         */
-        wp_set_current_user( $user->ID, $user->user_login );
-    }    
-    
+  
 };

--- a/test/phpunit/pro/test-post-list-query.php
+++ b/test/phpunit/pro/test-post-list-query.php
@@ -5,7 +5,7 @@
  * @package vektor-inc/vk-blocks-pro
  */
 
-class PostListBlockQueryTest extends WP_UnitTestCase {
+class PostListBlockQueryTest extends VK_UnitTestCase {
 
 	public static function create_test_posts() {
 

--- a/test/phpunit/pro/test-post-list.php
+++ b/test/phpunit/pro/test-post-list.php
@@ -8,7 +8,7 @@
 /**
  * Post List block test case.
  */
-class PostListBlockTest extends WP_UnitTestCase {
+class PostListBlockTest extends VK_UnitTestCase {
 
 	/**
 	 * PostListブロックを挿入する投稿
@@ -119,25 +119,6 @@ class PostListBlockTest extends WP_UnitTestCase {
 		$expected = vk_blocks_unescape_html( '<div class=\"vk_posts vk_posts-postType-post vk_posts-postType-page vk_posts-layout-card vk_postList \"><div id=\"post-' . intval( $this->page_id ) . '\" class=\"vk_post vk_post-postType-page card card-post vk_post-col-xs-12 vk_post-col-sm-6 vk_post-col-md-4 vk_post-col-lg-4 vk_post-col-xl-4 vk_post-col-xxl-4 post-' . intval( $this->page_id ) . ' page type-page status-publish hentry\"><div class=\"vk_post_imgOuter\" style=\"background-image:url(' . home_url() . '\/wp-content\/plugins\/vk-blocks-pro\/inc\/vk-blocks\/images\/no-image.png)\"><a href=\"' . home_url() . '\/?page_id=' . intval( $this->page_id ) . '\"><div class=\"card-img-overlay\"><\/div><img src=\"' . home_url() . '\/wp-content\/plugins\/vk-blocks-pro\/inc\/vk-blocks\/images\/no-image.png\" alt=\"\" class=\"vk_post_imgOuter_img card-img-top\" loading=\"lazy\" \/><\/a><\/div><!-- [ \/.vk_post_imgOuter ] --><div class=\"vk_post_body card-body\"><h5 class=\"vk_post_title card-title\"><a href=\"' . home_url() . '\/?page_id=' . intval( $this->page_id ) . '\">Page Title<span class=\"vk_post_title_new\">New!!<\/span><\/a><\/h5><\/div><!-- [ \/.card-body ] --><\/div><!-- [ \/.card ] --><div id=\"post-' . intval( $this->post_id ) . '\" class=\"vk_post vk_post-postType-post card card-post vk_post-col-xs-12 vk_post-col-sm-6 vk_post-col-md-4 vk_post-col-lg-4 vk_post-col-xl-4 vk_post-col-xxl-4 post-' . intval( $this->post_id ) . ' post type-post status-publish format-standard hentry category-parent_category\"><div class=\"vk_post_imgOuter\" style=\"background-image:url(' . home_url() . '\/wp-content\/plugins\/vk-blocks-pro\/inc\/vk-blocks\/images\/no-image.png)\"><a href=\"' . home_url() . '\/?p=' . intval( $this->post_id ) . '\"><div class=\"card-img-overlay\"><span class=\"vk_post_imgOuter_singleTermLabel\" style=\"color:#fff;background-color:#999999\">parent_category<\/span><\/div><img src=\"' . home_url() . '\/wp-content\/plugins\/vk-blocks-pro\/inc\/vk-blocks\/images\/no-image.png\" alt=\"\" class=\"vk_post_imgOuter_img card-img-top\" loading=\"lazy\" \/><\/a><\/div><!-- [ \/.vk_post_imgOuter ] --><div class=\"vk_post_body card-body\"><h5 class=\"vk_post_title card-title\"><a href=\"' . home_url() . '\/?p=' . intval( $this->post_id ) . '\">Post Title<span class=\"vk_post_title_new\">New!!<\/span><\/a><\/h5><\/div><!-- [ \/.card-body ] --><\/div><!-- [ \/.card ] --><\/div>' );
 
 		$this->assertEquals( $expected, $actual );
-	}
-
-	/**
-	 * Add user and set the user as current user.
-	 *
-	 * @param  string $role administrator, editor, author, contributor ...
-	 * @return void
-	 */
-	public function set_current_user( $role ) {
-		$user = $this->factory()->user->create_and_get(
-			array(
-				'role' => $role,
-			)
-		);
-
-		/*
-			* Set $user as current user
-			*/
-		wp_set_current_user( $user->ID, $user->user_login );
 	}
 
 };

--- a/test/phpunit/pro/test-post-new-badge.php
+++ b/test/phpunit/pro/test-post-new-badge.php
@@ -10,7 +10,7 @@ use VektorInc\VK_Helpers\VkHelpers;
 /**
  * DynamicText block test case.
  */
-class PostNewBadgeTest extends WP_UnitTestCase {
+class PostNewBadgeTest extends VK_UnitTestCase {
 
     /**
 	 * @var array

--- a/test/phpunit/pro/test-rest-api.php
+++ b/test/phpunit/pro/test-rest-api.php
@@ -5,7 +5,7 @@
 * @package Vk_Blocks_Pro
 */
 
-class RestAPITest extends WP_UnitTestCase {
+class RestAPITest extends VK_UnitTestCase {
 
     /**
     * Holds the WP REST Server object
@@ -70,19 +70,5 @@ class RestAPITest extends WP_UnitTestCase {
 
     }
 
-    /**
-    * Add user and set the user as current user.
-    *
-    * @param  string $role administrator, editor, author, contributor ...
-    * @return void
-    */
-    public function set_current_user( $role ) {
-        $user = self::factory()->user->create_and_get(
-            array(
-                'role' => $role,
-            )
-        );
-        wp_set_current_user( $user->ID, $user->user_login );
-    }
 }
 ;

--- a/test/phpunit/pro/test-sanitze-option.php
+++ b/test/phpunit/pro/test-sanitze-option.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class SanitizeOptions extends WP_UnitTestCase {
+class SanitizeOptions extends VK_UnitTestCase {
 
 	public function test_sanitize_options() {
 		$test_data = array(

--- a/test/phpunit/pro/test-select-post-list.php
+++ b/test/phpunit/pro/test-select-post-list.php
@@ -8,7 +8,7 @@
 /**
  * Select Post List Block Test case.
  */
-class SelectPostListBlockTest extends WP_UnitTestCase {
+class SelectPostListBlockTest extends VK_UnitTestCase {
 
 	/**
 	 * 選択投稿リストで設定するpage id
@@ -96,22 +96,4 @@ class SelectPostListBlockTest extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $actual );
 	}
 
-	/**
-	 * Add user and set the user as current user.
-	 *
-	 * @param  string $role administrator, editor, author, contributor ...
-	 * @return void
-	 */
-	public function set_current_user( $role ) {
-		$user = $this->factory()->user->create_and_get(
-			array(
-				'role' => $role,
-			)
-		);
-
-		/*
-			* Set $user as current user
-			*/
-		wp_set_current_user( $user->ID, $user->user_login );
-	}
 }

--- a/test/phpunit/pro/test-taxonomy.php
+++ b/test/phpunit/pro/test-taxonomy.php
@@ -1,6 +1,6 @@
 <?php
 
-class TaxonomyTest extends WP_UnitTestCase {
+class TaxonomyTest extends VK_UnitTestCase {
 
 	function test_taxonomy_render_callback() {
 

--- a/test/phpunit/pro/test-vk-blocks-options.php
+++ b/test/phpunit/pro/test-vk-blocks-options.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class VKBlocksOptionsTest extends WP_UnitTestCase {
+class VKBlocksOptionsTest extends VK_UnitTestCase {
 
 	public function test_get_deprecated_lists() {
 		$test_data = array(

--- a/test/phpunit/pro/test-vk-term-color.php
+++ b/test/phpunit/pro/test-vk-term-color.php
@@ -8,7 +8,7 @@ use VektorInc\VK_Term_Color\VkTermColor;
 /**
  * Post List block test case.
  */
-class VkTermColorTest extends WP_UnitTestCase {
+class VkTermColorTest extends VK_UnitTestCase {
 
 	/**
 	 * PostListブロックを挿入する投稿

--- a/test/phpunit/pro/test-vk_blocks_is_lightning.php
+++ b/test/phpunit/pro/test-vk_blocks_is_lightning.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class IsLightningTest extends WP_UnitTestCase {
+class IsLightningTest extends VK_UnitTestCase {
 
 	public function test_vk_blocks_is_lightning() {
 		$test_data = array(

--- a/test/phpunit/pro/test-vk_blocks_register_block_style.php
+++ b/test/phpunit/pro/test-vk_blocks_register_block_style.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
-class BlockStyleTest extends WP_UnitTestCase {
+class BlockStyleTest extends VK_UnitTestCase {
 
 	/**
 	 * register_block_styleでスタイルが登録されているかテスト

--- a/test/phpunit/utils.php
+++ b/test/phpunit/utils.php
@@ -28,3 +28,5 @@ function vk_blocks_unescape_html( $html ) {
 	// URLを開発環境に変更
 	return vk_blocks_replace_url( $html );
 }
+
+

--- a/test/phpunit/vk-unit-test-case.php
+++ b/test/phpunit/vk-unit-test-case.php
@@ -18,5 +18,4 @@ class VK_UnitTestCase extends WP_UnitTestCase {
         */
         wp_set_current_user( $user->ID, $user->user_login );
     } 
-    
 }

--- a/test/phpunit/vk-unit-test-case.php
+++ b/test/phpunit/vk-unit-test-case.php
@@ -1,0 +1,22 @@
+<?php
+
+class VK_UnitTestCase extends WP_UnitTestCase {
+
+    /**
+     * Set Current User
+     *
+     * @param string $role
+     * @return void
+     */
+    function set_current_user( $role ) {
+        $user = $this->factory()->user->create_and_get( array(
+            'role' => $role,
+        ) );
+
+        /*
+        * Set $user as the current user
+        */
+        wp_set_current_user( $user->ID, $user->user_login );
+    } 
+    
+}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
PHPUnitテストにおいて、set_current_userメソッドがあちこちで重複定義しているため、共通化したいです。
WP_UnitTestCase クラスを継承した VK_UnitTestCase クラスを作成し、VK_UnitTestCase 内に set_current_user メソッドを定義することで、全テストから利用可能になります。
また、今後全テストで共通して前処理、後処理させたい場合、共通メソッドを定義したい場合は、VK_UnitTestCaseクラスに記述すると良いことになります。

## どういう変更をしたか？

* WP_UnitTestCaseクラスを継承した VK_UnitTestCase クラスを定義、 set_current_userを定義
* 全PHPUnitテストの継承元を VK_UnitTestCase クラスに変更
* 各テストの set_current_user 定義を削除


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* レビュワー確認方法にオナh字

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*  npm run phpunit が通ることを確認
*  その他コードで気になることがあればお知らせください。

**一人チェックで良いかと思います。**

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
