### PR TITLE
[ リンクツールバー ] 相対パスを入力したらそのまま返すように修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,7 @@ e.g.
 
 == Changelog ==
 
-[ Bug fix ][ Link toolbar ] Add auto-conversion of relative URLs to full URLs.
+[ Bug fix ][ Link toolbar ] Fix to prevent adding http:// or https:// when a relative path is entered.
 
 = 1.83.0 =
 [ Add Function ][ Alert ] Add icon setting and inner block.

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Link toolbar ] Add auto-conversion of relative URLs to full URLs.
+
 = 1.83.0 =
 [ Add Function ][ Alert ] Add icon setting and inner block.
 [ Bug fix ][ Grid Column Card ] Fixed an issue where using a synced pattern would cause the destination edit page to crash.

--- a/src/components/link-toolbar/index.js
+++ b/src/components/link-toolbar/index.js
@@ -199,23 +199,20 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 
 	// URLのフォーマット関数を更新
 	const formatUrl = (url) => {
+		// 絶対パス・相対パス・アンカーリンクであればそのまま返す
 		if (
 			url.startsWith('http://') ||
 			url.startsWith('https://') ||
+			url.startsWith('/') ||
 			url.startsWith('#') ||
 			url === ''
 		) {
 			return url;
 		}
-		// URLが内部パスである場合、現在のドメインを使用してフルURLを作成
-		if (url.startsWith('/')) {
-			const protocol = window.location.protocol;
-			const host = window.location.host;
-			return `${protocol}//${host}${url}`;
-		}
-		// URLが内部パスでもフルパスでもない場合、httpを追加
+		// その他のリンクは http:// を付加する
 		return 'http://' + url;
 	};
+	
 
 	const handleSubmit = () => {
 		if (linkUrl) {

--- a/src/components/link-toolbar/index.js
+++ b/src/components/link-toolbar/index.js
@@ -197,6 +197,7 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 		}
 	};
 
+	// URLのフォーマット関数を更新
 	const formatUrl = (url) => {
 		if (
 			url.startsWith('http://') ||
@@ -206,6 +207,13 @@ const LinkToolbar = ({ linkUrl, setLinkUrl, linkTarget, setLinkTarget }) => {
 		) {
 			return url;
 		}
+		// URLが内部パスである場合、現在のドメインを使用してフルURLを作成
+		if (url.startsWith('/')) {
+			const protocol = window.location.protocol;
+			const host = window.location.host;
+			return `${protocol}//${host}${url}`;
+		}
+		// URLが内部パスでもフルパスでもない場合、httpを追加
 		return 'http://' + url;
 	};
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2195 

@kurudrive
機能として必要かどうかも見ていただけたらと思います。

## どういう変更をしたか？

LinkToolbar コンポーネント内で、今までは相対パスを入浴した時にhttp:///contact/のようになっていたので、ユーザーが入力した相対パスをそのまま返すように変更しました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/59dd0b44-7e86-4f98-b3f6-83ce2c4ea18a)

#### 変更後 After
![image](https://github.com/user-attachments/assets/2bca7567-6c9a-49e9-8b73-d2b2f724d5a5)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ifの中身を書き換えただけなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

グループブロックやグリッドカラムブロックなどで、以下のリンクの状態を確認しました。
- 相対パス（例：/content/）を入力し、入力したままの状態で返されることを確認しました。
- 絶対パス（例：http://example.com/content/）を入力し、変換されないことを確認しました。
- アンカーリンク（例：#section）を入力し、変換されないことを確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をしてください。
開発の方はコードの確認も行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
