### PR TITLE
【確認中】[ グリッドカラム ] Lightning以外でグリッドカラムを使うと右側に余白がついてしまう現象に対応

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ e.g.
 
 == Changelog ==
 
+[ Design Bug Fix ][ Grid Column ] Fixed right margin when using grid columns outside of Lightning。
 [ Bug Fix ][ Grid Column ] Content does not span full width when using grid columns outside of Lightning in col-12.
 [ Bug Fix ][ Core Group ] Fix stitching styles for theme.json in Group blocks.
 [ Design Bug Fix ]Fixed margin-block-start being attached to flow block

--- a/src/blocks/_pro/grid-column/style.scss
+++ b/src/blocks/_pro/grid-column/style.scss
@@ -16,6 +16,7 @@ $xxl-min: 1400px;
 	display: flex;
 	flex-wrap: wrap;
 	margin: 0 -15px;
+	justify-content: center;
 }
 .vk_gridColumn [class*="col-"] {
 	padding: 0 15px;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#1939

## どういう変更をしたか？

Lightning以外でグリッドカラムを使う時、どの画面サイズでも右側に余白がついてしまう現象に対応しました。
![image](https://github.com/vektor-inc/vk-blocks-pro/assets/21466284/307d0382-4325-40a5-8e07-4593ffdd293e)


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→CSSなので省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. [こちらのパターン](https://patterns.vektor-inc.co.jp/vk-patterns/%e5%8c%bb%e9%99%a2%e7%94%a8cta/)をコピペ
2. X-T9が適用されているローカルのWordPressで1を貼り付ける
3. フロントエンドでパターンを表示
4.  1〜3をLightning、TT4でも確認(Lightningについては今回の変更で悪影響がないかの確認。)

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

1. [こちらのパターン](https://patterns.vektor-inc.co.jp/vk-patterns/%e5%8c%bb%e9%99%a2%e7%94%a8cta/)をコピーしてください。
2. X-T9が適用されているローカルのWordPressで1を貼り付けてください。
3. フロントエンドでパターンを表示してください。
4.  1〜3をLightning、TT4でも確認してください。(Lightningについては今回の変更で悪影響がないかの確認してください。)

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
