### PR TITLE
【2人めコード確認待ち（丸山さんかリックさん）】[ アイコン ] ベタ塗りのとき背景色とアイコンの色を指定できるようにしました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ e.g.
 
 == Changelog ==
 
+[ Add Function ][ icon ] Add Font color option in solid type icon
 [ Design Bug Fix ]Fixed margin-block-start being attached to flow block
 
 = 1.70.0 =

--- a/src/blocks/icon/block.json
+++ b/src/blocks/icon/block.json
@@ -39,6 +39,9 @@
 		"iconColor": {
 			"type": "string"
 		},
+		"iconFontColor": {
+			"type": "string"
+		},
 		"iconUrl": {
 			"type": "string"
 		},

--- a/src/blocks/icon/component.js
+++ b/src/blocks/icon/component.js
@@ -126,7 +126,7 @@ export class VKBIcon extends Component {
 					fontClass += ` has-text-color has-${iconFontColor}-color `;
 				}
 			}
-			
+
 			// add class and inline css
 			const faIconFragment = fontAwesomeIcon.split(' ');
 			faIconFragment[0] = faIconFragment[0] + ` style="${fontStyle};"`;

--- a/src/blocks/icon/component.js
+++ b/src/blocks/icon/component.js
@@ -13,6 +13,7 @@ export class VKBIcon extends Component {
 		const iconAlign = this.props.lbAlign;
 		const iconType = this.props.lbType;
 		const iconColor = this.props.lbColor;
+		const iconFontColor = this.props.lbFontColor;
 		const iconUrl = this.props.lbUrl;
 		const iconTarget = this.props.lbTarget;
 
@@ -105,15 +106,31 @@ export class VKBIcon extends Component {
 			fontAwesomeIcon = fontAwesomeIcon.replace(/ fas/g, 'fas');
 
 			// font size
-			let size = null;
+			let fontStyle = ``;
+			let fontClass = ` vk_icon_font `;
 			if (!(iconSize === 36 && iconSizeUnit === 'px')) {
-				size = ` font-size:${iconSize}${iconSizeUnit}`;
+				fontStyle = ` font-size:${iconSize}${iconSizeUnit};`;
 			}
 
+			// icon color
+			if (
+				iconFontColor !== 'undefined' &&
+				iconFontColor !== null &&
+				iconFontColor !== undefined
+			) {
+				if (isHexColor(iconFontColor)) {
+					// custom color
+					fontStyle += ` color:${iconFontColor};`;
+				} else {
+					// palette color
+					fontClass += ` has-text-color has-${iconFontColor}-color `;
+				}
+			}
+			
 			// add class and inline css
 			const faIconFragment = fontAwesomeIcon.split(' ');
-			faIconFragment[0] = faIconFragment[0] + ` style="${size};"`;
-			faIconFragment[1] = ' ' + faIconFragment[1] + ` vk_icon_font `;
+			faIconFragment[0] = faIconFragment[0] + ` style="${fontStyle};"`;
+			faIconFragment[1] = ' ' + faIconFragment[1] + fontClass;
 			faIconTag = faIconFragment.join('');
 		}
 

--- a/src/blocks/icon/deprecated/1.70.0/component.js
+++ b/src/blocks/icon/deprecated/1.70.0/component.js
@@ -1,0 +1,154 @@
+import { Component } from '@wordpress/element';
+import parse from 'html-react-parser';
+import { isHexColor } from '@vkblocks/utils/is-hex-color';
+
+export class VKBIcon extends Component {
+	render() {
+		let fontAwesomeIcon = this.props.lbFontAwesomeIcon;
+		const iconSize = this.props.lbSize;
+		const iconSizeUnit = this.props.lbSizeUnit;
+		const iconMargin = this.props.lbMargin;
+		const iconMarginUnit = this.props.lbMarginUnit;
+		const iconRadius = this.props.lbRadius;
+		const iconAlign = this.props.lbAlign;
+		const iconType = this.props.lbType;
+		const iconColor = this.props.lbColor;
+		const iconUrl = this.props.lbUrl;
+		const iconTarget = this.props.lbTarget;
+
+		// outer & align
+		let outerClass = 'vk_icon_frame';
+		if (iconAlign === 'center') {
+			outerClass += ' text-center';
+		} else if (iconAlign === 'right') {
+			outerClass += ' text-right';
+		}
+
+		// color style
+		let borderClass = 'vk_icon_border';
+		let borderStyle = {};
+
+		if (iconType === '0') {
+			// Solid color
+			if (
+				iconColor !== 'undefined' &&
+				iconColor !== null &&
+				iconColor !== undefined
+			) {
+				// Solid color
+				borderClass += ` has-background`;
+
+				if (isHexColor(iconColor)) {
+					// custom color
+					borderStyle = {
+						backgroundColor: `${iconColor}`,
+					};
+				} else {
+					// palette color
+					borderClass += ` has-${iconColor}-background-color`;
+				}
+			}
+		} else {
+			if (
+				iconColor !== 'undefined' &&
+				iconColor !== null &&
+				iconColor !== undefined
+			) {
+				borderClass += ` has-text-color`;
+
+				if (isHexColor(iconColor)) {
+					// custom color
+					borderStyle = {
+						color: `${iconColor}`,
+					};
+				} else {
+					// palette color
+					borderClass += ` has-${iconColor}-color`;
+				}
+			}
+
+			if (iconType === '1') {
+				// Icon & Frame
+				outerClass += ' is-style-outline';
+			} else {
+				// icon only
+				outerClass += ' is-style-noline';
+			}
+		}
+
+		// margin
+		if (
+			!(
+				iconSize === 36 &&
+				iconSizeUnit === 'px' &&
+				iconMargin === 22 &&
+				iconMarginUnit === 'px'
+			)
+		) {
+			borderStyle.width =
+				'calc(' +
+				(iconSize + iconSizeUnit) +
+				' + ' +
+				(iconMargin * 2 + iconMarginUnit) +
+				')';
+			borderStyle.height = borderStyle.width;
+		}
+
+		// border radius
+		if (iconRadius !== 50) {
+			borderStyle.borderRadius = iconRadius + `%`;
+		}
+
+		// icon font
+		let faIconTag = '';
+		if (fontAwesomeIcon) {
+			fontAwesomeIcon = fontAwesomeIcon.replace(/ fas/g, 'fas');
+
+			// font size
+			let size = null;
+			if (!(iconSize === 36 && iconSizeUnit === 'px')) {
+				size = ` font-size:${iconSize}${iconSizeUnit}`;
+			}
+
+			// add class and inline css
+			const faIconFragment = fontAwesomeIcon.split(' ');
+			faIconFragment[0] = faIconFragment[0] + ` style="${size};"`;
+			faIconFragment[1] = ' ' + faIconFragment[1] + ` vk_icon_font `;
+			faIconTag = faIconFragment.join('');
+		}
+
+		const blockContent = (
+			<>
+				<div className={borderClass} style={borderStyle}>
+					{parse(faIconTag)}
+				</div>
+			</>
+		);
+
+		let blockContentWrapper = '';
+		if (iconUrl !== null && iconUrl !== undefined && iconUrl !== '') {
+			blockContentWrapper = (
+				/*
+				 target=_blankで指定すると、WordPressが自動でnoopener noreferrerを付与する。
+				 ブロックでもrelを付与しないとブロックが壊れる。
+				 */
+				<a
+					href={iconUrl}
+					className="vk_icon_link"
+					target={iconTarget && '_blank'}
+					rel={iconTarget && 'noopener noreferrer'}
+				>
+					{blockContent}
+				</a>
+			);
+		} else {
+			blockContentWrapper = blockContent;
+		}
+
+		return (
+			<>
+				<div className={outerClass}>{blockContentWrapper}</div>
+			</>
+		);
+	}
+}

--- a/src/blocks/icon/deprecated/1.70.0/save.js
+++ b/src/blocks/icon/deprecated/1.70.0/save.js
@@ -1,0 +1,44 @@
+import { VKBIcon } from './component';
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function save({ attributes }) {
+	let {
+		faIcon,
+		iconSize,
+		iconSizeUnit,
+		iconMargin,
+		iconMarginUnit,
+		iconRadius,
+		iconAlign,
+		iconType,
+		iconColor,
+		iconUrl,
+		iconTarget,
+	} = attributes;
+
+	if (faIcon && !faIcon.match(/<i/)) {
+		faIcon = `<i class="${faIcon}"></i>`;
+	}
+
+	const blockProps = useBlockProps.save({
+		className: `vk_icon`,
+	});
+
+	return (
+		<div {...blockProps}>
+			<VKBIcon
+				lbFontAwesomeIcon={faIcon}
+				lbSize={iconSize}
+				lbSizeUnit={iconSizeUnit}
+				lbMargin={iconMargin}
+				lbMarginUnit={iconMarginUnit}
+				lbRadius={iconRadius}
+				lbAlign={iconAlign}
+				lbType={iconType}
+				lbColor={iconColor}
+				lbUrl={iconUrl}
+				lbTarget={iconTarget}
+			/>
+		</div>
+	);
+}

--- a/src/blocks/icon/deprecated/index.js
+++ b/src/blocks/icon/deprecated/index.js
@@ -48,6 +48,15 @@ const blockAttributes = {
 	},
 };
 
