### PR TITLE
WordPress 6.5 で useSetting が非推奨になったので変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@wordpress/e2e-test-utils": "^10.13.0",
         "@wordpress/edit-post": "^7.19.0",
         "@wordpress/element": "^5.19.0",
-        "@wordpress/env": "5.16.0",
+        "@wordpress/env": "9.6.0",
         "@wordpress/hooks": "^3.42.0",
         "@wordpress/i18n": "^4.42.0",
         "@wordpress/icons": "^9.33.0",
@@ -7117,14 +7117,14 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
-      "integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.6.0.tgz",
+      "integrity": "sha512-vXFcr+MfMhREEw+8TBrEtS4MlTJSAjEj5qtUHYK4dpN5DaD1LqQjPxgFFcCvKrZf0ZtT99NQqw+HHB7rYK64rg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -13492,10 +13492,13 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
       "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@wordpress/e2e-test-utils": "^10.13.0",
     "@wordpress/edit-post": "^7.19.0",
     "@wordpress/element": "^5.19.0",
-    "@wordpress/env": "5.16.0",
+    "@wordpress/env": "9.6.0",
     "@wordpress/hooks": "^3.42.0",
     "@wordpress/i18n": "^4.42.0",
     "@wordpress/icons": "^9.33.0",

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,8 @@ e.g.
 
 == Changelog ==
 
+[ Other ] Fixed useSetting deprecated 
+
 = 1.72.0 =
 [ Specification Change ][ Child Page List ] Hide "Term's name on Image" and "Taxonomies (all)" display options.
 [ Design Bug fix ][ grid-column ] Fixed vk_gridColumn_item to be aligned to the beginning and to be the basic width size of the parent element.

--- a/src/blocks/_pro/blog-card-featured-image/dimension-controls.js
+++ b/src/blocks/_pro/blog-card-featured-image/dimension-controls.js
@@ -10,10 +10,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import {
-	InspectorControls,
-	useSettings
-} from '@wordpress/block-editor';
+import { InspectorControls, useSettings } from '@wordpress/block-editor';
 
 const SCALE_OPTIONS = (
 	<>

--- a/src/blocks/_pro/blog-card-featured-image/dimension-controls.js
+++ b/src/blocks/_pro/blog-card-featured-image/dimension-controls.js
@@ -10,7 +10,10 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { InspectorControls, useSetting } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useSettings
+} from '@wordpress/block-editor';
 
 const SCALE_OPTIONS = (
 	<>
@@ -49,9 +52,13 @@ const DimensionControls = ({
 	setAttributes,
 }) => {
 	const defaultUnits = ['px', '%', 'vw', 'em', 'rem'];
+
+	const spacingUnits = [...useSettings('spacing.units')[0]];
+
 	const units = useCustomUnits({
-		availableUnits: useSetting('spacing.units') || defaultUnits,
+		availableUnits: spacingUnits || defaultUnits,
 	});
+
 	const onDimensionChange = (dimension, nextValue) => {
 		const parsedValue = parseFloat(nextValue);
 		/**

--- a/src/components/advanced-color-gradient-control/index.js
+++ b/src/components/advanced-color-gradient-control/index.js
@@ -3,7 +3,7 @@ import {
 	__experimentalColorGradientControl as ColorGradientControl,
 	getGradientSlugByValue,
 	getColorObjectByColorValue,
-	useSettings
+	useSettings,
 } from '@wordpress/block-editor';
 import { colorSlugToColorCode } from '@vkblocks/utils/color-slug-to-color-code';
 import { gradientSlugToGradientCode } from '@vkblocks/utils/gradient-slug-to-gradient-code';

--- a/src/components/advanced-color-gradient-control/index.js
+++ b/src/components/advanced-color-gradient-control/index.js
@@ -3,7 +3,7 @@ import {
 	__experimentalColorGradientControl as ColorGradientControl,
 	getGradientSlugByValue,
 	getColorObjectByColorValue,
-	useSetting,
+	useSettings
 } from '@wordpress/block-editor';
 import { colorSlugToColorCode } from '@vkblocks/utils/color-slug-to-color-code';
 import { gradientSlugToGradientCode } from '@vkblocks/utils/gradient-slug-to-gradient-code';
@@ -22,8 +22,9 @@ export const AdvancedColorGradientControl = (props) => {
 		attributes[gradientSchema]
 	);
 
-	const defaultGradients = useSetting('color.gradients.default');
-	const themeGradients = useSetting('color.gradients.theme');
+	const defaultGradients = [...useSettings('color.gradients.default')[0]];
+	const themeGradients = [...useSettings('color.gradients.theme')[0]];
+
 	const gradientsArray = [];
 	if (themeGradients?.length > 0) {
 		gradientsArray.push({


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

useSetting が WordPress 6.5 で非推奨になった

## どういう変更をしたか？

useSetting を useSettings に変更。ただし、返り値の形式が違うので調整

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？
コンソール関連のテストってどうするんですかねぇ...

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

■ Before

* develop でビルド
* ブログカードブロックを配置
  -> コンソールに警告が出る
* グリッドカラムカードブロックを配置 -> グリッドカラムアイテムブロックを選択
  -> コンソールに警告が出る

![スクリーンショット 2024-04-12 20 16 48](https://github.com/vektor-inc/vk-blocks-pro/assets/3272660/ec896f5c-e52f-4871-a0e9-cfab3717d161)
![スクリーンショット 2024-04-12 20 33 13](https://github.com/vektor-inc/vk-blocks-pro/assets/3272660/9cf9cd90-d2ed-4d94-bf78-9cf92100ad07)

■ After

* このブランチでビルド
* もとの手順を行って警告が出なくなる事を確認

## 確認URL

* ローカルでよろしくお願いいたします。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

* 実装者に同じ
* こんな書き換え方でええんかな...

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
