### PR TITLE
Remove min-height from "Custom CSS" on edit screen.

### DIFF
--- a/editor-css/_editor_before_custom-css-extension.scss
+++ b/editor-css/_editor_before_custom-css-extension.scss
@@ -1,6 +1,5 @@
 .vk_edit_custom_css {
 	border: 1px dashed #ccc !important;
-	min-height:3em;
 	left:0;
 	&:before {
 		position:absolute;

--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,7 @@ e.g.
 [ Add Function ][ Spacer ][ Common margin ] Add size option XXL/XXS.
 [ Add Function ][ Outer (Pro) ] Added option to min height setting.
 [ Bug fix ] Fixed an issue with redundant JavaScript loading in the WordPress 6.5 environment. 
+[ Bug fix ] Remove min-height from "Custom CSS" on edit screen.
 [ Specification Change ][ Outer ] Remove the negative margin for .vk_outer-width-full.
 [ Other ] Fixed useSetting deprecated
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

カスタムCSSに最小高さ指定がついてるけどこれ不要では...何のために付いてるんだろう...

■ Before

![スクリーンショット 2024-05-12 0 22 29](https://github.com/vektor-inc/vk-blocks-pro/assets/3272660/38c85065-8a0d-4abf-860a-f069b3b3bc07)

## どういう変更をしたか？

■ After

![スクリーンショット 2024-05-11 23 57 26](https://github.com/vektor-inc/vk-blocks-pro/assets/3272660/905c9eae-ad22-4044-8b3e-e3174502ea3b)


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？