### PR TITLE
【2人目確認中】ダイナミックテキストブロックでユーザー名表示機能を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ e.g.
 
 == Changelog ==
 
+[ Add Function ][ Dynamic Text (Pro) ] Add feature to display logged-in username.
+
 = 1.67.0 =
 [ Add Block ][ Category Badge (Pro) ] Creates badges displaying linked categories or terms for posts, with flexible design customization.
 

--- a/src/blocks/_pro/dynamic-text/block.json
+++ b/src/blocks/_pro/dynamic-text/block.json
@@ -29,6 +29,22 @@
 			"type": "string",
 			"default": null
 		},
+		"userNamePrefixText": {
+			"type": "string",
+			"default": null
+		},
+		"userNameSuffixText": {
+			"type": "string",
+			"default": null
+		},
+		"userNameLoggedOutText": {
+			"type": "string",
+			"default": null
+		},
+		"isLoginLink": {
+			"type": "boolean",
+			"default": true
+		},				
 		"fieldType": {
 			"type": "string",
 			"default": "text"

--- a/src/blocks/_pro/dynamic-text/block.json
+++ b/src/blocks/_pro/dynamic-text/block.json
@@ -44,7 +44,7 @@
 		"isLoginLink": {
 			"type": "boolean",
 			"default": true
-		},				
+		},
 		"fieldType": {
 			"type": "string",
 			"default": "text"

--- a/src/blocks/_pro/dynamic-text/edit.js
+++ b/src/blocks/_pro/dynamic-text/edit.js
@@ -310,12 +310,17 @@ export default function DynamicTextEdit(props) {
 								}
 							/>
 							<TextControl
-								label={__('Text for Logged Out Users', 'vk-blocks-pro')}
+								label={__(
+									'Text for Logged Out Users',
+									'vk-blocks-pro'
+								)}
 								value={userNameLoggedOutText}
 								onChange={(value) =>
-									setAttributes({ userNameLoggedOutText: value })
+									setAttributes({
+										userNameLoggedOutText: value,
+									})
 								}
-							/>	
+							/>
 							<ToggleControl
 								label={__(
 									'Link to Login on Logout',
@@ -327,7 +332,7 @@ export default function DynamicTextEdit(props) {
 										isLoginLink: checked,
 									})
 								}
-							/>						
+							/>
 						</BaseControl>
 					)}
 					{displayElement === 'custom-field' && (

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -140,12 +140,13 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 				$block_content .= esc_html($attributes['userNamePrefixText']) . $current_user->display_name . esc_html($attributes['userNameSuffixText']);
 			}
 		} else {
-			if ( $attributes['isLoginLink'] ) {
+			$userNameLoggedOutText = isset($attributes['userNameLoggedOutText']) ? esc_html($attributes['userNameLoggedOutText']) : '';
+			if ( isset($attributes['isLoginLink']) && $attributes['isLoginLink'] ) {
 				$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
-				$block_content .= '<a href="' . wp_login_url($current_url) . '">' . esc_html($attributes['userNameLoggedOutText']) . '</a>';
+				$block_content .= '<a href="' . wp_login_url($current_url) . '">' . esc_html($userNameLoggedOutText) . '</a>';
 			} else {
-				$block_content .= esc_html($attributes['userNameLoggedOutText']);
+				$block_content .= esc_html($userNameLoggedOutText);
 			}
 		}
 	} elseif ( 'custom-field' === $attributes['displayElement'] ) {

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -19,6 +19,8 @@ function vk_blocks_dynamic_text_get_attributes_default() {
 		'tagName'                  => 'div',
 		'ancestorPageHiddenOption' => null,
 		'parentPageHiddenOption'   => null,
+		'userNameBeforeText'	   => null,
+		'userNameAfterText'	  	   => null,
 		'customFieldName'          => null,
 		'fieldType'                => 'text',
 		'isLinkSet'                => false,
@@ -131,6 +133,21 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 			$parent_post_title = get_post( $post )->post_title;
 		}
 		$block_content .= $parent_post_title;
+	} elseif ( 'user-name' === $attributes['displayElement'] ) {
+		if ( is_user_logged_in() ) {
+			$current_user = wp_get_current_user();
+			if ( $current_user->display_name ) {
+				$block_content .= esc_html($attributes['userNamePrefixText']) . $current_user->display_name . esc_html($attributes['userNameSuffixText']);
+			}
+		} else {
+			if ( $attributes['isLoginLink'] ) {
+				$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+
+				$block_content .= '<a href="' . wp_login_url($current_url) . '">' . esc_html($attributes['userNameLoggedOutText']) . '</a>';
+			} else {
+				$block_content .= esc_html($attributes['userNameLoggedOutText']);
+			}
+		}
 	} elseif ( 'custom-field' === $attributes['displayElement'] ) {
 		$block_content .= vk_blocks_dynamic_text_custom_field_render( $attributes, $content, $block );
 	}
