### PR TITLE
見出しブロックを非推奨に

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-global-settings.php
+++ b/inc/vk-blocks/class-vk-blocks-global-settings.php
@@ -72,6 +72,7 @@ class VK_Blocks_Global_Settings {
 			array(
 				'name'   => 'heading',
 				'is_pro' => false,
+				'is_deprecated' => true,
 			),
 			array(
 				'name'   => 'icon',

--- a/inc/vk-blocks/class-vk-blocks-global-settings.php
+++ b/inc/vk-blocks/class-vk-blocks-global-settings.php
@@ -70,8 +70,8 @@ class VK_Blocks_Global_Settings {
 				'is_pro' => false,
 			),
 			array(
-				'name'   => 'heading',
-				'is_pro' => false,
+				'name'          => 'heading',
+				'is_pro'        => false,
 				'is_deprecated' => true,
 			),
 			array(

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ This is a plugin that extends Gutenberg's blocks.
 * Classic FAQ
 * New FAQ
 * Flow
-* Heading（with sub text）
+* Heading (not recommended)
 * Icon
 * Icon Outer
 * Page Content
@@ -102,6 +102,8 @@ e.g.
 1. VK Blocks examples.
 
 == Changelog ==
+
+[ Other ][ Headding ] Marked as Not Recommended
 
 = 1.67.0 =
 [ Add Block ][ Category Badge (Pro) ] Creates badges displaying linked categories or terms for posts, with flexible design customization.

--- a/src/blocks/heading/block.json
+++ b/src/blocks/heading/block.json
@@ -2,7 +2,7 @@
 	"apiVersion": 2,
 	"name": "vk-blocks/heading",
 	"category": "vk-blocks-cat",
-	"title": "Heading",
+	"title": "Heading(not recommended)",
 	"attributes": {
 		"anchor": {
 			"type": "string",


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#1880 

## どういう変更をしたか？

* 見出しブロックを非推奨に変更
* #1880 のやりとりにあるように、ブロック名に（非推奨）をつけることにしました。
* 翻訳は別ブランチで行います。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* レビュワー確認方法に同じ

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* developブランチで予めVK見出しブロックを適当な場所に配置し保存してください。
* VK Blocksの設定値（ vk-blocks-options ）がDBに保存されている状態で以下のように動作するか確認してください。
  * VK Blocksの設定画面のブロックマネージャーで「VK非推奨ブロック」の中に「Headding(not recommended)」が表示されていることを確認（チェックは入っているはずです）
  * 予め保存してあるVK見出しブロックが正常に動くことを確認してください。
* クリーンインストールの状態、つまり、VK Blocksの設定値（ vk-blocks-options ）がDBに保存されていない状態にしてください。wp-env destroy を行うと良いかと思います。
  * VK Blocksの設定画面のブロックマネージャーで「VK非推奨ブロック」の中に「Headding(not recommended)」が表示されていて、チェックが入っていないことを確認してください。
  * 編集画面でVK見出しブロックがインサーターに表示されないことを確認してください。

 **1人チェック+ @kurudrive さんで確認をお願いしたいです。**

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
