### PR TITLE
【確認中】[ カテゴリーバッジ ] WP6.6でスピナーが出続ける現象を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Category Badge (Pro) ] Fixed error handling and compatibility.
 [ Editor Design Bug Fix ][ Slider Item ]Fixed to hide content that exceeds the height when setting the slider height.
 [ Design Bug Fix ] Added dynamic color settings for common css.
 [ Add function ][ Slider Item ] Fix infinite loop in slider item block when used in reusable blocks.

--- a/src/blocks/_pro/post-category-badge/edit.js
+++ b/src/blocks/_pro/post-category-badge/edit.js
@@ -20,16 +20,19 @@ export default function CategoryBadgeEdit(props) {
 	const { postId, postType } = context;
 
 	// termColorを取得（VKTermColor::get_post_single_term_info() の返り値）
-	const { value: termColorInfo, isResolving: isLoading } = useSelect(
-		(select) => {
-			if (!autoTaxonomy) return { value: {}, isResolving: false };
-			return select('vk-blocks/term-color').getTermColorInfo(
-				postId,
-				autoTaxonomy
-			);
-		},
-		[autoTaxonomy, postId]
-	) || {};
+	const { value: termColorInfo, isResolving: isLoading } =
+		useSelect(
+			(select) => {
+				if (!autoTaxonomy) {
+					return { value: {}, isResolving: false };
+				}
+				return select('vk-blocks/term-color').getTermColorInfo(
+					postId,
+					autoTaxonomy
+				);
+			},
+			[autoTaxonomy, postId]
+		) || {};
 
 	// タクソノミー名取得
 	function getTaxonomyName(slug, taxonomies) {
@@ -54,40 +57,43 @@ export default function CategoryBadgeEdit(props) {
 	}
 
 	// タクソノミー一覧を取得
-	const taxonomies = useSelect(
-		(select) => {
-			const allTaxonomies = select('core').getTaxonomies();
-			return allTaxonomies
-				? allTaxonomies.filter(
-						(_taxonomy) =>
-							_taxonomy.slug !== 'post_tag' &&
-							_taxonomy.hierarchical
-					)
-				: [];
-		},
-		[postType]
-	) || [];
+	const taxonomies =
+		useSelect(
+			(select) => {
+				const allTaxonomies = select('core').getTaxonomies();
+				return allTaxonomies
+					? allTaxonomies.filter(
+							(_taxonomy) =>
+								_taxonomy.slug !== 'post_tag' &&
+								_taxonomy.hierarchical
+						)
+					: [];
+			},
+			[postType]
+		) || [];
 
 	// タクソノミーが「Auto」に設定されている場合の処理
-	const autoTaxonomy = taxonomy === '' ? getAutoTaxonomy(taxonomies, postType) : taxonomy;
+	const autoTaxonomy =
+		taxonomy === '' ? getAutoTaxonomy(taxonomies, postType) : taxonomy;
 
 	// 投稿に関連付けられたタームを取得
-	const terms = useSelect(
-		(select) => {
-			if (!autoTaxonomy) {
-				return [];
-			}
-			return select('core').getEntityRecords(
-				'taxonomy',
-				autoTaxonomy,
-				{
-					per_page: -1, // すべてのタームを取得
-					post: postId,
+	const terms =
+		useSelect(
+			(select) => {
+				if (!autoTaxonomy) {
+					return [];
 				}
-			);
-		},
-		[autoTaxonomy, postId]
-	) || [];
+				return select('core').getEntityRecords(
+					'taxonomy',
+					autoTaxonomy,
+					{
+						per_page: -1, // すべてのタームを取得
+						post: postId,
+					}
+				);
+			},
+			[autoTaxonomy, postId]
+		) || [];
 
 	const selectedTerm = terms.length > 0 ? terms[0] : null;
 
@@ -106,13 +112,15 @@ export default function CategoryBadgeEdit(props) {
 	const termUrl = termColorInfo?.term_url || '';
 
 	// 対象のタームが見つからなかったらタクソノミ名を表示
-	const termName = isLoading ? (
-		<Spinner />
-	) : selectedTerm ? (
-		selectedTerm.name
-	) : (
-		getTaxonomyName(autoTaxonomy, taxonomies)
-	);
+	let termName;
+
+	if (isLoading) {
+		termName = <Spinner />;
+	} else if (selectedTerm) {
+		termName = selectedTerm.name;
+	} else {
+		termName = getTaxonomyName(autoTaxonomy, taxonomies);
+	}
 
 	return (
 		<>

--- a/src/blocks/_pro/post-category-badge/edit.js
+++ b/src/blocks/_pro/post-category-badge/edit.js
@@ -11,7 +11,6 @@ import {
 	PanelBody,
 	ToggleControl,
 	SelectControl,
-	// Spinner, // 使用されていないため削除
 } from '@wordpress/components';
 
 export default function CategoryBadgeEdit(props) {
@@ -35,8 +34,21 @@ export default function CategoryBadgeEdit(props) {
 			[postType]
 		) || [];
 
-	// タクソノミーが未設定の場合、自動でデフォルトを設定
-	const autoTaxonomy = taxonomy || (taxonomies.length > 0 ? 'category' : '');
+	// 自動判定用の関数
+	function getAutoTaxonomy(taxonomies, postType) {
+		// 投稿タイプに関連するカスタムタクソノミーを優先して選択
+		const customTaxonomy = taxonomies.find((tax) => tax.types.includes(postType));
+		if (customTaxonomy) {
+			return customTaxonomy.slug;
+		}
+
+		// カスタムタクソノミーがない場合はカテゴリーを選択
+		const defaultTaxonomy = taxonomies.find((tax) => tax.slug === 'category');
+		return defaultTaxonomy ? defaultTaxonomy.slug : '';
+	}
+
+	// タクソノミーが「Auto」に設定されている場合の処理
+	const autoTaxonomy = taxonomy === '' ? getAutoTaxonomy(taxonomies, postType) : taxonomy;
 
 	// termColorを取得（VKTermColor::get_post_single_term_info() の返り値）
 	const { value: termColorInfo, isResolving: isLoading } = useSelect(
@@ -70,10 +82,6 @@ export default function CategoryBadgeEdit(props) {
 			},
 			[autoTaxonomy, postId]
 		) || [];
-
-	// const selectedTaxonomyName = autoTaxonomy
-	// 	? taxonomies.find((tax) => tax.slug === autoTaxonomy)?.name
-	// 	: __('Auto', 'vk-blocks-pro'); // 使用されていないため削除
 
 	const selectedTerm = terms && terms.length > 0 ? terms[0] : null;
 
@@ -116,7 +124,7 @@ export default function CategoryBadgeEdit(props) {
 					{taxonomies.length > 1 && (
 						<SelectControl
 							label={__('Select Taxonomy', 'vk-blocks-pro')}
-							value={autoTaxonomy}
+							value={taxonomy === '' ? '' : taxonomy} // 表面上は「自動」に表示
 							options={[
 								{
 									label: __('Auto', 'vk-blocks-pro'),


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2151 

## どういう変更をしたか？

post-category-badge ブロックが WordPress 6.6 でカテゴリーやターム名を適切に取得・表示しない問題を修正しました。
自動判定された autoTaxonomy を使用して、適切なタクソノミーを選択し、それに基づいてタームを取得するようにしました。これにより、クエリループに基づいたタームが正しく取得され、表示されるようになりました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/6d75b2b1-ee97-485f-b366-adbf0e620f40)

#### 変更後 After
![image](https://github.com/user-attachments/assets/faf2da58-7623-4bbe-8b2e-c83f0dae504a)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→editを修正しただけなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下をX-T9のサイト編集、固定ページで確認しました。
- クエリループの中にカテゴリーやタームが自動で正しく取得され、編集画面およびフロントエンドで表示されることを確認。
- カテゴリーやタームがない場合はタクソノミ名が表示されることを確認。
- クエリループで投稿からカスタム投稿に変更した時、カテゴリーバッジがAutoの場合は、自動的にカスタム投稿のターム名を取得することを確認。
- 複数のカテゴリーやタームが選択されている場合、選択されたいずれかのものが表示されていることを確認。
- フロントエンドでもカテゴリーバッチが正しく取得されていることを確認。
- 「タームへのリンクを有効にする」がONの場合、フロントエンドでカテゴリーバッジをクリックしたらカテゴリーやタームのアーカイブページに移動することを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をお願いします。
また、開発の方はコードの確認もお願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
