### PR TITLE
「css微修正」スタイルが直線上下（border-top-bottom）の時のborderの設定を追加

### DIFF
--- a/src/extensions/core/table/style.scss
+++ b/src/extensions/core/table/style.scss
@@ -3,7 +3,17 @@
     thead th,tfoot td{
         font-weight: bold;
     }
-    &.is-style-vk-table {
+    &.is-style-vk-table {     
+        &-border-top-bottom,
+        &-border,
+        &-border-stripes{
+            // theme.json のあるファイルでテーブルの線の色指定がない場合のみ適用
+			table:where(:not(.has-border-color)){
+				:where(th,td){
+					border:1px solid var(--vk-color-border-hr);
+				}
+			}
+        }
         &-border-top-bottom {
 			table,
 			th,
@@ -12,24 +22,11 @@
                 border-right: none;
 			}
         }
-        &-border {
-			// theme.json のあるファイルでテーブルの線の色指定がない場合のみ適用
-			table:where(:not(.has-border-color)){
-				th,td{
-					border:1px solid var(--vk-color-border-hr);
-				}
-			}
-        }
+
         &-border-stripes{
             tbody tr:nth-child(2n+1) {
                 background-color: #f0f0f0;
             }
-			// theme.json のあるファイルでテーブルの線の色指定がない場合のみ適用
-			table:where(:not(.has-border-color)){
-				th,td{
-					border:1px solid var(--vk-color-border-hr);
-				}
-			}
         }
     }
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-blocks-pro/pull/2130#issuecomment-2251887413

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->

スタイルが直線上下のときのborderの設定がなかったため追加しました。
デフォルトのスタイルはテーマ側の設定になると思いますので何もしていません。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-07-26 12 16 26](https://github.com/user-attachments/assets/50eab81b-4544-46c5-b863-20b08e158089)

#### 変更後 After
![スクリーンショット 2024-07-26 17 35 37](https://github.com/user-attachments/assets/022aefd1-e908-4fbd-b559-114864772d45)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？
cssの微修正のため書いておりませんが、必要であれば書きます

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
CSSの微修正のため書いていません

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

<!-- [ 実装者が確認した手順を箇条書きで記載してください。予備知識のないレビュワーが見て再現しやすい手順で記載してください。 ] -->

* テーマはLightningで、VK Blocks Proの分割読み込みを有効にします。
* テーブルブロックを設置してスタイルを「直線上下」にして、borderの色が薄いグレーになることを確認しました。


## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

<!-- [ レビュワーがどういう手順で何を確認して欲しいかを記載してください。 ] -->

* テーマはLightningで、VK Blocks Proの分割読み込みを有効にします。
* テーブルブロックを設置してスタイルを「直線上下」にして、borderの色が薄いグレーになることを確認してください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
