### PR TITLE
【2人目確認中】グループブロックのスタイルstitch で、内部のリンクが効かなくなるのを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ e.g.
 
 == Changelog ==
 
+[ Design Bug fix ][ group ]Fixed an issue where internal links were not working in group block style stitches.
 [ Specification Change ][ Child Page List ] Hide "Term's name on Image" and "Taxonomies (all)" display options.
 
 = 1.71.0 =

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -432,6 +432,7 @@ ol {
 			height: calc(100% - 1em);
 			border: dashed 2px;
 			border-radius: 8px;
+			pointer-events: none;
 		}
 		//@include inner-item-pad-mag;
 		// thema.jsonでは .wp-block-group__inner-container がつかないためコメントアウト


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-blocks-pro/issues/1968

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

グループブロックのスタイルstitch の`before`要素が `position: absolute;` で配置されているため、リンクを含む内部の要素より前面に表示され、リンクがクリックできなくなっているので、`before`要素に`pointer-events: none;` を追加しました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

*グループブロックを配置してスタイルをスティッチにし、中に最新の投稿ブロックを配置します。フロント画面でタイトルなどのリンクが正常に効いていることを確認しました。


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*グループブロックを配置してスタイルをスティッチにし、中に最新の投稿ブロックを配置します。フロント画面でタイトルなどのリンクが正常に効いていることを確認してください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
