### PR TITLE
グループブロックでtheme.jsonを使わないで設定できる「線の色」パネルで設定した色が設定できないのを修正しました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ] Added dynamic color settings for `vk-has-*` and `has-vk-*` classes.
 [ Bug fix ][ Grid Column Card (Pro) ] Fixed that Grid Column Card Item Footer block button horizontal align right not work.
 [ Add function ][ Core Cover ] Add toolbar link for components.
 [ Specification Change ] Delete width setting from sidebar.

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -465,13 +465,16 @@ ol {
 	}
 
 	@each $colorClass, $color in $colorPalette {
-		&.#{$colorClass}-color {
+		&.vk-has-#{$colorClass}-color,
+		&.has-vk-#{$colorClass}-color {
+			color: initial;
 			border-color: $color;
 			.wp-block-group__inner-container {
+				color: initial;
 				border-color: $color;
 			}
 		}
-	}
+	}	
 } //.wp-block-group
 .is-style-vk-group {
 	&-solid {

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -135,32 +135,45 @@ $stylePalette: (
 );
 
 $colorPalette: (
-	has-vk-pale-pink: #f78da7,
-	has-vk-vivid-red: #cf2e2e,
-	has-vk-luminous-vivid-orange: #ff6900,
-	has-vk-luminous-vivid-amber: #fcb900,
-	has-vk-light-green-cyan: #7bdcb5,
-	has-vk-vivid-green-cyan: #00d084,
-	has-vk-pale-cyan-blue: #8ed1fc,
-	has-vk-vivid-cyan-blue: #0693e3,
-	has-vk-vivid-purple: #9b51e0,
-	has-vk-very-light-gray: #eee,
-	has-vk-cyan-bluish-gray: #abb8c3,
-	has-vk-very-dark-gray: #313131,
-	has-vk-white: #ffffff,
-	has-vk-color-primary: var(--wp--preset--color--vk-color-primary),
-	has-vk-color-primary-dark: var(--wp--preset--color--vk-color-primary-dark),
-	has-vk-color-primary-vivid: var(--wp--preset--color--vk-color-primary-vivid),
-	has-vk-color-custom-1: var(--wp--preset--color--vk-color-custom-1),
-	has-vk-color-custom-2: var(--wp--preset--color--vk-color-custom-2),
-	has-vk-color-custom-3: var(--wp--preset--color--vk-color-custom-3),
-	has-vk-color-custom-4: var(--wp--preset--color--vk-color-custom-4),
-	has-vk-color-custom-5: var(--wp--preset--color--vk-color-custom-5),
+	(pale-pink, #f78da7),
+	(vivid-red, #cf2e2e),
+	(luminous-vivid-orange, #ff6900),
+	(luminous-vivid-amber, #fcb900),
+	(light-green-cyan, #7bdcb5),
+	(vivid-green-cyan, #00d084),
+	(pale-cyan-blue, #8ed1fc),
+	(vivid-cyan-blue, #0693e3),
+	(vivid-purple, #9b51e0),
+	(very-light-gray, #eee),
+	(cyan-bluish-gray, #abb8c3),
+	(very-dark-gray, #313131),
+	(white, #ffffff),
+	(color-primary, var(--wp--preset--color--vk-color-primary)),
+	(color-primary-dark, var(--wp--preset--color--vk-color-primary-dark)),
+	(color-primary-vivid, var(--wp--preset--color--vk-color-primary-vivid)),
+	(color-custom-1, var(--wp--preset--color--vk-color-custom-1)),
+	(color-custom-2, var(--wp--preset--color--vk-color-custom-2)),
+	(color-custom-3, var(--wp--preset--color--vk-color-custom-3)),
+	(color-custom-4, var(--wp--preset--color--vk-color-custom-4)),
+	(color-custom-5, var(--wp--preset--color--vk-color-custom-5))
 );
 
 /*-------------------------------------------*/
 /* カラー設定
 /*-------------------------------------------*/
+@each $name, $color in $colorPalette {
+	:root {
+		.has-vk-#{$name}-color,
+		.vk-has-#{$name}-color {
+			color: #{$color};
+		}
+		.has-vk-#{$name}-background-color,
+		.vk-has-#{$name}-background-color {
+			background-color: #{$color};
+		}
+	}
+}
+
 @each $colorClass, $color in $colorPalette {
 	:root {
 		// 一般的なカラー設定

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -164,11 +164,11 @@ $colorPalette: (
 @each $name, $color in $colorPalette {
 	:root {
 		.has-vk-#{$name}-color,
-		.vk-has-#{$name}-color {
+		.vk-has-vk-#{$name}-color {
 			color: #{$color};
 		}
 		.has-vk-#{$name}-background-color,
-		.vk-has-#{$name}-background-color {
+		.vk-has-vk-#{$name}-background-color {
 			background-color: #{$color};
 		}
 	}
@@ -177,17 +177,20 @@ $colorPalette: (
 @each $colorClass, $color in $colorPalette {
 	:root {
 		// 一般的なカラー設定
-		.#{$colorClass}-background-color {
-			@if $colorClass == has-vk-color-primary {
-				// has-vk-color-primary-background-colorクラスはデフォルトで設定される。Lightning以外のテーマに対応するため代替値を設定
+		.vk-has-#{$colorClass}-background-color,
+		.has-vk-#{$colorClass}-background-color {
+			@if $colorClass == color-primary {
+				// color-primaryに関する特殊処理
 				background-color: var(--wp--preset--color--vk-color-primary, #337ab7);
 			} @else {
 				background-color: #{$color};
 			}
 		}
 
-		.#{$colorClass}-color {
-			@if $colorClass == has-vk-color-primary {
+		.vk-has-#{$colorClass}-color,
+		.has-vk-#{$colorClass}-color {
+			@if $colorClass == color-primary {
+				// color-primaryに関する特殊処理
 				color: var(--wp--preset--color--vk-color-primary, #337ab7);
 			} @else {
 				color: #{$color};
@@ -474,7 +477,7 @@ ol {
 				border-color: $color;
 			}
 		}
-	}	
+	}
 } //.wp-block-group
 .is-style-vk-group {
 	&-solid {

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -161,19 +161,6 @@ $colorPalette: (
 /*-------------------------------------------*/
 /* カラー設定
 /*-------------------------------------------*/
-@each $name, $color in $colorPalette {
-	:root {
-		.has-vk-#{$name}-color,
-		.vk-has-vk-#{$name}-color {
-			color: #{$color};
-		}
-		.has-vk-#{$name}-background-color,
-		.vk-has-vk-#{$name}-background-color {
-			background-color: #{$color};
-		}
-	}
-}
-
 @each $colorClass, $color in $colorPalette {
 	:root {
 		// 一般的なカラー設定


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2177 

## どういう変更をしたか？

- vk-has-* と has-vk-* の両方のクラス名に対して、同一の色が適用されるようにSCSSファイルを修正しました。
- @eachループを使用して、カラーパレット内の各カラーに対応するクラス名を統一的に処理するようにしました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/2e668fa3-d869-4de2-98c6-63231ece1c86)
![image](https://github.com/user-attachments/assets/b6d18bfb-7548-4a5e-8e2d-92c2de5fd4c3)

#### 変更後 After
![image](https://github.com/user-attachments/assets/54542a92-f5d1-4c43-a710-5753ce74714b)
![image](https://github.com/user-attachments/assets/563a6a9f-0210-4f79-989a-6b8682cf0a56)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→CSSを整理しただけなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

テーマLightningにて以下を確認しました。

1. 外観 > カスタマイズ > Lightning 機能設定 > theme.json 設定 のチェックを外す。
2. 編集画面でグループブロックを追加し スタイル > 直線 など枠線の入るスタイルを設置
3. 「線の色」パネルでオレンジやプライマリーカラーなどを設定した時、線やテキストが選んだ色になることを確認しました。(developの場合、線の色が変わりません。)

※ コミットを遡って /src/utils/common.scss の vk-has-* から has-vk-* の クラス名を変える前のコードをいくつかビルドしましたが、カスタムカラーの色は線の色で設定されませんでした。必要ならissue化します。

また、以下の確認も行いました。
- スタイル > 色 での設定も適切に反映されることを確認しました。
- 設定 > VK Blocks > 分割読み込みを有効にする にチェックをした時でも線の色が適切に設定されていることを確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