@@ -141,6 +158,11 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 	return $block_content;
 }
 
+/**
+ * Register Dynamic Text block.
+ *
+ * @return void
+ */
 /**
  * Register Dynamic Text block.
  *
@@ -188,6 +210,22 @@ function vk_blocks_register_block_dynamic_text() {
 						'type'    => 'boolean',
 						'default' => true,
 					),
+					'userNamePrefixText'                  => array(
+						'type'    => 'string',
+						'default' => '',
+					),	
+					'userNameSuffixText'                  => array(
+						'type'    => 'string',
+						'default' => '',
+					),	
+					'userNameLoggedOutText'   => array(
+						'type'    => 'string',
+						'default' =>  ''
+					),
+					'isLoginLink'             => array(
+						'type'    => 'boolean',
+						'default' => true
+					),													
 					'customFieldName'          => array(
 						'type'    => 'string',
 						'default' => '',

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -137,13 +137,20 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 		if ( is_user_logged_in() ) {
 			$current_user = wp_get_current_user();
 			if ( $current_user->display_name ) {
-				$block_content .= esc_html($attributes['userNamePrefixText']) . $current_user->display_name . esc_html($attributes['userNameSuffixText']);
+				$prefix = isset($attributes['userNamePrefixText']) ? esc_html($attributes['userNamePrefixText']) : '';
+				$suffix = isset($attributes['userNameSuffixText']) ? esc_html($attributes['userNameSuffixText']) : '';
+			
+				$block_content .= $prefix . $current_user->display_name . $suffix;
 			}
 		} else {
 			$userNameLoggedOutText = isset($attributes['userNameLoggedOutText']) ? esc_html($attributes['userNameLoggedOutText']) : '';
 			if ( isset($attributes['isLoginLink']) && $attributes['isLoginLink'] ) {
-				$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-
+				$post = get_post();
+				if ( is_singular() ) {
+					$current_url = get_permalink( $post->id );
+				} else {
+					$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+				}
 				$block_content .= '<a href="' . wp_login_url($current_url) . '">' . esc_html($userNameLoggedOutText) . '</a>';
 			} else {
 				$block_content .= esc_html($userNameLoggedOutText);

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -19,8 +19,8 @@ function vk_blocks_dynamic_text_get_attributes_default() {
 		'tagName'                  => 'div',
 		'ancestorPageHiddenOption' => null,
 		'parentPageHiddenOption'   => null,
-		'userNameBeforeText'	   => null,
-		'userNameAfterText'	  	   => null,
+		'userNameBeforeText'       => null,
+		'userNameAfterText'        => null,
 		'customFieldName'          => null,
 		'fieldType'                => 'text',
 		'isLinkSet'                => false,
@@ -137,23 +137,23 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 		if ( is_user_logged_in() ) {
 			$current_user = wp_get_current_user();
 			if ( $current_user->display_name ) {
-				$prefix = isset($attributes['userNamePrefixText']) ? esc_html($attributes['userNamePrefixText']) : '';
-				$suffix = isset($attributes['userNameSuffixText']) ? esc_html($attributes['userNameSuffixText']) : '';
-			
+				$prefix = isset( $attributes['userNamePrefixText'] ) ? esc_html( $attributes['userNamePrefixText'] ) : '';
+				$suffix = isset( $attributes['userNameSuffixText'] ) ? esc_html( $attributes['userNameSuffixText'] ) : '';
+
 				$block_content .= $prefix . $current_user->display_name . $suffix;
 			}
 		} else {
-			$userNameLoggedOutText = isset($attributes['userNameLoggedOutText']) ? esc_html($attributes['userNameLoggedOutText']) : '';
-			if ( isset($attributes['isLoginLink']) && $attributes['isLoginLink'] ) {
+			$userNameLoggedOutText = isset( $attributes['userNameLoggedOutText'] ) ? esc_html( $attributes['userNameLoggedOutText'] ) : '';
+			if ( isset( $attributes['isLoginLink'] ) && $attributes['isLoginLink'] ) {
 				$post = get_post();
 				if ( is_singular() ) {
 					$current_url = get_permalink( $post->id );
 				} else {
 					$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 				}
-				$block_content .= '<a href="' . wp_login_url($current_url) . '">' . esc_html($userNameLoggedOutText) . '</a>';
+				$block_content .= '<a href="' . wp_login_url( $current_url ) . '">' . esc_html( $userNameLoggedOutText ) . '</a>';
 			} else {
-				$block_content .= esc_html($userNameLoggedOutText);
+				$block_content .= esc_html( $userNameLoggedOutText );
 			}
 		}
 	} elseif ( 'custom-field' === $attributes['displayElement'] ) {
@@ -218,22 +218,22 @@ function vk_blocks_register_block_dynamic_text() {
 						'type'    => 'boolean',
 						'default' => true,
 					),
-					'userNamePrefixText'                  => array(
+					'userNamePrefixText'       => array(
 						'type'    => 'string',
 						'default' => '',
-					),	
-					'userNameSuffixText'                  => array(
-						'type'    => 'string',
-						'default' => '',
-					),	
-					'userNameLoggedOutText'   => array(
-						'type'    => 'string',
-						'default' =>  ''
 					),
-					'isLoginLink'             => array(
+					'userNameSuffixText'       => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'userNameLoggedOutText'    => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'isLoginLink'              => array(
 						'type'    => 'boolean',
-						'default' => true
-					),													
+						'default' => true,
+					),
 					'customFieldName'          => array(
 						'type'    => 'string',
 						'default' => '',

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -143,17 +143,19 @@ function vk_blocks_dynamic_text_render_callback( $attributes, $content, $block )
 				$block_content .= $prefix . $current_user->display_name . $suffix;
 			}
 		} else {
-			$userNameLoggedOutText = isset( $attributes['userNameLoggedOutText'] ) ? esc_html( $attributes['userNameLoggedOutText'] ) : '';
+			$loggedout_text = isset( $attributes['userNameLoggedOutText'] ) ? esc_html( $attributes['userNameLoggedOutText'] ) : '';
 			if ( isset( $attributes['isLoginLink'] ) && $attributes['isLoginLink'] ) {
 				$post = get_post();
 				if ( is_singular() ) {
 					$current_url = get_permalink( $post->id );
 				} else {
-					$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+					$http_host   = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+					$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+					$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $http_host . $request_uri;
 				}
-				$block_content .= '<a href="' . wp_login_url( $current_url ) . '">' . esc_html( $userNameLoggedOutText ) . '</a>';
+				$block_content .= '<a href="' . wp_login_url( $current_url ) . '">' . esc_html( $loggedout_text ) . '</a>';
 			} else {
-				$block_content .= esc_html( $userNameLoggedOutText );
+				$block_content .= esc_html( $loggedout_text );
 			}
 		}
 	} elseif ( 'custom-field' === $attributes['displayElement'] ) {

--- a/test/phpunit/pro/test-dynamic-text.php
+++ b/test/phpunit/pro/test-dynamic-text.php
@@ -136,18 +136,68 @@ class DynamicText extends VK_UnitTestCase {
 				'target_url' => get_permalink( $data['parent_page_id'] ),
 				'correct'    => '<h3 class="vk_dynamicText wp-block-vk-blocks-dynamic-text">ancestor_page</h3>',
 			),
-			// ユーザー名
+			// ユーザー名（Prefix/Suffixあり）%%USER_DISPLAY_NAME%% は該当するユーザー名に置き換えられます
 			array(
 				'attributes' => array(
 					'displayElement'           => 'user-name',
 					'tagName'                  => 'div',
-					'userNamePrefixText' => 'こんにちは',
-					'userNameSuffixText' => 'さん',
+					'userNamePrefixText' => 'PrefixText',
+					'userNameSuffixText' => 'SuffixText',
+				),
+				'user' => 'administrator',
+				'target_url' => get_permalink( $data['child_page_id'] ),
+				'correct'    => '<div class="vk_dynamicText wp-block-vk-blocks-dynamic-text">PrefixText%%USER_DISPLAY_NAME%%SuffixText</div>',
+			),
+
+			// ユーザー名（Prefixのみ）
+			array(
+				'attributes' => array(
+					'displayElement'           => 'user-name',
+					'tagName'                  => 'h2',
+					'userNamePrefixText' => 'PrefixText'
+				),
+				'user' => 'administrator',
+				'target_url' => get_permalink( $data['child_page_id'] ),
+				'correct'    => '<h2 class="vk_dynamicText wp-block-vk-blocks-dynamic-text">PrefixText%%USER_DISPLAY_NAME%%</h2>',
+			),
+
+			// ユーザー名（Suffixのみ）
+			array(
+				'attributes' => array(
+					'displayElement'           => 'user-name',
+					'tagName'                  => 'h3',
+					'userNameSuffixText' => 'SuffixText'
+				),
+				'user' => 'administrator',
+				'target_url' => get_permalink( $data['child_page_id'] ),
+				'correct'    => '<h3 class="vk_dynamicText wp-block-vk-blocks-dynamic-text">%%USER_DISPLAY_NAME%%SuffixText</h3>',
+			),	
+
+			// ユーザー名（ログアウト）
+			array(
+				'attributes' => array(
+					'displayElement'           => 'user-name',
+					'tagName'                  => 'h3',
+					'userNameSuffixText' => 'SuffixText',
+					'userNameLoggedOutText' => 'Please login!'
 				),
 				'target_url' => get_permalink( $data['child_page_id'] ),
-				'correct'    => '<span class="vk_dynamicText wp-block-vk-blocks-dynamic-text">parent_page</span>',
-			),
+				'correct'    => '<h3 class="vk_dynamicText wp-block-vk-blocks-dynamic-text">Please login!</h3>',
+			),	
 		
+			// ユーザー名（ログアウト・リンクあり）
+			array(
+				'attributes' => array(
+					'displayElement'           => 'user-name',
+					'tagName'                  => 'h3',
+					'userNameSuffixText' => 'SuffixText',
+					'userNameLoggedOutText' => 'Please login!',
+					'isLoginLink' => true
+				),
+				'target_url' => get_permalink( $data['child_page_id'] ),
+				'correct'    => '<h3 class="vk_dynamicText wp-block-vk-blocks-dynamic-text"><a href="' . wp_login_url(get_permalink( $data['child_page_id'] )) . '">Please login!</a></h3>',
+			),
+
 			// カスタムフィールド - テキスト
 			array(
 				'attributes' => array(
@@ -197,10 +247,19 @@ class DynamicText extends VK_UnitTestCase {
 		// vk_blocks_dynamic_text_render_callback() の引数として渡津 $block オブジェクトを作成する。
 		$block = new BlockObject( $data['post_id'] );
 
+		var_dump( get_permalink( $data['child_page_id'] ));
 		foreach ( $test_data as $value ) {
-
 			// Move to test page.
 			$this->go_to( $value['target_url'] );
+
+			if ( isset( $value['user'] ) ) {
+				// ユーザーを作成し、カレントユーザーにセット
+				$user = $this->set_current_user( $value['user'] );
+				$value['correct'] = str_replace('%%USER_DISPLAY_NAME%%', $user->display_name, $value['correct']);
+			} else {
+				wp_logout();
+			}
+
 			WP_Block_Supports::$block_to_render = array(
 				'blockName' => 'vk-blocks/dynamic-text',
 				'attrs'     => $value['attributes'],

--- a/test/phpunit/pro/test-dynamic-text.php
+++ b/test/phpunit/pro/test-dynamic-text.php
@@ -136,17 +136,18 @@ class DynamicText extends WP_UnitTestCase {
 				'target_url' => get_permalink( $data['parent_page_id'] ),
 				'correct'    => '<h3 class="vk_dynamicText wp-block-vk-blocks-dynamic-text">ancestor_page</h3>',
 			),
-			// 親ページのタイトル（先祖ページ有り）
+			// ユーザー名
 			array(
 				'attributes' => array(
-					'displayElement'           => 'parent-page',
-					'tagName'                  => 'span',
-					'parentPageHiddenOption' => true,
+					'displayElement'           => 'user-name',
+					'tagName'                  => 'div',
+					'userNamePrefixText' => 'こんにちは',
+					'userNameSuffixText' => 'さん',
 				),
 				'target_url' => get_permalink( $data['child_page_id'] ),
 				'correct'    => '<span class="vk_dynamicText wp-block-vk-blocks-dynamic-text">parent_page</span>',
 			),
-
+		
 			// カスタムフィールド - テキスト
 			array(
 				'attributes' => array(


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1879 

## どういう変更をしたか？

* ユーザー名を表示する機能を追加
  * ユーザー名の前後に表示するテキストが指定できる
  * 非ログイン時に表示するテキストが指定できる
  * ログイン画面へのリンクのOn/Offが指定できる

※ 翻訳は別ブランチで行います。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* レビュワー確認方法に同じ

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*  表示要素を「Current login user name」にする
* 適当なpostを作成し、ダイナミックテキストを配置する
* ログイン名ならびに「PREFIX LABEL（前につけるラベル）」「SUFFIX LABEL（後につけるラベル）」がエディタ・フロントに正常に反映されるか
*  「TEXT FOR LOGGED OUT USERS」の内容がログアウト時に反映されるかを確認する。
* 「Link to Login on Logout」をONにして、ログアウトし、テキストクリック時にログイン画面に遷移し、ログインできること、また、ログイン後にログイン前の画面に遷移することを確認する。
* 上記をサイトエディターでヘッダーなどに配置し、トップページ・アーカイブページ・各カスタム投稿タイプの記事を表示させ、それぞれ動作チェックを行う。
* その他コードなどで気になる点があればご指摘ください。
* ラベルなど英文で気になる点があればご指摘ください。

**※２人チェックでお願いします。**

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
