### PR TITLE
スマホやタブレットでスクロール時に勝手に開閉しないようにしました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,8 @@ e.g.
 
 == Changelog ==
 
-[ Bug Fix][ Blog Card ] Make it editable in the edit screen in WordPress 6.6
+[ Bug fix ][ Accordion(Pro) ] Remove resize event causing accordion closure on scroll.
+[ Bug Fix ][ Blog Card ] Make it editable in the edit screen in WordPress 6.6
 [ Bug Fix ] Setting a grid column block inside a reusable block no longer causes an error.
 [ Editor Design Bug Fix ][ Slider Item ]Fixed to hide content that exceeds the height when setting the slider height.
 [ Design Bug Fix ] Added dynamic color settings for common css.
@@ -148,7 +149,7 @@ e.g.
 
 = 1.77.0 =
 [ Add function ][ Outer (Pro) ] Add toolbar link for components.
-[ Add function ][ Accordion ] Added initial display state setting.
+[ Add function ][ Accordion(Pro) ] Added initial display state setting.
 [ Specification Change ][ Tab (Pro) ] Accessibility support
 [ Bug fix ][ Table of Contents (Pro) ] Fix "OBJ" characters appeared in the Table of Contents on Windows.
 [ Bug fix ] Delete unnecessary development files included in 1.76.2.
@@ -216,7 +217,7 @@ e.g.
 [ Editor Design Bug fix ][ Slider ] Fixed an issue where slider item height disappears when editorMode is slide and alignfull.
 
 = 1.71.0 =
-[ Add function ][ Accordion ] Add plain style to accordion block.
+[ Add function ][ Accordion(Pro) ] Add plain style to accordion block.
 [ Add Function ][ icon ] Add Font color option in solid type icon.
 [ Bug fix ][ Button ] Fixed buttonColorCustom in the editor to display the correct color.
 [ Bug fix ][ Table of Contents (Pro) ] Fixed visibility issue in 6.5.

--- a/src/blocks/_pro/accordion/view.js
+++ b/src/blocks/_pro/accordion/view.js
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		// 初期ロード時とウィンドウサイズが変わった時に実行
+		// 初期ロード時に実行
 		updateAccordion();
 	});
 });

--- a/src/blocks/_pro/accordion/view.js
+++ b/src/blocks/_pro/accordion/view.js
@@ -50,7 +50,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		// 初期ロード時とウィンドウサイズが変わった時に実行
 		updateAccordion();
-		window.addEventListener('resize', updateAccordion);
 	});
 });
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2155

## どういう変更をしたか？
`window.addEventListener('resize', updateAccordion);`を削除して、スマホやタブレットのスクロール時に勝手に閉じないようにしました。

jsから1行削除しただけなので1人の確認でいいと思いますが、確認内容に応じて2人目の必要性をを適宜ご判断ください。

### スクリーンショットまたは動画

#### 変更前 Before
https://github.com/user-attachments/assets/c679ad6b-dfc3-4591-8f91-db8d1b4ba879

#### 変更後 After
https://github.com/user-attachments/assets/dbe36a2f-2d04-4bb8-bdb0-8293c8dbd269

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→view.jsから1行削除しただけなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. アコーディオンを設置し、モバイル、タブレット、PCでそれぞれ初期状態(開く/閉じる)を設定。
2. スマホやPCでフロントエンドを確認時、スクロールして勝手に初期状態から変わらないか確認しました。
3. スマホやPCでフロントエンドを確認時、アコーディオンの開閉を変更→スクロール でアコーディオンの開閉状態が維持できているかを確認。
(developの場合はアコーディオンの開閉を変更→スクロールをした時、再びアコーディオンに戻ると初期状態に戻ってしまってました。)

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行なってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
