### PR TITLE
[ 分割読み込み ] キーカラーが反映されない場合がある現象に対応しました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,8 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Design Bug Fix ] Added dynamic color settings for common css.
 [ Add function ][ Slider Item ] Fix infinite loop in slider item block when used in reusable blocks.
-
 [ Bug fix ] The split loading option is now supported for core/heading, core/image, and core/table styles.
 
 = 1.80.1 =

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -4,6 +4,7 @@
 
 .text-nowrap {
 	white-space: nowrap;
+	color :#ff6900;
 }
 
 /*-------------------------------------------*/
@@ -120,14 +121,8 @@
 }
 
 /*-------------------------------------------*/
-/* リストデザイン
+/* パレット設定
 /*-------------------------------------------*/
-@mixin mark-before {
-	font-family: "Font Awesome 5 Free";
-	font-weight: 900;
-	position: absolute;
-}
-
 $stylePalette: (
 	is-style-vk-arrow-mark: "\f138",
 	is-style-vk-triangle-mark: "\f0da",
@@ -141,28 +136,63 @@ $stylePalette: (
 );
 
 $colorPalette: (
-	vk-has-pale-pink-color: #f78da7,
-	vk-has-vivid-red-color: #cf2e2e,
-	vk-has-luminous-vivid-orange-color: #ff6900,
-	vk-has-luminous-vivid-amber-color: #fcb900,
-	vk-has-light-green-cyan-color: #7bdcb5,
-	vk-has-vivid-green-cyan-color: #00d084,
-	vk-has-pale-cyan-blue-color: #8ed1fc,
-	vk-has-vivid-cyan-blue-color: #0693e3,
-	vk-has-vivid-purple-color: #9b51e0,
-	vk-has-very-light-gray-color: #eee,
-	vk-has-cyan-bluish-gray-color: #abb8c3,
-	vk-has-very-dark-gray-color: #313131,
-	vk-has-white-color: #ffffff,
-	vk-has-vk-color-primary-color: var(--wp--preset--color--vk-color-primary),
-	vk-has-vk-color-primary-dark-color: var(--wp--preset--color--vk-color-primary-dark),
-	vk-has-vk-color-primary-vivid-color: var(--wp--preset--color--vk-color-primary-vivid),
-	vk-has-vk-color-custom-1-color: var(--wp--preset--color--vk-color-custom-1),
-	vk-has-vk-color-custom-2-color: var(--wp--preset--color--vk-color-custom-2),
-	vk-has-vk-color-custom-3-color: var(--wp--preset--color--vk-color-custom-3),
-	vk-has-vk-color-custom-4-color: var(--wp--preset--color--vk-color-custom-4),
-	vk-has-vk-color-custom-5-color: var(--wp--preset--color--vk-color-custom-5),
+	has-vk-pale-pink: #f78da7,
+	has-vk-vivid-red: #cf2e2e,
+	has-vk-luminous-vivid-orange: #ff6900,
+	has-vk-luminous-vivid-amber: #fcb900,
+	has-vk-light-green-cyan: #7bdcb5,
+	has-vk-vivid-green-cyan: #00d084,
+	has-vk-pale-cyan-blue: #8ed1fc,
+	has-vk-vivid-cyan-blue: #0693e3,
+	has-vk-vivid-purple: #9b51e0,
+	has-vk-very-light-gray: #eee,
+	has-vk-cyan-bluish-gray: #abb8c3,
+	has-vk-very-dark-gray: #313131,
+	has-vk-white: #ffffff,
+	has-vk-color-primary: var(--wp--preset--color--vk-color-primary),
+	has-vk-color-primary-dark: var(--wp--preset--color--vk-color-primary-dark),
+	has-vk-color-primary-vivid: var(--wp--preset--color--vk-color-primary-vivid),
+	has-vk-color-custom-1: var(--wp--preset--color--vk-color-custom-1),
+	has-vk-color-custom-2: var(--wp--preset--color--vk-color-custom-2),
+	has-vk-color-custom-3: var(--wp--preset--color--vk-color-custom-3),
+	has-vk-color-custom-4: var(--wp--preset--color--vk-color-custom-4),
+	has-vk-color-custom-5: var(--wp--preset--color--vk-color-custom-5),
 );
+
+/*-------------------------------------------*/
+/* カラー設定
+/*-------------------------------------------*/
+@each $colorClass, $color in $colorPalette {
+	:root,
+	:root .editor-styles-wrapper {
+		// 一般的なカラー設定
+		.#{$colorClass}-background-color {
+			@if $colorClass == has-vk-color-primary {
+				// has-vk-color-primary-background-colorクラスはデフォルトで設定される。Lightning以外のテーマに対応するため代替値を設定
+				background-color: var(--wp--preset--color--vk-color-primary, #337ab7);
+			} @else {
+				background-color: #{$color};
+			}
+		}
+
+		.#{$colorClass}-color {
+			@if $colorClass == has-vk-color-primary {
+				color: var(--wp--preset--color--vk-color-primary, #337ab7);
+			} @else {
+				color: #{$color};
+			}
+		}
+	}
+}
+
+/*-------------------------------------------*/
+/* リストデザイン
+/*-------------------------------------------*/
+@mixin mark-before {
+	font-family: "Font Awesome 5 Free";
+	font-weight: 900;
+	position: absolute;
+}
 
 ul,
 ol {
@@ -353,8 +383,8 @@ ol {
 			}
 		}
 
-		&.is-style-vk-numbered-circle-mark.#{$colorClass},
-		&.is-style-vk-numbered-square-mark.#{$colorClass} {
+		&.is-style-vk-numbered-circle-mark.#{$colorClass}-color,
+		&.is-style-vk-numbered-square-mark.#{$colorClass}-color {
 			li::before {
 				color: #ffffff;
 				background-color: $color;
@@ -424,7 +454,7 @@ ol {
 	}
 
 	@each $colorClass, $color in $colorPalette {
-		&.#{$colorClass} {
+		&.#{$colorClass}-color {
 			border-color: $color;
 			.wp-block-group__inner-container {
 				border-color: $color;

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -163,8 +163,7 @@ $colorPalette: (
 /* カラー設定
 /*-------------------------------------------*/
 @each $colorClass, $color in $colorPalette {
-	:root,
-	:root .editor-styles-wrapper {
+	:root {
 		// 一般的なカラー設定
 		.#{$colorClass}-background-color {
 			@if $colorClass == has-vk-color-primary {

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -4,7 +4,6 @@
 
 .text-nowrap {
 	white-space: nowrap;
-	color :#ff6900;
 }
 
 /*-------------------------------------------*/


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2128

## どういう変更をしたか？

リストデザインにあったカラーパレット設定を使うため、変数名を調整し、一般的なカラー設定を追加しました。
また、カラーパレットを含むパレット設定に見出しをつけ、独立させました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/42c7ca26-6267-4868-aa3f-e67bdd3a1cdf)

#### 変更後 After
![image](https://github.com/user-attachments/assets/3d22f030-efcc-44f0-a5b4-9ac9154930b6)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→CSSのみのためスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

X-T9、かつ、分割読み込みをONにした時に以下を確認しました。
このブランチで
[bunkatsu.txt](https://github.com/user-attachments/files/16420555/bunkatsu.txt)のブロックを変種画面にコピペした際、変更後 Afterになるかを確認しました。
※buildブランチの時は変更前 Beforeになります。

また、以下も確認しました。

- プライマリーカラー以外に、プライマリーホバーや背景 セカンダリを選択した時でもフロントエンドで色が反映されていました。
- リストアイコンやグループブロックにプライマリーカラーを設定した時に、上記の変更の影響を受けずに引き続きプライマリーカラーが使われていました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をお願いいたします。
また、コードの確認をお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