+/* 次回対応おねがいします
+const blockAttributes3 = {
+	...blockAttributes2,
+	iconFontColor: {
+		type: 'string',
+	},
+}
+*/
+
 const blockAttributes2 = {
 	...blockAttributes,
 	iconColor: {

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -34,6 +34,7 @@ export default function IconEdit(props) {
 		iconAlign,
 		iconType,
 		iconColor,
+		iconFontColor,
 		iconUrl,
 		iconTarget,
 	} = attributes;
@@ -226,7 +227,10 @@ export default function IconEdit(props) {
 						isSmall
 						isPrimary={iconType === '1'}
 						isSecondary={iconType !== '1'}
-						onClick={() => setAttributes({ iconType: '1' })}
+						onClick={() => {
+							setAttributes({ iconType: '1' });
+							setAttributes({ iconFontColor: undefined });
+						}}
 					>
 						{__('Icon & Frame', 'vk-blocks-pro')}
 					</Button>
@@ -234,7 +238,10 @@ export default function IconEdit(props) {
 						isSmall
 						isPrimary={iconType === '2'}
 						isSecondary={iconType !== '2'}
-						onClick={() => setAttributes({ iconType: '2' })}
+						onClick={() => {
+							setAttributes({ iconType: '2' });
+							setAttributes({ iconFontColor: undefined });
+						}}
 					>
 						{__('Icon only', 'vk-blocks-pro')}
 					</Button>
@@ -290,9 +297,22 @@ export default function IconEdit(props) {
 					/>
 				</PanelBody>
 				<PanelBody title={__('Color', 'vk-blocks-pro')}>
-					<BaseControl>
+					<BaseControl
+						id={`vk_block_icon_color`}
+						label={iconType === '0' || iconType === null
+						? __('Background Color', 'vk-blocks-pro')
+						: __('Icon Color', 'vk-blocks-pro')}
+					>
 						<AdvancedColorPalette schema={'iconColor'} {...props} />
 					</BaseControl>
+					{(iconType === '0' || iconType === null) && (
+						<BaseControl
+							id={`vk_block_icon_font_color`}
+							label={__('Icon Color', 'vk-blocks-pro')}
+						>
+							<AdvancedColorPalette schema={'iconFontColor'} {...props} />
+						</BaseControl>
+					)}
 				</PanelBody>
 			</InspectorControls>
 			<div {...blockProps}>
@@ -306,6 +326,7 @@ export default function IconEdit(props) {
 					lbAlign={iconAlign}
 					lbType={iconType}
 					lbColor={iconColor}
+					lbFontColor={iconFontColor}
 				/>
 			</div>
 		</>

--- a/src/blocks/icon/edit.js
+++ b/src/blocks/icon/edit.js
@@ -299,9 +299,11 @@ export default function IconEdit(props) {
 				<PanelBody title={__('Color', 'vk-blocks-pro')}>
 					<BaseControl
 						id={`vk_block_icon_color`}
-						label={iconType === '0' || iconType === null
-						? __('Background Color', 'vk-blocks-pro')
-						: __('Icon Color', 'vk-blocks-pro')}
+						label={
+							iconType === '0' || iconType === null
+								? __('Background Color', 'vk-blocks-pro')
+								: __('Icon Color', 'vk-blocks-pro')
+						}
 					>
 						<AdvancedColorPalette schema={'iconColor'} {...props} />
 					</BaseControl>
@@ -310,7 +312,10 @@ export default function IconEdit(props) {
 							id={`vk_block_icon_font_color`}
 							label={__('Icon Color', 'vk-blocks-pro')}
 						>
-							<AdvancedColorPalette schema={'iconFontColor'} {...props} />
+							<AdvancedColorPalette
+								schema={'iconFontColor'}
+								{...props}
+							/>
 						</BaseControl>
 					)}
 				</PanelBody>

--- a/src/blocks/icon/index.js
+++ b/src/blocks/icon/index.js
@@ -26,6 +26,7 @@ export const settings = {
 			iconType: '0',
 			iconAlign: 'left',
 			iconColor: 'undefined',
+			iconFontColor: 'undefined',
 			iconUrl: url,
 			iconTarget: false,
 		},

--- a/src/blocks/icon/save.js
+++ b/src/blocks/icon/save.js
@@ -12,6 +12,7 @@ export default function save({ attributes }) {
 		iconAlign,
 		iconType,
 		iconColor,
+		iconFontColor,
 		iconUrl,
 		iconTarget,
 	} = attributes;
@@ -36,6 +37,7 @@ export default function save({ attributes }) {
 				lbAlign={iconAlign}
 				lbType={iconType}
 				lbColor={iconColor}
+				lbFontColor={iconFontColor}
 				lbUrl={iconUrl}
 				lbTarget={iconTarget}
 			/>

--- a/test/e2e-tests/fixtures/blocks/vk-blocks__icon__default.html
+++ b/test/e2e-tests/fixtures/blocks/vk-blocks__icon__default.html
@@ -1,4 +1,3 @@
-<!-- wp:vk-blocks/icon -->
-<div class="wp-block-vk-blocks-icon vk_icon"
-><div class="vk_icon_frame"><div class="vk_icon_border"><i class="fas vk_icon_font fa-user"></i></div></div></div>
+<!-- wp:vk-blocks/icon {"iconFontColor":"#ffff00"} -->
+<div class="wp-block-vk-blocks-icon vk_icon"><div class="vk_icon_frame"><div class="vk_icon_border"><i style="color:#ffff00" class="fas vk_icon_font fa-user"></i></div></div></div>
 <!-- /wp:vk-blocks/icon -->

--- a/test/e2e-tests/fixtures/blocks/vk-blocks__icon__deprecated-1-70-0.html
+++ b/test/e2e-tests/fixtures/blocks/vk-blocks__icon__deprecated-1-70-0.html
@@ -1,0 +1,4 @@
+<!-- wp:vk-blocks/icon -->
+<div class="wp-block-vk-blocks-icon vk_icon"
+><div class="vk_icon_frame"><div class="vk_icon_border"><i class="fas vk_icon_font fa-user"></i></div></div></div>
+<!-- /wp:vk-blocks/icon -->


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
 [ アイコン ] ベタ塗り白で表示できるようにしたい #1936 

## どういう変更をしたか？

* アイコンのスタイルが[塗り]のときアイコンフォントの色を指定できるようにしました
* アイコンのスタイルが[塗り]のとき、従来のアイコン色は背景色とし、今回追加した追加した[アイコンの色]をアイコンフォントの色として表示します

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

* アイコンのスタイルが[塗り]のときだけ、背景色とアイコンの色を設定することができる
* アイコンの色デフォルトは白
* アイコンの色を Lightning のパレットから選択した際に反映される
* アイコンの色を カスタムカラーで選択した場合も反映される
* 過去に設置した塗りのアイコンも正しく表示される → 背景色は以前の[アイコンの色]、アイコンフォントは白で表示

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 実装者が確認した手順と同じです
* デザイナーさんのほか開発のかたにコード見てもらえますか

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
