### PR TITLE
【確認待ち】Update/button to core navigation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification Change ] The Button Block has been made compatible for use within the Core Navigation Block.
+
 = 1.70.0 =
 [ Specification Change ] core/social-link, core/site-logo, core/site-title and core/site-tagline correspond to margin-extension
 [ Add function ][ Breadcrumb ] Add the ability to input breadcrumb separators.

--- a/src/blocks/button/index.js
+++ b/src/blocks/button/index.js
@@ -202,14 +202,17 @@ addFilter('blocks.getSaveElement', 'vk-blocks/button', VKButtonInlineCss, 11);
  * Adds the button block to the allowed blocks of the core/navigation block.
  *
  * @param {Object} settings - The block settings.
- * @param {string} name - The block name.
- * @returns {Object} - The modified block settings.
+ * @param {string} name     - The block name.
+ * @return {Object} - The modified block settings.
  */
-const VKButtonAllowNav = ( settings, name ) => {
-	if ( name === 'core/navigation') {
+const VKButtonAllowNav = (settings, name) => {
+	if (name === 'core/navigation') {
 		const { allowedBlocks = [] } = settings;
-		return { ...settings, allowedBlocks: [ ...allowedBlocks, 'vk-blocks/button' ] };
+		return {
+			...settings,
+			allowedBlocks: [...allowedBlocks, 'vk-blocks/button'],
+		};
 	}
 	return settings;
 };
-addFilter( 'blocks.registerBlockType', 'vk-blocks/button', VKButtonAllowNav, 11 );
+addFilter('blocks.registerBlockType', 'vk-blocks/button', VKButtonAllowNav, 11);

--- a/src/blocks/button/index.js
+++ b/src/blocks/button/index.js
@@ -197,3 +197,19 @@ const VKButtonInlineCss = (el, type, attributes) => {
 	return el;
 };
 addFilter('blocks.getSaveElement', 'vk-blocks/button', VKButtonInlineCss, 11);
+
+/**
+ * Adds the button block to the allowed blocks of the core/navigation block.
+ *
+ * @param {Object} settings - The block settings.
+ * @param {string} name - The block name.
+ * @returns {Object} - The modified block settings.
+ */
+const VKButtonAllowNav = ( settings, name ) => {
+	if ( name === 'core/navigation') {
+		const { allowedBlocks = [] } = settings;
+		return { ...settings, allowedBlocks: [ ...allowedBlocks, 'vk-blocks/button' ] };
+	}
+	return settings;
+};
+addFilter( 'blocks.registerBlockType', 'vk-blocks/button', VKButtonAllowNav, 11 );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

WordPress 6.5 でコアのブロックに許可するインナーブロックをフックで改変できるようになったので...

## どういう変更をしたか？

コアのナビゲーションブロック内にボタンブロックが使えるように指定

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* コアのナビゲーションブロックを配置
* 内部に VK ボタンブロックが配置できる事を確認

## 確認URL

ローカルでよろしくお願いいたします。

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* コアのナビゲーションブロックを配置
* 内部に VK ボタンブロックが配置できる事を確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
