### PR TITLE
【２人目確認中】[ 子ページリスト ] 表示要素の中の「画像右上分類名」と「分類」を非表示にしました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification Change ][ Child Page List ] Hide "Term's name on Image" and "Taxonomies (all)" display options.
+
 = 1.70.0 =
 [ Specification Change ] core/social-link, core/site-logo, core/site-title and core/site-tagline correspond to margin-extension
 [ Add function ][ Breadcrumb ] Add the ability to input breadcrumb separators.

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -93,7 +93,7 @@ export const DisplayItemsControl = (props) => {
 					'Number of days to display the new post mark',
 					'vk-blocks-pro'
 				)}
-				value={new_date}
+				value={new_date} //eslint-disable-line camelcase
 				onChange={(value) =>
 					setAttributes({ new_date: parseInt(value) })
 				}
@@ -123,7 +123,7 @@ export const DisplayItemsControl = (props) => {
 				id={'vk_displayItem-buttonAlign'}
 			>
 				<SelectControl
-					value={btn_align}
+					value={btn_align} //eslint-disable-line camelcase
 					onChange={(value) => setAttributes({ btn_align: value })}
 					options={[
 						{

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -35,7 +35,7 @@ export const DisplayItemsControl = (props) => {
 		>
 			<CheckboxControl
 				label={__('Image', 'vk-blocks-pro')}
-				checked={display_image}
+				checked={display_image} //eslint-disable-line camelcase
 				onChange={(checked) =>
 					setAttributes({ display_image: checked })
 				}

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -10,18 +10,18 @@ import {
 export const DisplayItemsControl = (props) => {
 	const { setAttributes, attributes } = props;
 	const {
-		display_image,
-		display_image_overlay_term,
-		display_excerpt,
-		display_author,
-		display_date,
-		display_new,
-		display_taxonomies,
-		display_btn,
-		new_date,
-		new_text,
-		btn_text,
-		btn_align,
+		display_image, //eslint-disable-line camelcase
+		display_image_overlay_term, //eslint-disable-line camelcase
+		display_excerpt, //eslint-disable-line camelcase
+		display_author, //eslint-disable-line camelcase
+		display_date, //eslint-disable-line camelcase
+		display_new, //eslint-disable-line camelcase
+		display_taxonomies, //eslint-disable-line camelcase
+		display_btn, //eslint-disable-line camelcase
+		new_date, //eslint-disable-line camelcase
+		new_text, //eslint-disable-line camelcase
+		btn_text, //eslint-disable-line camelcase
+		btn_align, //eslint-disable-line camelcase
 	} = attributes;
 
 	// 「子ページリスト」ブロックかどうかをチェック

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -27,7 +27,6 @@ export const DisplayItemsControl = (props) => {
 	// 「子ページリスト」ブロックかどうかをチェック
 	const isChildPageList = props.name === 'vk-blocks/child-page';
 
-
 	return (
 		<PanelBody
 			title={__('Display item', 'vk-blocks-pro')}
@@ -79,7 +78,9 @@ export const DisplayItemsControl = (props) => {
 				<CheckboxControl
 					label={__('Taxonomies (all)', 'vk-blocks-pro')}
 					checked={display_taxonomies} //eslint-disable-line camelcase
-					onChange={(checked) =>setAttributes({ display_taxonomies: checked })}
+					onChange={(checked) =>
+						setAttributes({ display_taxonomies: checked })
+					}
 				/>
 			)}
 			<CheckboxControl

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -51,7 +51,7 @@ export const DisplayItemsControl = (props) => {
 			{!isChildPageList && (
 				<CheckboxControl
 					label={__("Term's name on Image", 'vk-blocks-pro')}
-					checked={display_image_overlay_term}
+					checked={display_image_overlay_term} //eslint-disable-line camelcase
 					onChange={(checked) =>
 						setAttributes({ display_image_overlay_term: checked })
 					}
@@ -59,26 +59,26 @@ export const DisplayItemsControl = (props) => {
 			)}
 			<CheckboxControl
 				label={__('Excerpt', 'vk-blocks-pro')}
-				checked={display_excerpt}
+				checked={display_excerpt} //eslint-disable-line camelcase
 				onChange={(checked) =>
 					setAttributes({ display_excerpt: checked })
 				}
 			/>
 			<CheckboxControl
 				label={__('Author', 'vk-blocks-pro')}
-				checked={display_author}
+				checked={display_author} //eslint-disable-line camelcase
 				onChange={(checked) =>
 					setAttributes({ display_author: checked })
 				}
 			/>
 			<CheckboxControl
 				label={__('Date', 'vk-blocks-pro')}
-				checked={display_date}
+				checked={display_date} //eslint-disable-line camelcase
 				onChange={(checked) => setAttributes({ display_date: checked })}
 			/>
 			<CheckboxControl
 				label={__('New mark', 'vk-blocks-pro')}
-				checked={display_new}
+				checked={display_new} //eslint-disable-line camelcase
 				onChange={(checked) => setAttributes({ display_new: checked })}
 			/>
 			{/*  「子ページリスト」ブロックの場合、分類（全項目）を表示しない */}

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -100,8 +100,8 @@ export const DisplayItemsControl = (props) => {
 				type={'number'}
 			/>
 			<TextControl
-				label={__('New post mark', 'vk-blocks-pro')} //eslint-disable-line camelcase
-				value={new_text}
+				label={__('New post mark', 'vk-blocks-pro')}
+				value={new_text} //eslint-disable-line camelcase
 				onChange={(value) => setAttributes({ new_text: value })}
 			/>
 			<h4 className={'postList_itemCard_button-option'}>
@@ -115,7 +115,7 @@ export const DisplayItemsControl = (props) => {
 			</p>
 			<TextControl
 				label={__('Button text', 'vk-blocks-pro')}
-				value={btn_text}
+				value={btn_text} //eslint-disable-line camelcase
 				onChange={(value) => setAttributes({ btn_text: value })}
 			/>
 			<BaseControl

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -10,19 +10,23 @@ import {
 export const DisplayItemsControl = (props) => {
 	const { setAttributes, attributes } = props;
 	const {
-		display_image, //eslint-disable-line camelcase
-		display_image_overlay_term, //eslint-disable-line camelcase
-		display_excerpt, //eslint-disable-line camelcase
-		display_author, //eslint-disable-line camelcase
-		display_date, //eslint-disable-line camelcase
-		display_new, //eslint-disable-line camelcase
-		display_taxonomies, //eslint-disable-line camelcase
-		display_btn, //eslint-disable-line camelcase
-		new_date, //eslint-disable-line camelcase
-		new_text, //eslint-disable-line camelcase
-		btn_text, //eslint-disable-line camelcase
-		btn_align, //eslint-disable-line camelcase
+		display_image,
+		display_image_overlay_term,
+		display_excerpt,
+		display_author,
+		display_date,
+		display_new,
+		display_taxonomies,
+		display_btn,
+		new_date,
+		new_text,
+		btn_text,
+		btn_align,
 	} = attributes;
+
+	// 「子ページリスト」ブロックかどうかをチェック
+	const isChildPageList = props.name === 'vk-blocks/child-page';
+
 
 	return (
 		<PanelBody
@@ -31,55 +35,58 @@ export const DisplayItemsControl = (props) => {
 		>
 			<CheckboxControl
 				label={__('Image', 'vk-blocks-pro')}
-				checked={display_image} //eslint-disable-line camelcase
+				checked={display_image}
 				onChange={(checked) =>
 					setAttributes({ display_image: checked })
 				}
 			/>
-			<CheckboxControl
-				label={__("Term's name on Image", 'vk-blocks-pro')}
-				checked={display_image_overlay_term} //eslint-disable-line camelcase
-				onChange={(checked) =>
-					setAttributes({ display_image_overlay_term: checked })
-				}
-			/>
+			{/*  「子ページリスト」ブロックの場合、画像右上分類名を表示しない */}
+			{!isChildPageList && (
+				<CheckboxControl
+					label={__("Term's name on Image", 'vk-blocks-pro')}
+					checked={display_image_overlay_term}
+					onChange={(checked) =>
+						setAttributes({ display_image_overlay_term: checked })
+					}
+				/>
+			)}
 			<CheckboxControl
 				label={__('Excerpt', 'vk-blocks-pro')}
-				checked={display_excerpt} //eslint-disable-line camelcase
+				checked={display_excerpt}
 				onChange={(checked) =>
 					setAttributes({ display_excerpt: checked })
 				}
 			/>
 			<CheckboxControl
 				label={__('Author', 'vk-blocks-pro')}
-				checked={display_author} //eslint-disable-line camelcase
+				checked={display_author}
 				onChange={(checked) =>
 					setAttributes({ display_author: checked })
 				}
 			/>
 			<CheckboxControl
 				label={__('Date', 'vk-blocks-pro')}
-				checked={display_date} //eslint-disable-line camelcase
+				checked={display_date}
 				onChange={(checked) => setAttributes({ display_date: checked })}
 			/>
-
 			<CheckboxControl
 				label={__('New mark', 'vk-blocks-pro')}
-				checked={display_new} //eslint-disable-line camelcase
+				checked={display_new}
 				onChange={(checked) => setAttributes({ display_new: checked })}
 			/>
-
-			<CheckboxControl
-				label={__('Taxonomies (all)', 'vk-blocks-pro')}
-				checked={display_taxonomies} //eslint-disable-line camelcase
-				onChange={(checked) =>
-					setAttributes({ display_taxonomies: checked })
-				}
-			/>
-
+			{/*  「子ページリスト」ブロックの場合、分類（全項目）を表示しない */}
+			{!isChildPageList && (
+				<CheckboxControl
+					label={__('Taxonomies (all)', 'vk-blocks-pro')}
+					checked={display_taxonomies}
+					onChange={(checked) =>
+						setAttributes({ display_taxonomies: checked })
+					}
+				/>
+			)}
 			<CheckboxControl
 				label={__('Button', 'vk-blocks-pro')}
-				checked={display_btn} //eslint-disable-line camelcase
+				checked={display_btn}
 				onChange={(checked) => setAttributes({ display_btn: checked })}
 			/>
 			<h4>{__('New mark option', 'vk-blocks-pro')}</h4>
@@ -88,7 +95,7 @@ export const DisplayItemsControl = (props) => {
 					'Number of days to display the new post mark',
 					'vk-blocks-pro'
 				)}
-				value={new_date} //eslint-disable-line camelcase
+				value={new_date}
 				onChange={(value) =>
 					setAttributes({ new_date: parseInt(value) })
 				}
@@ -96,7 +103,7 @@ export const DisplayItemsControl = (props) => {
 			/>
 			<TextControl
 				label={__('New post mark', 'vk-blocks-pro')}
-				value={new_text} //eslint-disable-line camelcase
+				value={new_text}
 				onChange={(value) => setAttributes({ new_text: value })}
 			/>
 			<h4 className={'postList_itemCard_button-option'}>
@@ -110,7 +117,7 @@ export const DisplayItemsControl = (props) => {
 			</p>
 			<TextControl
 				label={__('Button text', 'vk-blocks-pro')}
-				value={btn_text} //eslint-disable-line camelcase
+				value={btn_text}
 				onChange={(value) => setAttributes({ btn_text: value })}
 			/>
 			<BaseControl
@@ -118,7 +125,7 @@ export const DisplayItemsControl = (props) => {
 				id={'vk_displayItem-buttonAlign'}
 			>
 				<SelectControl
-					value={btn_align} //eslint-disable-line camelcase
+					value={btn_align}
 					onChange={(value) => setAttributes({ btn_align: value })}
 					options={[
 						{

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -40,13 +40,6 @@ export const DisplayItemsControl = (props) => {
 					setAttributes({ display_image: checked })
 				}
 			/>
-			<CheckboxControl
-				label={__("Term's name on Image", 'vk-blocks-pro')}
-				checked={display_image_overlay_term} //eslint-disable-line camelcase
-				onChange={(checked) =>
-					setAttributes({ display_image_overlay_term: checked })
-				}
-			/>
 			{/*  「子ページリスト」ブロックの場合、画像右上分類名を表示しない */}
 			{!isChildPageList && (
 				<CheckboxControl
@@ -85,10 +78,8 @@ export const DisplayItemsControl = (props) => {
 			{!isChildPageList && (
 				<CheckboxControl
 					label={__('Taxonomies (all)', 'vk-blocks-pro')}
-					checked={display_taxonomies}
-					onChange={(checked) =>
-						setAttributes({ display_taxonomies: checked })
-					}
+					checked={display_taxonomies} //eslint-disable-line camelcase
+					onChange={(checked) =>setAttributes({ display_taxonomies: checked })}
 				/>
 			)}
 			<CheckboxControl

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -84,7 +84,7 @@ export const DisplayItemsControl = (props) => {
 			)}
 			<CheckboxControl
 				label={__('Button', 'vk-blocks-pro')}
-				checked={display_btn}
+				checked={display_btn} //eslint-disable-line camelcase
 				onChange={(checked) => setAttributes({ display_btn: checked })}
 			/>
 			<h4>{__('New mark option', 'vk-blocks-pro')}</h4>
@@ -100,7 +100,7 @@ export const DisplayItemsControl = (props) => {
 				type={'number'}
 			/>
 			<TextControl
-				label={__('New post mark', 'vk-blocks-pro')}
+				label={__('New post mark', 'vk-blocks-pro')} //eslint-disable-line camelcase
 				value={new_text}
 				onChange={(value) => setAttributes({ new_text: value })}
 			/>

--- a/src/components/display-items-control/index.js
+++ b/src/components/display-items-control/index.js
@@ -40,6 +40,13 @@ export const DisplayItemsControl = (props) => {
 					setAttributes({ display_image: checked })
 				}
 			/>
+			<CheckboxControl
+				label={__("Term's name on Image", 'vk-blocks-pro')}
+				checked={display_image_overlay_term} //eslint-disable-line camelcase
+				onChange={(checked) =>
+					setAttributes({ display_image_overlay_term: checked })
+				}
+			/>
 			{/*  「子ページリスト」ブロックの場合、画像右上分類名を表示しない */}
 			{!isChildPageList && (
 				<CheckboxControl


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#1113

↑上記のissueのタイトルが途中から【相談】が削除されていたので、実装を行うかもしれないと思い作業しました。

## どういう変更をしたか？

子ページリストブロックで表示要素の中の「画像右上分類名」と「分類」を非表示にしました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？
子ページリストの他に表示要素を使っているブロックで「画像右上分類名」と「分類」が表示されていることを確認しました。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* 編集画面で「子ページリスト」ブロックを配置
* 表示要素の中から「画像右上分類名」と「分類」がなくなっていることを確認
* 投稿リストや選択投稿リストブロックでは使われている表示要素では「画像右上分類名」と「分類」が表示されていることを確認

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 編集画面で「子ページリスト」ブロックを配置します。
* 表示要素の中から「画像右上分類名」と「分類」がなくなっていることを確認してください。
* 投稿リストや選択投稿リストブロックでは使われている表示要素では「画像右上分類名」と「分類」が表示されていることを確認してください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
