### PR TITLE
[ php微修正 / 1人でいいかも ] build-cssの読み込みを直しました

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-block-loader.php
+++ b/inc/vk-blocks/class-vk-blocks-block-loader.php
@@ -100,16 +100,11 @@ class VK_Blocks_Block_Loader {
 	 */
 	public function add_styles() {
 		// 分割読み込みの場合は register されるファイルが false 指定で何も読み込まれなくなっている.
-		if ( self::should_load_separate_assets() ) {
-			// 各ブロックごとのスタイルをここで読み込む
-			wp_enqueue_style( 'vk-blocks-utils-common-css', VK_BLOCKS_DIR_URL . 'build/utils/common.css', array(), VK_BLOCKS_VERSION );
-			wp_enqueue_style( 'vk-blocks/core-table', VK_BLOCKS_DIR_URL . 'build/extensions/core/table/style.css', array(), VK_BLOCKS_VERSION );
-			wp_enqueue_style( 'vk-blocks/core-heading', VK_BLOCKS_DIR_URL . 'build/extensions/core/heading/style.css', array(), VK_BLOCKS_VERSION );
-			wp_enqueue_style( 'vk-blocks/core-image', VK_BLOCKS_DIR_URL . 'build/extensions/core/image/style.css', array(), VK_BLOCKS_VERSION );
-		} else {
-			// 結合ファイルを読み込む
-			wp_enqueue_style( 'vk-blocks-build-css' );
-		}
+		wp_enqueue_style( 'vk-blocks-build-css' );
+		wp_enqueue_style( 'vk-blocks-utils-common-css');
+		wp_enqueue_style( 'vk-blocks/core-table', VK_BLOCKS_DIR_URL . 'build/extensions/core/table/style.css', array(), VK_BLOCKS_VERSION );
+		wp_enqueue_style( 'vk-blocks/core-heading', VK_BLOCKS_DIR_URL . 'build/extensions/core/heading/style.css', array(), VK_BLOCKS_VERSION );
+		wp_enqueue_style( 'vk-blocks/core-image', VK_BLOCKS_DIR_URL . 'build/extensions/core/image/style.css', array(), VK_BLOCKS_VERSION );
 	}
 
 	/**

--- a/inc/vk-blocks/class-vk-blocks-block-loader.php
+++ b/inc/vk-blocks/class-vk-blocks-block-loader.php
@@ -101,7 +101,7 @@ class VK_Blocks_Block_Loader {
 	public function add_styles() {
 		// 分割読み込みの場合は register されるファイルが false 指定で何も読み込まれなくなっている.
 		wp_enqueue_style( 'vk-blocks-build-css' );
-		wp_enqueue_style( 'vk-blocks-utils-common-css');
+		wp_enqueue_style( 'vk-blocks-utils-common-css' );
 		wp_enqueue_style( 'vk-blocks/core-table', VK_BLOCKS_DIR_URL . 'build/extensions/core/table/style.css', array(), VK_BLOCKS_VERSION );
 		wp_enqueue_style( 'vk-blocks/core-heading', VK_BLOCKS_DIR_URL . 'build/extensions/core/heading/style.css', array(), VK_BLOCKS_VERSION );
 		wp_enqueue_style( 'vk-blocks/core-image', VK_BLOCKS_DIR_URL . 'build/extensions/core/image/style.css', array(), VK_BLOCKS_VERSION );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/2123#issuecomment-2257272191

## どういう変更をしたか？

#2130 で編集画面の表示が崩れてしまったため、build-cssの読み込みを直しました。
該当のif文を削除しただけですので、確認は1人で大丈夫かと思います。
(もし気になるようなら2人目確認でももちろん大丈夫です。)

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/2af4b0a6-9a0e-4051-9b6c-e19ee4bc685e)

#### 変更後 After
![image](https://github.com/user-attachments/assets/16381474-4951-4206-b08d-9c98d1c47851)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
→ #2130 はまだ配信されていないためスキップ。
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→スキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

このブランチで
[bunkatsu.txt](https://github.com/user-attachments/files/16420555/bunkatsu.txt)のブロックを変種画面にコピペした際、変更後 Afterになるかを確認しました。
※buildブランチの時は変更前 Beforeになります。

また、複数の環境で確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
