### PR TITLE
【2人目確認待ち】プレビュー（スライド）でalignfullの時に高さが検出されなくなっていたのでmargin:auto;削除

### DIFF
--- a/editor-css/_editor_before_slider.scss
+++ b/editor-css/_editor_before_slider.scss
@@ -7,7 +7,6 @@
 	.vk_slider.vk_swiper.vk_slider.vk_swiper.alignfull {
 		max-width: 100vw;
 		.vk_slider_item {
-			margin: auto;
 			max-width: 100vw;
 			&.vk_slider_item-paddingLR-use,
 			&.vk_slider_item-paddingLR-zero{

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ e.g.
 
 == Changelog ==
 
+[ Editor Design Bug fix ][ Slider ]Fixed an issue where slider item height disappears when editorMode is slide and alignfull.
 [ Design Bug fix ][ group ]Fixed an issue where internal links were not working in group block style stitches.
 [ Specification Change ][ Child Page List ] Hide "Term's name on Image" and "Taxonomies (all)" display options.
 [ Design Bug Fix ][ Balloon ] Harmonized icon image display in balloon blocks with frontend editing.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-blocks-pro/issues/1916

## どういう変更をしたか？

* このプルリクで変更した事を記載してください

よくよくみてみたところ、全幅サイズの時に高さが検出されなくなっているようでしたので、編集画面用のcssの`alignfull`にかいてある`.vk_slider_item`の`margin:auto;`を削除しました。念のため複数表示にしてみたりと確認したところ特になくても問題なさそうでした。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

*この[スライダー](https://patterns.vektor-inc.co.jp/vk-patterns/top-slider/)パターンをコピペします。
*編集モードを「プレビュー（スライド）」にして、スライドアイテム内の高さが出ていることを確認しました。念のため複数表示の確認もしました



## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*この[スライダー](https://patterns.vektor-inc.co.jp/vk-patterns/top-slider/)パターンをコピペします。
*編集モードを「プレビュー（スライド）」にして、スライドアイテム内の高さが出ていることを確認してください。念のため複数表示の確認もしてもらえるとうれしいです

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
