### PR TITLE
FontAwesome が gulp dist の過程で壊れないように修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -317,7 +317,7 @@ gulp.task('dist', (done) => {
 			'!./dist/**',
 			'!./node_modules/**',
 		],
-		{ base: './' }
+		{ base: './', buffer: false } // buffer: false オプションを追加
 	).pipe(gulp.dest('dist/vk-blocks-pro')); // distディレクトリに出力
 	done();
 });
@@ -337,7 +337,7 @@ gulp.task('dist:free', (done) => {
 			'!./dist/**',
 			'!./node_modules/**',
 		],
-		{ base: './' }
+		{ base: './', buffer: false } // buffer: false オプションを追加
 	).pipe(gulp.dest('dist/vk-blocks')); // distディレクトリに出力
 	done();
 });


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

Font Awesome が gulp dist の過程で壊れないように修正