### PR TITLE
【2人目確認中】[ ボタンブロック ] 文字の色がカスタム色のとき編集画面に反映されないのを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Button ] Fixed buttonColorCustom in the editor to display the correct color.
+
 = 1.70.0 =
 [ Specification Change ] core/social-link, core/site-logo, core/site-title and core/site-tagline correspond to margin-extension
 [ Add function ][ Breadcrumb ] Add the ability to input breadcrumb separators.

--- a/src/blocks/button/component.js
+++ b/src/blocks/button/component.js
@@ -18,6 +18,7 @@ export class VKBButton extends Component {
 		const iconSizeAfter = this.props.lbIconSizeAfter;
 		const richText = this.props.lbRichtext;
 		const subCaption = this.props.lbsubCaption;
+		const isSelected = this.props.isSelected;
 		let aClass = '';
 		let aStyle = {};
 		let iconBefore = '';
@@ -74,6 +75,18 @@ export class VKBButton extends Component {
 					aClass += ` has-${buttonColorCustom}-color`;
 				}
 			}
+		}
+
+		// 文字色がカスタムカラーの場合
+		if (
+			buttonTextColorCustom !== undefined &&
+			isHexColor(buttonTextColorCustom) &&
+			isSelected
+		) {
+			aStyle = {
+				// 編集画面対策
+				color: `${buttonTextColorCustom}`,
+			};
 		}
 
 		aClass = `${aClass} btn-${buttonSize}`;

