### PR TITLE
【2人目確認中】[ Outer ] 余白 (上下)の「標準の余白を使用」用のCSS追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Outer (Pro) ] Add vertical padding variables.
 [ Add function ][ Outer (Pro) ] Add serrated and large triangle in divider style.
 
 = 1.79.1 =

--- a/src/blocks/_pro/outer/style.scss
+++ b/src/blocks/_pro/outer/style.scss
@@ -143,6 +143,26 @@ $media-xxl-down: 1399.98px;
 }
 
 .vk_outer-paddingVertical-use {
+	--vk-outer-padding: 1.5em;
+	@media (min-width: $media-sm-up) {
+		--vk-outer-padding: 2em;
+	}
+
+	@media (min-width: $media-md-up) {
+		--vk-outer-padding: 2.5em;
+	}
+
+	@media (min-width: $media-lg-up) {
+		--vk-outer-padding: 3em;
+	}
+
+	@media (min-width: $media-xl-up) {
+		--vk-outer-padding: 3.5em;
+	}
+
+	@media (min-width: $media-xxl-up) {
+		--vk-outer-padding: 4em;
+	}
 	padding-top: var(--vk-outer-padding);
 	padding-bottom: var(--vk-outer-padding);
 }

--- a/src/blocks/_pro/outer/style.scss
+++ b/src/blocks/_pro/outer/style.scss
@@ -112,7 +112,7 @@ $media-xxl-down: 1399.98px;
 	--vk-outer-padding: 0;
 }
 
-.vk_outer-paddingLR-use {
+.vk_outer-paddingLR-use, .vk_outer-paddingVertical-use {
 	--vk-outer-padding: 1.5em;
 	@media (min-width: $media-sm-up) {
 		--vk-outer-padding: 2em;
@@ -133,9 +133,11 @@ $media-xxl-down: 1399.98px;
 	@media (min-width: $media-xxl-up) {
 		--vk-outer-padding: 4em;
 	}
-	padding-left: var(--vk-outer-padding);
-	padding-right: var(--vk-outer-padding);
 }
+
+.vk_outer-paddingLR-use {
+	padding-left: var(--vk-outer-padding);
+	padding-right: var(--vk-outer-padding);}
 
 .vk_outer-paddingLR-zero {
 	padding-left: 0;
@@ -143,26 +145,6 @@ $media-xxl-down: 1399.98px;
 }
 
 .vk_outer-paddingVertical-use {
-	--vk-outer-padding: 1.5em;
-	@media (min-width: $media-sm-up) {
-		--vk-outer-padding: 2em;
-	}
-
-	@media (min-width: $media-md-up) {
-		--vk-outer-padding: 2.5em;
-	}
-
-	@media (min-width: $media-lg-up) {
-		--vk-outer-padding: 3em;
-	}
-
-	@media (min-width: $media-xl-up) {
-		--vk-outer-padding: 3.5em;
-	}
-
-	@media (min-width: $media-xxl-up) {
-		--vk-outer-padding: 4em;
-	}
 	padding-top: var(--vk-outer-padding);
 	padding-bottom: var(--vk-outer-padding);
 }

--- a/src/blocks/_pro/outer/style.scss
+++ b/src/blocks/_pro/outer/style.scss
@@ -137,7 +137,8 @@ $media-xxl-down: 1399.98px;
 
 .vk_outer-paddingLR-use {
 	padding-left: var(--vk-outer-padding);
-	padding-right: var(--vk-outer-padding);}
+	padding-right: var(--vk-outer-padding);
+}
 
 .vk_outer-paddingLR-zero {
 	padding-left: 0;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://discord.com/channels/1010092469863587892/1010175825930367019/1262969379495215155

## どういう変更をしたか？

.vk_outer-paddingVertical-use クラスが --vk-outer-padding 変数を使用するように修正し、縦方向のパディングが正しく適用されるようにしました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/5aa1fa3a-7974-4f42-9163-17a99fc65c5a)

#### 変更後 After
![image](https://github.com/user-attachments/assets/e15ee1f2-04dd-4ccb-8645-f69e972f97a9)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→CSSを追加しただけなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. 編集画面でOuterブロックを設置し、レイアウト設定 > 余白 (上下) > 「標準の余白を使用」を選択。
2. 上下にPaddingが追加されることを確認。
3. レイアウト設定 > 余白 (上下) > 「標準の余白を使用しない」を選択したら上下のPaddingがなくなることを確認。
4. 保存し、フロントエンドで上下にPaddingが追加されることを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行なってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
