### PR TITLE
【確認中】[ リンクツールバー ] WP6.6で発生するエラーを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ] Fixed an error in the component link toolbar in WordPress version 6.6.
 [ Fix ][ Table of Contents (Pro) ] Improved pseudo elements for frontend page accessibility.
 [ Add function ][ Core Group ] Add toolbar link for components by item.
 [ Add function ][ Grid Column (Pro) ] Add toolbar link for components by item.

--- a/src/components/link-toolbar/index.js
+++ b/src/components/link-toolbar/index.js
@@ -108,22 +108,22 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 				!formattedUrl.startsWith(window.location.origin) &&
 				!formattedUrl.startsWith('#');
 
-			const fetchTitle = function(url) {
+			const fetchTitle = function (url) {
 				if (url.startsWith('#')) {
 					return Promise.resolve(url); // アンカーリンクの場合はそのまま返す
 				}
 				return fetch(url, { method: 'GET' })
-					.then(response => response.text())
-					.then(text => {
+					.then((response) => response.text())
+					.then((text) => {
 						const titleMatch = text.match(/<title>(.*?)<\/title>/i);
 						return titleMatch ? titleMatch[1] : url;
 					})
-					.catch(error => {
+					.catch(() => {
 						return url;
 					});
 			};
 
-			fetchTitle(formattedUrl).then(title => {
+			fetchTitle(formattedUrl).then((title) => {
 				setLinkTitle(title);
 			});
 
@@ -142,7 +142,7 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 							style={{ width: '16px', height: '16px' }}
 						/>
 					);
-				} catch (error) {
+				} catch {
 					setIcon(link); // URLが無効な場合はリンクアイコンを使用
 				}
 			}
@@ -167,10 +167,11 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 		setIsOpen(false);
 	};
 
-	const handleCopy = function(url) {
+	const handleCopy = function (url) {
 		const formattedUrl = url.startsWith('#') ? url : formatUrl(url);
 		if (typeof window !== 'undefined' && window.navigator.clipboard) {
-			window.navigator.clipboard.writeText(formattedUrl)
+			window.navigator.clipboard
+				.writeText(formattedUrl)
 				.then(() => {
 					setAriaMessage(
 						__('Link copied to clipboard.', 'vk-blocks-pro')
@@ -178,7 +179,7 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 					setSnackbarVisible(true);
 					setTimeout(() => setSnackbarVisible(false), 3000);
 				})
-				.catch(error => {
+				.catch(() => {
 					// console.error('Failed to copy: ', error);
 				});
 		} else {
@@ -190,9 +191,7 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 			textArea.select();
 			document.execCommand('copy');
 			document.body.removeChild(textArea);
-			setAriaMessage(
-				__('Link copied to clipboard.', 'vk-blocks-pro')
-			);
+			setAriaMessage(__('Link copied to clipboard.', 'vk-blocks-pro'));
 			setSnackbarVisible(true);
 			setTimeout(() => setSnackbarVisible(false), 3000);
 		}

--- a/src/components/link-toolbar/index.js
+++ b/src/components/link-toolbar/index.js
@@ -108,21 +108,22 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 				!formattedUrl.startsWith(window.location.origin) &&
 				!formattedUrl.startsWith('#');
 
-			const fetchTitle = async (url) => {
+			const fetchTitle = function(url) {
 				if (url.startsWith('#')) {
-					return url; // アンカーリンクの場合はそのまま返す
+					return Promise.resolve(url); // アンカーリンクの場合はそのまま返す
 				}
-				try {
-					const response = await fetch(url, { method: 'GET' });
-					const text = await response.text();
-					const titleMatch = text.match(/<title>(.*?)<\/title>/i);
-					return titleMatch ? titleMatch[1] : url;
-				} catch (error) {
-					return url;
-				}
+				return fetch(url, { method: 'GET' })
+					.then(response => response.text())
+					.then(text => {
+						const titleMatch = text.match(/<title>(.*?)<\/title>/i);
+						return titleMatch ? titleMatch[1] : url;
+					})
+					.catch(error => {
+						return url;
+					});
 			};
 
-			fetchTitle(formattedUrl).then((title) => {
+			fetchTitle(formattedUrl).then(title => {
 				setLinkTitle(title);
 			});
 
@@ -166,33 +167,34 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 		setIsOpen(false);
 	};
 
-	const handleCopy = async (url) => {
+	const handleCopy = function(url) {
 		const formattedUrl = url.startsWith('#') ? url : formatUrl(url);
-		try {
-			if (typeof window !== 'undefined' && window.navigator.clipboard) {
-				await window.navigator.clipboard.writeText(formattedUrl);
-				setAriaMessage(
-					__('Link copied to clipboard.', 'vk-blocks-pro')
-				);
-				setSnackbarVisible(true);
-				setTimeout(() => setSnackbarVisible(false), 3000);
-			} else {
-				// Clipboard API がサポートされていない場合のフォールバック
-				const textArea = document.createElement('textarea');
-				textArea.value = formattedUrl;
-				document.body.appendChild(textArea);
-				textArea.focus();
-				textArea.select();
-				document.execCommand('copy');
-				document.body.removeChild(textArea);
-				setAriaMessage(
-					__('Link copied to clipboard.', 'vk-blocks-pro')
-				);
-				setSnackbarVisible(true);
-				setTimeout(() => setSnackbarVisible(false), 3000);
-			}
-		} catch (error) {
-			// console.error('Failed to copy: ', error);
+		if (typeof window !== 'undefined' && window.navigator.clipboard) {
+			window.navigator.clipboard.writeText(formattedUrl)
+				.then(() => {
+					setAriaMessage(
+						__('Link copied to clipboard.', 'vk-blocks-pro')
+					);
+					setSnackbarVisible(true);
+					setTimeout(() => setSnackbarVisible(false), 3000);
+				})
+				.catch(error => {
+					// console.error('Failed to copy: ', error);
+				});
+		} else {
+			// Clipboard API がサポートされていない場合のフォールバック
+			const textArea = document.createElement('textarea');
+			textArea.value = formattedUrl;
+			document.body.appendChild(textArea);
+			textArea.focus();
+			textArea.select();
+			document.execCommand('copy');
+			document.body.removeChild(textArea);
+			setAriaMessage(
+				__('Link copied to clipboard.', 'vk-blocks-pro')
+			);
+			setSnackbarVisible(true);
+			setTimeout(() => setSnackbarVisible(false), 3000);
 		}
 	};
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2094 
#2095 

## どういう変更をしたか？

WordPress6.6においてリンクツールバーのコンポーネントのエラーを修正しました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/vektor-inc/vk-blocks-pro/assets/21466284/3e43075c-6714-4733-aa69-fdea1692e217)

#### 変更後 After
![image](https://github.com/vektor-inc/vk-blocks-pro/assets/21466284/068fe30d-b181-4e83-b51e-1f295aa66be9)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→スキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

リンクツールバーを設置した

* コアのグループ
* グリッドカラムカード
* Outer
* スライダーアイテム

のブロックが対象です。

WP6.6の状態でかつ編集画面に上記のブロックを設置した時、以下のようになることを確認しました。

* エラーが起きない。
* リンクを設置できる。
* 設定したリンクの削除やコピーできる。

また、フロントエンドで以下を確認しました。

* ブロックのリンクをクリックできる。
* リンクを別タブで開く設定した時はそのように動く。
* リンクを設定して保存後、編集画面でリンクを削除した状態で保存した後にフロントエンドでもリンクが消えている。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をしてくだいさい。
また、開発の方はコードのレビューもお願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
