### PR TITLE
set_current_user で作成したユーザー情報を返す

### DIFF
--- a/test/phpunit/vk-unit-test-case.php
+++ b/test/phpunit/vk-unit-test-case.php
@@ -17,5 +17,8 @@ class VK_UnitTestCase extends WP_UnitTestCase {
         * Set $user as the current user
         */
         wp_set_current_user( $user->ID, $user->user_login );
+
+        return $user;
+        
     } 
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1893 で 汎用的に使えるようにした set_current_user ですが、作成したユーザー情報を返す機能が現在開発中の案件で必要となったので、ユーザー情報をreturn するようにします。

## どういう変更をしたか？

* ユーザー情報をreturn するだけの変更。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*  npm run phpunit が通ることを確認
*  余裕があれば  $this->set_current_user( 'administrator' );  の返り値をvar_dumpしてユーザー情報が返ってくることを確認ください。（mustではないです）

※ 一人レビューで良いです。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
