### PR TITLE
[ スライダー ] 再利用ブロックで使用するとエディタがクラッシュする現象に対応しました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ e.g.
 
 == Changelog ==
 
+[ Add function ][ Slider Item ] Fix infinite loop in slider item block when used in reusable blocks.
 
 = 1.80.1 =
 [ Bug Fix ] Fixed in WordPress 6.4.x / 6.5.x so that blocks can be used.

--- a/src/blocks/slider-item/edit.js
+++ b/src/blocks/slider-item/edit.js
@@ -74,7 +74,10 @@ export default function SliderItemEdit(props) {
 
 	// コアの余白システムに値を適用
 	useEffect(() => {
-		if (paddingValue !== attributes.style?.spacing?.padding?.left || paddingValue !== attributes.style?.spacing?.padding?.right) {
+		if (
+			paddingValue !== attributes.style?.spacing?.padding?.left ||
+			paddingValue !== attributes.style?.spacing?.padding?.right
+		) {
 			setAttributes({
 				style: {
 					spacing: {
@@ -86,7 +89,7 @@ export default function SliderItemEdit(props) {
 				},
 			});
 		}
-	}, [paddingValue]);	
+	}, [paddingValue]);
 
 	let containerClass = '';
 	if (classPaddingLR === ` is-layout-constrained` || classPaddingLR === '') {

--- a/src/blocks/slider-item/edit.js
+++ b/src/blocks/slider-item/edit.js
@@ -74,17 +74,19 @@ export default function SliderItemEdit(props) {
 
 	// コアの余白システムに値を適用
 	useEffect(() => {
-		setAttributes({
-			style: {
-				spacing: {
-					padding: {
-						left: paddingValue,
-						right: paddingValue,
+		if (paddingValue !== attributes.style?.spacing?.padding?.left || paddingValue !== attributes.style?.spacing?.padding?.right) {
+			setAttributes({
+				style: {
+					spacing: {
+						padding: {
+							left: paddingValue,
+							right: paddingValue,
+						},
 					},
 				},
-			},
-		});
-	}, [paddingValue]);
+			});
+		}
+	}, [paddingValue]);	
 
 	let containerClass = '';
 	if (classPaddingLR === ` is-layout-constrained` || classPaddingLR === '') {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2135

## どういう変更をしたか？

RICKさんが書いてくださったように、コアの余白システムに値を適用する機能が無限ループしてエラーになっていたのでその部分を修正しました。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-07-26 13 16 57](https://github.com/user-attachments/assets/017e3f82-e889-42d6-92b5-61ad230c898d)
![スクリーンショット 2024-07-26 13 17 08](https://github.com/user-attachments/assets/5433a727-2cf2-40ab-8d61-3ee8506c48cc)

#### 変更後 After
![スクリーンショット 2024-07-26 13 21 03](https://github.com/user-attachments/assets/c47de7e3-29f0-4572-84c5-912fef09e4fb)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→useEffectにif文を追加しただけなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. developブランチにして固定ページでスライダーを追加。
https://patterns.vektor-inc.co.jp/vk-patterns/gallery_full-slider/
2. 追加したスライダーを選択し「パターンを作成」をして「追加」をクリックしてください。（この時点で「変更前 Before」のように固まります。）
3. fix/slider-item/infinite-loopブランチに切り替えてもう一度固定ページにスライダー追加→パターンを作成をしてください。(先ほど作成した固定ページで確認する場合は一回「ページを離れる」をクリックしてからもう一度読み込んでください。)
![image](https://github.com/user-attachments/assets/c033c055-6f1e-447d-a51e-e795720c76fd)
4. 「変更後 After」のように再利用ブロックに追加できたことを確認しました。また、以下を確認しました。

- スライダー入りの再利用ブロックを固定ページに挿入したときにページが固まらない。
- スライダー入りの再利用ブロックを挿入した固定ページを保存後、もう一度ページを読み込んだ時に固まらない。


## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行なってください。
また開発の方はコードの確認もお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
