### PR TITLE
[ インライン文字サイズ ] 単位を選択するとポップアップが閉じてしまうのを改善

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ e.g.
 1. VK Blocks examples.
 
 == Changelog ==
+[ Bug Fix ][ Inline Font Size ] Applies only Font Size has a numeric value.
 
 = 1.69.0 =
 [ Add function ][ Slider ] Add Slider Mode on Editor.

--- a/src/extensions/common/inline-font-size/inline.js
+++ b/src/extensions/common/inline-font-size/inline.js
@@ -70,7 +70,11 @@ function InlineFontSizePicker({ name, value, onChange, setIsSettingFontSize }) {
 	};
 
 	const onInlineFontSizeChange = (newFontSize) => {
-		if (newFontSize) {
+		if (!newFontSize) {
+			// reset font size
+			onChange(removeFormat(value, name));
+		} else if(newFontSize.match(/\d/)) {
+			// Applies only Font Size has a numeric value.
 			onChange(
 				applyFormat(value, {
 					type: name,
@@ -80,11 +84,7 @@ function InlineFontSizePicker({ name, value, onChange, setIsSettingFontSize }) {
 					},
 				})
 			);
-		} else {
-			// reset font size
-			onChange(removeFormat(value, name));
 		}
-		//setIsSettingFontSize(false);
 	};
 
 	const activeFontSize = getActiveInlineFontSize(value, name);


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 [インライン文字サイズ]単位を選択するとポップアップが閉じてしまう #1910 

## どういう変更をしたか？

* カスタムサイズで指定しようとしたとき、
初期設定の数値が空の状態で単位を変更すると FontSizePicker(ポップアップ) が閉じてしまうので、数値が入っていない場合は処理を行わないように修正しました。
* FontSizePicker を2度開かないとカスタムサイズを指定できないため、パターン作成で面倒なため対応しました


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* 段落の一部(インライン)を選択し、ツールバーよりインライン文字サイズを選択
* カスタムサイズのタブを選択する
* 最初は数値が空の状態(ここに数値が入っているときはもとから問題なし)
* 単位 px を em、rem などに変更する
* ここで FontSizePicker が閉じてしまってたので、数値を入力されているか、「適用」をクリックしないと閉じないことを確認
* 下記の画面です

![inline](https://github.com/vektor-inc/vk-blocks-pro/assets/4631838/bcbb4388-7e24-4785-b334-4158ed5b74cc)


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 実装者が確認した手順と同じです

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
