### PR TITLE
【２人目確認中】[ core/group ]  編集画面でjsのエラーがあったので修正

### DIFF
--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -169,13 +169,16 @@ const save = (props) => {
 		tagName: CustomTag = 'div',
 	} = attributes;
 
+	// Use block properties, setting className to include has-link if linkUrl is present
 	const blockProps = useBlockProps.save({
 		className: linkUrl ? `${className} has-link` : className,
 	});
 
+	// Determine rel attribute based on linkTarget
 	const relAttribute =
 		linkTarget === '_blank' ? 'noopener noreferrer' : 'noopener';
 
+	// Extract prefix for custom link class
 	const prefix = 'wp-block-group';
 
 	return (

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -40,6 +40,7 @@ export const addAttribute = (settings) => {
 			...settings.attributes,
 			color: {
 				type: 'string',
+				default: '',
 			},
 			linkUrl: {
 				type: 'string',
@@ -48,6 +49,10 @@ export const addAttribute = (settings) => {
 			linkTarget: {
 				type: 'string',
 				default: '',
+			},
+			tagName: {
+				type: 'string',
+				default: 'div',
 			},
 		};
 	}
@@ -157,7 +162,7 @@ addFilter('editor.BlockEdit', 'vk-blocks/group-style', addBlockControl);
  */
 const save = (props) => {
 	const { attributes } = props;
-	const { linkUrl, linkTarget, className = '' } = attributes;
+	const { linkUrl, linkTarget, className = '', tagName: CustomTag = 'div' } = attributes;
 
 	const blockProps = useBlockProps.save({
 		className: linkUrl ? `${className} has-link` : className,
@@ -169,7 +174,7 @@ const save = (props) => {
 	const prefix = 'wp-block-group';
 
 	return (
-		<div {...blockProps}>
+		<CustomTag {...blockProps}>
 			{linkUrl && (
 				<a
 					href={linkUrl}
@@ -179,15 +184,14 @@ const save = (props) => {
 					className={`${prefix}-vk-link`}
 				></a>
 			)}
-			{className.includes('img-replacement-wrap') && (
+			{className.includes('img-replacement-wrap') ? (
 				<div className="wp-block-group__inner-container">
 					<InnerBlocks.Content />
 				</div>
-			)}
-			{!className.includes('img-replacement-wrap') && (
+			) : (
 				<InnerBlocks.Content />
 			)}
-		</div>
+		</CustomTag>
 	);
 };
 
@@ -217,6 +221,12 @@ const overrideBlockSettings = (settings, name) => {
 			newSettings.attributes.linkTarget = {
 				type: 'string',
 				default: '',
+			};
+		}
+		if (!newSettings.attributes.tagName) {
+			newSettings.attributes.tagName = {
+				type: 'string',
+				default: 'div',
 			};
 		}
 		return newSettings;

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -159,16 +159,12 @@ const save = (props) => {
 	const { attributes } = props;
 	const { linkUrl, linkTarget, className } = attributes;
 
-	// Use block properties, setting className to include has-link if linkUrl is present
 	const blockProps = useBlockProps.save({
 		className: linkUrl ? `${className} has-link` : className,
 	});
 
-	// Determine rel attribute based on linkTarget
-	const relAttribute =
-		linkTarget === '_blank' ? 'noopener noreferrer' : 'noopener';
+	const relAttribute = linkTarget === '_blank' ? 'noopener noreferrer' : 'noopener';
 
-	// Extract prefix for custom link class
 	const prefix = 'wp-block-group';
 
 	return (
@@ -182,10 +178,13 @@ const save = (props) => {
 					className={`${prefix}-vk-link`}
 				></a>
 			)}
-			<InnerBlocks.Content />
+			<div className="wp-block-group__inner-container">
+				<InnerBlocks.Content />
+			</div>
 		</div>
 	);
 };
+
 
 // Support for existing group blocks and version management
 import { assign } from 'lodash';

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -192,13 +192,7 @@ const save = (props) => {
 					className={`${prefix}-vk-link`}
 				></a>
 			)}
-			{className.includes('img-replacement-wrap') ? (
-				<div className="wp-block-group__inner-container">
-					<InnerBlocks.Content />
-				</div>
-			) : (
-				<InnerBlocks.Content />
-			)}
+			<InnerBlocks.Content />
 		</CustomTag>
 	);
 };

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -162,7 +162,12 @@ addFilter('editor.BlockEdit', 'vk-blocks/group-style', addBlockControl);
  */
 const save = (props) => {
 	const { attributes } = props;
-	const { linkUrl, linkTarget, className = '', tagName: CustomTag = 'div' } = attributes;
+	const {
+		linkUrl,
+		linkTarget,
+		className = '',
+		tagName: CustomTag = 'div',
+	} = attributes;
 
 	const blockProps = useBlockProps.save({
 		className: linkUrl ? `${className} has-link` : className,

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -157,13 +157,14 @@ addFilter('editor.BlockEdit', 'vk-blocks/group-style', addBlockControl);
  */
 const save = (props) => {
 	const { attributes } = props;
-	const { linkUrl, linkTarget, className } = attributes;
+	const { linkUrl, linkTarget, className = '' } = attributes;
 
 	const blockProps = useBlockProps.save({
 		className: linkUrl ? `${className} has-link` : className,
 	});
 
-	const relAttribute = linkTarget === '_blank' ? 'noopener noreferrer' : 'noopener';
+	const relAttribute =
+		linkTarget === '_blank' ? 'noopener noreferrer' : 'noopener';
 
 	const prefix = 'wp-block-group';
 
@@ -178,13 +179,17 @@ const save = (props) => {
 					className={`${prefix}-vk-link`}
 				></a>
 			)}
-			<div className="wp-block-group__inner-container">
+			{className.includes('img-replacement-wrap') && (
+				<div className="wp-block-group__inner-container">
+					<InnerBlocks.Content />
+				</div>
+			)}
+			{!className.includes('img-replacement-wrap') && (
 				<InnerBlocks.Content />
-			</div>
+			)}
 		</div>
 	);
 };
-
 
 // Support for existing group blocks and version management
 import { assign } from 'lodash';


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

groupにリンク設定を追加した影響で編集画面でcore/groupのjsのエラーがあったので修正しました。

## どういう変更をしたか？

編集画面でcore/groupのエラーがあったので修正しました。

~~groupブロックの中に`<div class="wp-block-group__inner-container">`を含む場合と含まない場合があるのでそれを判別した変更にしています。~~
→現在機能していなプラグインが引き起こしていたので削除したらこの問題は解消しました。

- groupブロックでdiv以外のタグを入れた時に、現行のjsでは強制的にdivにしてしまうのでそこも修正しました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/a94d567b-b5ff-4fa4-b44e-a2ba3b8e95ff)

#### 変更後 After
![image](https://github.com/user-attachments/assets/baccd443-1f04-4bee-8ac0-0bf292e5a681)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ → まだgroupに設定したリンク設定が正式にリリースされているわけではないのでスキップ。
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ スキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. developブランチにして編集画面でグループブロックを設置。
2. groupブロックを選択するとエラーが表示されることを確認。
3. groupブロックをもう一つ作り、高度な設定でdiv以外ブロックを選択し保存。
4. このブランチに変更して編集画面でgroupブロックを選択したらエラーが解消されることを確認。
5. div以外ブロックを選択したgroupブロックには「ブロックのリカバリーを試行」が出ているはずなので、それをクリックした後にもエラーが解消されることを確認。

なお、groupにリンク設定を追加した影響でこの現象は起こっていますが、まだ正式にリリースされていないので5のような場合に「ブロックのリカバリーを試行」を出ないようにするなどの試みは行ってません。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をしてください。
また、開発の方はコードの確認もお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