--- a/src/blocks/button/component.js
+++ b/src/blocks/button/component.js
@@ -20,11 +20,9 @@ export class VKBButton extends Component {
 		const subCaption = this.props.lbsubCaption;
 		const inlineStyle = this.props.inlineStyle;
 		let aClass = '';
-		let aStyle = {};
 		let iconBefore = '';
 		let iconAfter = '';
 
-		aStyle = null;
 		aClass = `vk_button_link`;
 
 		// 塗り

--- a/src/blocks/button/component.js
+++ b/src/blocks/button/component.js
@@ -18,7 +18,7 @@ export class VKBButton extends Component {
 		const iconSizeAfter = this.props.lbIconSizeAfter;
 		const richText = this.props.lbRichtext;
 		const subCaption = this.props.lbsubCaption;
-		const isSelected = this.props.isSelected;
+		const inlineStyle = this.props.inlineStyle;
 		let aClass = '';
 		let aStyle = {};
 		let iconBefore = '';
@@ -78,6 +78,7 @@ export class VKBButton extends Component {
 		}
 
 		// 文字色がカスタムカラーの場合
+		/*
 		if (
 			buttonTextColorCustom !== undefined &&
 			isHexColor(buttonTextColorCustom) &&
@@ -88,6 +89,7 @@ export class VKBButton extends Component {
 				color: `${buttonTextColorCustom}`,
 			};
 		}
+		*/
 
 		aClass = `${aClass} btn-${buttonSize}`;
 
@@ -126,7 +128,7 @@ export class VKBButton extends Component {
 			/* eslint react/jsx-no-target-blank: 0 */
 			<a
 				href={buttonUrl}
-				style={aStyle}
+				style={inlineStyle}
 				className={aClass}
 				role={'button'}
 				aria-pressed={true}

--- a/src/blocks/button/deprecated/hooks/index.js
+++ b/src/blocks/button/deprecated/hooks/index.js
@@ -6,6 +6,7 @@ import ButtonHook1_39_2 from './1.39.2';
 
 // saveの数分必要
 export default [
+	ButtonHook1_39_2, // 1.71.0
 	ButtonHook1_39_2,
 	ButtonHook1_39_2,
 	ButtonHook1_29_2,

--- a/src/blocks/button/deprecated/save/1.70.1/component.js
+++ b/src/blocks/button/deprecated/save/1.70.1/component.js
@@ -1,0 +1,135 @@
+import { Component } from '@wordpress/element';
+import parse from 'html-react-parser';
+import { isHexColor } from '@vkblocks/utils/is-hex-color';
+
+export class VKBButton extends Component {
+	render() {
+		const buttonTextColorCustom = this.props.lbTextColorCustom;
+		const buttonColorCustom = this.props.lbColorCustom;
+		const buttonColor = this.props.lbColor;
+		const buttonType = this.props.lbType;
+		const buttonAlign = this.props.lbAlign;
+		const buttonSize = this.props.lbSize;
+		const buttonUrl = this.props.lbUrl;
+		const buttonTarget = this.props.lbTarget;
+		let fontAwesomeIconBefore = this.props.lbFontAwesomeIconBefore;
+		let fontAwesomeIconAfter = this.props.lbFontAwesomeIconAfter;
+		const iconSizeBefore = this.props.lbIconSizeBefore;
+		const iconSizeAfter = this.props.lbIconSizeAfter;
+		const richText = this.props.lbRichtext;
+		const subCaption = this.props.lbsubCaption;
+		let aClass = '';
+		let aStyle = {};
+		let iconBefore = '';
+		let iconAfter = '';
+
+		aStyle = null;
+		aClass = `vk_button_link`;
+
+		// 塗り
+		if (buttonType === '0' || buttonType === null) {
+			// 規定カラーの場合
+			if (buttonColor !== 'custom' && buttonColorCustom === undefined) {
+				aClass += ` btn has-background has-vk-color-${buttonColor}-background-color`;
+			} else {
+				aClass += ` btn has-background`;
+				// カスタムパレットカラーの場合
+				if (!isHexColor(buttonColorCustom)) {
+					aClass += ` has-${buttonColorCustom}-background-color`;
+				}
+			}
+
+			// 文字色
+			if (
+				buttonColor === 'custom' &&
+				buttonTextColorCustom !== undefined
+			) {
+				aClass += ` btn has-text-color`;
+				// カスタムパレットカラーの場合
+				if (!isHexColor(buttonTextColorCustom)) {
+					aClass += ` has-${buttonTextColorCustom}-color`;
+				}
+			}
+			// 塗りなし
+		} else if (buttonType === '1') {
+			// 規定カラーの場合
+			if (buttonColor !== 'custom' && buttonColorCustom === undefined) {
+				aClass += ` btn has-text-color is-style-outline has-vk-color-${buttonColor}-color`;
+			} else {
+				aClass += ` btn has-text-color is-style-outline`;
+				// カスタムパレットカラーの場合
+				if (!isHexColor(buttonColorCustom)) {
+					aClass += ` has-${buttonColorCustom}-color`;
+				}
+			}
+			// テキストのみ
+		} else if (buttonType === '2') {
+			// 規定カラーの場合
+			if (buttonColor !== 'custom' && buttonColorCustom === undefined) {
+				aClass += ` has-text-color vk_button_link-type-text has-vk-color-${buttonColor}-color`;
+			} else {
+				aClass += ` has-text-color vk_button_link-type-text`;
+				// カスタムパレットカラーの場合
+				if (!isHexColor(buttonColorCustom)) {
+					aClass += ` has-${buttonColorCustom}-color`;
+				}
+			}
+		}
+
+		aClass = `${aClass} btn-${buttonSize}`;
+
+		if (buttonAlign === 'block') {
+			aClass = `${aClass} btn-block`;
+		}
+
+		//過去バージョンをリカバリーした時にiconを正常に表示する
+		if (fontAwesomeIconBefore && !fontAwesomeIconBefore.match(/<i/)) {
+			fontAwesomeIconBefore = `<i class="${fontAwesomeIconBefore}"></i>`;
+		}
+		if (fontAwesomeIconAfter && !fontAwesomeIconAfter.match(/<i/)) {
+			fontAwesomeIconAfter = `<i class="${fontAwesomeIconAfter}"></i>`;
+		}
+
+		if (fontAwesomeIconBefore) {
+			let fontAwesomeIconBeforeClassName =
+				fontAwesomeIconBefore.match(/class="(.*?)"/)[1];
+			fontAwesomeIconBeforeClassName += ` vk_button_link_before`;
+			const styleBefore = iconSizeBefore
+				? ` style='font-size: ${iconSizeBefore}'`
+				: '';
+			iconBefore = `<i class="${fontAwesomeIconBeforeClassName}"${styleBefore}></i>`;
+		}
+		if (fontAwesomeIconAfter) {
+			let fontAwesomeIconAfterClassName =
+				fontAwesomeIconAfter.match(/class="(.*?)"/)[1];
+			fontAwesomeIconAfterClassName += ` vk_button_link_after`;
+			const styleAfter = iconSizeAfter
+				? ` style='font-size: ${iconSizeAfter}'`
+				: '';
+			iconAfter = `<i class="${fontAwesomeIconAfterClassName}"${styleAfter}></i>`;
+		}
+
+		return (
+			/* eslint react/jsx-no-target-blank: 0 */
+			<a
+				href={buttonUrl}
+				style={aStyle}
+				className={aClass}
+				role={'button'}
+				aria-pressed={true}
+				target={buttonTarget ? '_blank' : null}
+				rel={'noopener'}
+			>
+				<div className={'vk_button_link_caption'}>
+					{parse(iconBefore)}
+					{richText}
+					{parse(iconAfter)}
+				</div>
+				{/*サブキャプションが入力された時のみ表示*/}
+				{subCaption && (
+					<p className={'vk_button_link_subCaption'}>{subCaption}</p>
+				)}
+			</a>
+		);
+	}
+}

--- a/src/blocks/button/deprecated/save/1.70.1/save.js
+++ b/src/blocks/button/deprecated/save/1.70.1/save.js
@@ -1,0 +1,93 @@
+import { VKBButton } from './component';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { isHexColor } from '@vkblocks/utils/is-hex-color';
+
+export default function save(props) {
+	const { attributes } = props;
+	const {
+		content,
+		subCaption,
+		buttonUrl,
+		buttonTarget,
+		buttonSize,
+		buttonType,
+		buttonEffect,
+		buttonColor,
+		buttonTextColorCustom,
+		buttonColorCustom,
+		buttonAlign,
+		buttonWidthMobile,
+		buttonWidthTablet,
+		buttonWidth,
+		outerGap,
+		fontAwesomeIconBefore,
+		fontAwesomeIconAfter,
+		iconSizeBefore,
+		iconSizeAfter,
+		blockId,
+	} = attributes;
+
+	let containerClass = '';
+	// カスタムカラーの場合 またはアウターにギャップが指定されれいる場合
+	if (
+		(buttonColorCustom !== undefined && isHexColor(buttonColorCustom)) ||
+		(buttonTextColorCustom !== undefined &&
+			isHexColor(buttonTextColorCustom)) ||
+		outerGap
+	) {
+		containerClass = `vk_button vk_button-color-custom vk_button-${blockId}`;
+	} else {
+		containerClass = `vk_button vk_button-color-custom`;
+	}
+
+	if (buttonWidthMobile || buttonWidthTablet || buttonWidth) {
+		// 横並びボタンで幅が指定されている
+		if (buttonWidthMobile) {
+			containerClass += ` vk_button-width-mobile-${buttonWidthMobile}`;
+		}
+		if (buttonWidthTablet) {
+			containerClass += ` vk_button-width-tablet-${buttonWidthTablet}`;
+		}
+		if (buttonWidth) {
+			containerClass += ` vk_button-width-${buttonWidth}`;
+		}
+	} else {
+		containerClass += ` vk_button-align-${buttonAlign}`;
+	}
+
+	// エフェクト
+	if (buttonEffect !== '') {
+		containerClass += ` is-style-${buttonEffect}`;
+	}
+
+	const blockProps = useBlockProps.save({
+		className: containerClass,
+	});
+
+	return (
+		<div {...blockProps}>
+			<VKBButton
+				lbTextColorCustom={buttonTextColorCustom}
+				lbColorCustom={buttonColorCustom}
+				lbColor={buttonColor}
+				lbType={buttonType}
+				lbAlign={buttonAlign}
+				lbSize={buttonSize}
+				lbUrl={buttonUrl}
+				lbTarget={buttonTarget}
+				lbFontAwesomeIconBefore={fontAwesomeIconBefore}
+				lbFontAwesomeIconAfter={fontAwesomeIconAfter}
+				lbIconSizeBefore={iconSizeBefore}
+				lbIconSizeAfter={iconSizeAfter}
+				lbsubCaption={subCaption}
+				lbRichtext={
+					<RichText.Content
+						tagName={'span'}
+						className={'vk_button_link_txt'}
+						value={content}
+					/>
+				}
+			/>
+		</div>
+	);
+}

--- a/src/blocks/button/deprecated/save/index.js
+++ b/src/blocks/button/deprecated/save/index.js
@@ -7,6 +7,7 @@ import save1_31_0 from './1.31.0/save';
 import save1_35_0 from './1.35.0/save';
 import save1_39_2 from './1.39.2/save';
 import save1_43_0 from './1.43.0/save';
+import save1_70_1 from './1.70.1/save';
 
 const blockAttributes = {
 	content: {
@@ -148,7 +149,6 @@ const blockAttributes10 = {
 	},
 };
 
-/* 次回対応おねがいします
 const blockAttributes11 = {
 	...blockAttributes10,
 	buttonEffect: {
@@ -156,9 +156,13 @@ const blockAttributes11 = {
 		default: ''
 	},
 }
-*/
+
 
 export const deprecated = [
+	{
+		attributes: blockAttributes11,
+		save: save1_70_1,
+	},
 	{
 		attributes: blockAttributes10,
 		save: save1_43_0,

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -810,6 +810,7 @@ export default function ButtonEdit(props) {
 					lbIconSizeBefore={iconSizeBefore}
 					lbIconSizeAfter={iconSizeAfter}
 					lbsubCaption={subCaption}
+					isSelected={true}
 					lbRichtext={
 						<RichText
 							tagName={'span'}

--- a/src/blocks/button/edit.js
+++ b/src/blocks/button/edit.js
@@ -207,6 +207,17 @@ export default function ButtonEdit(props) {
 		className: containerClass,
 	});
 
+	let inlineStyle = {};
+	if (
+		buttonTextColorCustom !== undefined &&
+		isHexColor(buttonTextColorCustom)
+	) {
+		inlineStyle = {
+			// 編集画面対策
+			color: `${buttonTextColorCustom}`,
+		};
+	}
+
 	return (
 		<>
 			<BlockControls>
@@ -810,7 +821,7 @@ export default function ButtonEdit(props) {
 					lbIconSizeBefore={iconSizeBefore}
 					lbIconSizeAfter={iconSizeAfter}
 					lbsubCaption={subCaption}
-					isSelected={true}
+					inlineStyle={inlineStyle}
 					lbRichtext={
 						<RichText
 							tagName={'span'}
@@ -836,7 +847,7 @@ export default function ButtonEdit(props) {
 								'vk-blocks/nowrap',
 								'vk-blocks/inline-font-size',
 							]}
-							isSelected={true}
+							inlineStyle={inlineStyle}
 						/>
 					}
 				/>


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 [ ボタンブロック ] 背景を白にした時に文字色が効かないので直したい #1937 

## どういう変更をしたか？

* 調べたところ「背景を白にした」の問題ではなく、文字の色がカスタム色のときだけ編集画面に反映されない現象でした
* 原因はコアのグループブロックが編集画面で、配下の要素に強制的にグループブロックの文字色を指定しているためでした
* ですので、VKボタンがグループの中にあり、グループの文字色が設定されている場合に発生します
* VKボタンは `<style>` で文字色を指定していますが、編集画面では上記に負けてしまうようです
* VKボタンで文字の色がカスタム色の場合は、編集画面のみインラインで文字色を指定するようにしました

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。
**[再現方法]**
* グループブロックのなかに [VKボタン] を設置する
* グループブロックの文字色を指定する
* [VKボタン] で文字の色をカスタム色に設定したとき、グループブロックの文字色で表示されてしまう(編集画面のみ)

**[確認方法]**
* 上記 [再現方法] の状態から、VKボタンで文字の色が編集画面で表示される
* [VKボタン] で文字の色をカスタム色の場合、編集画面のみ VKボタンの `<a> `要素に `style `属性で `color` が指定される
* 文字の色がカスタム色でない場合、 `<a> `要素に `style `属性は出力されない
* フロントエンドでは、VKボタンの `<a> `要素に `style `属性は出力されない → 従来どおり、スタイルは別途 `<style> `タグで出力される
* 文字の色をカスタム色でない場合も確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 実装者の確認事項と同じです
* 発生していたブロックパターンをコメント欄に添付します
* 編集画面の修正ですので、deprecated はいらないかな？と思います、もし必要でしたら教えてください！
  * ここ不安ですので、デザイナーさんのほか開発のかたにコード見てもらえると助かります

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
