### PR TITLE
[ パンくず ] パンくずリスト設定で設定したセパレーターをVKテーマのパンくず機能でも適用できるようにしました

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,6 +76,10 @@ gulp.task('helper-js-pro', (done) => {
 		.pipe(uglify())
 		.pipe(rename('vk-animation.min.js'))
 		.pipe(gulp.dest('./build/'));
+	gulp.src('src/blocks/_pro/breadcrumb/view.js')
+		.pipe(uglify())
+		.pipe(rename('vk-breadcrumb.min.js'))
+		.pipe(gulp.dest('./build/'));
 	gulp.src('src/blocks/_pro/fixed-display/view.js')
 		.pipe(uglify())
 		.pipe(rename('vk-fixed-display.min.js'))

--- a/inc/vk-blocks-pro/vk-blocks-pro-functions.php
+++ b/inc/vk-blocks-pro/vk-blocks-pro-functions.php
@@ -29,11 +29,14 @@ function vk_blocks_pro_load_scripts() {
 	// Accordion Block
 	wp_enqueue_script( 'vk-blocks-accordion', VK_BLOCKS_DIR_URL . 'build/vk-accordion.min.js', array(), VK_BLOCKS_VERSION, true );
 
-	// Faq Block
-	wp_enqueue_script( 'vk-blocks-faq2', VK_BLOCKS_DIR_URL . 'build/vk-faq2.min.js', array(), VK_BLOCKS_VERSION, true );
-
 	// Animation Block
 	wp_enqueue_script( 'vk-blocks-animation', VK_BLOCKS_DIR_URL . 'build/vk-animation.min.js', array(), VK_BLOCKS_VERSION, true );
+
+	// Breadcrumb Block
+	wp_enqueue_script( 'vk-blocks-breadcrumb', VK_BLOCKS_DIR_URL . 'build/vk-breadcrumb.min.js', array(), VK_BLOCKS_VERSION, true );
+
+	// Faq Block
+	wp_enqueue_script( 'vk-blocks-faq2', VK_BLOCKS_DIR_URL . 'build/vk-faq2.min.js', array(), VK_BLOCKS_VERSION, true );
 
 	// Fixed Display Block
 	wp_enqueue_script( 'vk-blocks-fixed-display', VK_BLOCKS_DIR_URL . 'build/vk-fixed-display.min.js', array(), VK_BLOCKS_VERSION, true );

--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,7 @@ e.g.
 
 == Changelog ==
 
-
+[ Add function ][ Breadcrumb(Pro) ] Add breadcrumb settings now work with Vektor Inc. theme products.
 [ Add function ] Added support for custom CSS including pseudo-elements.
 [ Bug fix ][ Grid Column Card ] Fix infinite loop in grid column card block when used in reusable blocks.
 [ Add function ][ Column ] Add toolbar link for components.
@@ -251,7 +251,7 @@ e.g.
 
 = 1.70.0 =
 [ Specification Change ] core/social-link, core/site-logo, core/site-title and core/site-tagline correspond to margin-extension
-[ Add function ][ Breadcrumb ] Add the ability to input breadcrumb separators.
+[ Add function ][ Breadcrumb(Pro) ] Add the ability to input breadcrumb separators.
 
 = 1.69.1 =
 [ Bug fix ][ Inline Font Size ] Applies only Font Size has a numeric value.

--- a/src/admin/breadcrumb.js
+++ b/src/admin/breadcrumb.js
@@ -1,5 +1,5 @@
 import { useState, useContext, useEffect } from '@wordpress/element';
-import { TextControl } from '@wordpress/components'; // TextControl を追加
+import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { AdminContext } from '@vkblocks/admin/index';
 

--- a/src/blocks/_pro/breadcrumb/index.php
+++ b/src/blocks/_pro/breadcrumb/index.php
@@ -53,6 +53,9 @@
 		 'class_list'         => 'vk_breadcrumb_list',
 		 'class_list_item'    => 'vk_breadcrumb_list_item',
 	 );
+
+	return $vk_breadcrumb->get_breadcrumb( $breadcrumb_options );
+
  }
  
  /**
@@ -109,10 +112,20 @@ function vk_blocks_register_breadcrumb_separator_style() {
 
 	// セパレーターのデザインが設定されている場合に動的CSSを生成
 	if ( '' !== $separator_design ) {
-		// セパレーターの文字列を適切にエスケープ
 		$separator_escaped = addslashes( $separator_design );
-		$dynamic_css = '<style>li.vk_breadcrumb_list_item:after, .breadcrumb-list li:after { content: "' . $separator_escaped . '"; }</style>';
-		echo $dynamic_css; // グローバルにスタイルを出力
+		$dynamic_css = '
+  			<style>
+     			li.vk_breadcrumb_list_item:after,
+				.breadcrumb-list li:after,
+				.breadSection .breadcrumb > li + li:before {
+    				content: "' . $separator_escaped . '";
+	  			}
+				.breadcrumb-list li:last-child:after,
+				.p-breadcrumbs li+li:before {
+					content: none;
+				}
+      		</style>';
+		echo $dynamic_css; 
 	}
 }
 add_action( 'wp_footer', 'vk_blocks_register_breadcrumb_separator_style' );

--- a/src/blocks/_pro/breadcrumb/index.php
+++ b/src/blocks/_pro/breadcrumb/index.php
@@ -5,128 +5,111 @@
  * @package vk-blocks
  */
 
- use VektorInc\VK_Breadcrumb\VkBreadcrumb;
-
- /**
-  * Breadcrumb render callback
-  *
-  * @param array $attributes Block attributes.
-  * @return string
-  */
- function vk_blocks_breadcrumb_render_callback( $attributes ) {
-	 if ( is_front_page() ) {
-		 return '';
-	 }
-	 $vk_breadcrumb = new VkBreadcrumb();
- 
-	 $outer_classes = 'vk_breadcrumb';
-	 if ( isset( $attributes['vkb_hidden'] ) && $attributes['vkb_hidden'] ) {
-		 $outer_classes .= ' vk_hidden';
-	 }
-	 if ( isset( $attributes['vkb_hidden_xxl'] ) && $attributes['vkb_hidden_xxl'] ) {
-		 $outer_classes .= ' vk_hidden-xxl';
-	 }
-	 if ( isset( $attributes['vkb_hidden_xl_v2'] ) && $attributes['vkb_hidden_xl_v2'] ) {
-		 $outer_classes .= ' vk_hidden-xl';
-	 }
-	 if ( isset( $attributes['vkb_hidden_lg'] ) && $attributes['vkb_hidden_lg'] ) {
-		 $outer_classes .= ' vk_hidden-lg';
-	 }
-	 if ( isset( $attributes['vkb_hidden_md'] ) && $attributes['vkb_hidden_md'] ) {
-		 $outer_classes .= ' vk_hidden-md';
-	 }
-	 if ( isset( $attributes['vkb_hidden_sm'] ) && $attributes['vkb_hidden_sm'] ) {
-		 $outer_classes .= ' vk_hidden-sm';
-	 }
-	 if ( isset( $attributes['vkb_hidden_xs'] ) && $attributes['vkb_hidden_xs'] ) {
-		 $outer_classes .= ' vk_hidden-xs';
-	 }
- 
-	 // block.jsonのSupportsで設定したクラス名やスタイルを取得する
-	 $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $outer_classes ) );
- 
-	 $breadcrumb_options = array(
-		 'id_outer'           => 'vk_breadcrumb',
-		 'class_outer'        => 'vk_breadcrumb', // wrapper_attributesを設定した場合、この文字列はパンくずリスト前後のコメントアウトに表示される
-		 'wrapper_attributes' => $wrapper_attributes,
-		 'class_inner'        => 'vk_breadcrumb_inner',
-		 'class_list'         => 'vk_breadcrumb_list',
-		 'class_list_item'    => 'vk_breadcrumb_list_item',
-	 );
-
-	return $vk_breadcrumb->get_breadcrumb( $breadcrumb_options );
-
- }
- 
- /**
-  * Register block breadcrumb
-  *
-  * @return void
-  */
- function vk_blocks_register_block_breadcrumb() {
- 
-	 // Register Style.
-	 if ( ! is_admin() ) {
-		 wp_register_style(
-			 'vk-blocks/breadcrumb',
-			 VK_BLOCKS_DIR_URL . 'build/_pro/breadcrumb/style.css',
-			 array(),
-			 VK_BLOCKS_VERSION
-		 );
-	 }
- 
-	 global $vk_blocks_common_attributes;
-	 register_block_type(
-		 __DIR__,
-		 array(
-			 'style'           => 'vk-blocks/breadcrumb',
-			 'editor_style'    => 'vk-blocks-build-editor-css',
-			 'editor_script'   => 'vk-blocks-build-js',
-			 'attributes'      => array_merge(
-				 array(
-					 'className' => array(
-						 'type'    => 'string',
-						 'default' => '',
-					 ),
-				 ),
-				 $vk_blocks_common_attributes
-			 ),
-			 'render_callback' => 'vk_blocks_breadcrumb_render_callback',
-		 )
-	 );
- }
- add_action( 'init', 'vk_blocks_register_block_breadcrumb', 99 );
+use VektorInc\VK_Breadcrumb\VkBreadcrumb;
 
 /**
- * Registers dynamic separator style globally
+ * Breadcrumb render callback
+ *
+ * @param array $attributes Block attributes.
+ * @return string
  */
-function vk_blocks_register_breadcrumb_separator_style() {
-	// ブロックの属性からセパレーターデザインの値を取得
-	$vk_blocks_options = VK_Blocks_Options::get_options();
+function vk_blocks_breadcrumb_render_callback( $attributes ) {
+	if ( is_front_page() ) {
+		return '';
+	}
+	$vk_breadcrumb = new VkBreadcrumb();
 
-	if ( isset( $vk_blocks_options['vk_blocks_pro_breadcrumb_separator'] ) ) {
-		$separator_design = $vk_blocks_options['vk_blocks_pro_breadcrumb_separator'];
-	} else {
-		$separator_design = '';
+	$outer_classes = 'vk_breadcrumb';
+	if ( isset( $attributes['vkb_hidden'] ) && $attributes['vkb_hidden'] ) {
+		$outer_classes .= ' vk_hidden';
+	}
+	if ( isset( $attributes['vkb_hidden_xxl'] ) && $attributes['vkb_hidden_xxl'] ) {
+		$outer_classes .= ' vk_hidden-xxl';
+	}
+	if ( isset( $attributes['vkb_hidden_xl_v2'] ) && $attributes['vkb_hidden_xl_v2'] ) {
+		$outer_classes .= ' vk_hidden-xl';
+	}
+	if ( isset( $attributes['vkb_hidden_lg'] ) && $attributes['vkb_hidden_lg'] ) {
+		$outer_classes .= ' vk_hidden-lg';
+	}
+	if ( isset( $attributes['vkb_hidden_md'] ) && $attributes['vkb_hidden_md'] ) {
+		$outer_classes .= ' vk_hidden-md';
+	}
+	if ( isset( $attributes['vkb_hidden_sm'] ) && $attributes['vkb_hidden_sm'] ) {
+		$outer_classes .= ' vk_hidden-sm';
+	}
+	if ( isset( $attributes['vkb_hidden_xs'] ) && $attributes['vkb_hidden_xs'] ) {
+		$outer_classes .= ' vk_hidden-xs';
 	}
 
-	// セパレーターのデザインが設定されている場合に動的CSSを生成
-	if ( '' !== $separator_design ) {
-		$separator_escaped = addslashes( $separator_design );
-		$dynamic_css = '
-  			<style>
-     			li.vk_breadcrumb_list_item:after,
-				.breadcrumb-list li:after,
-				.breadSection .breadcrumb > li + li:before {
-    				content: "' . $separator_escaped . '";
-	  			}
-				.breadcrumb-list li:last-child:after,
-				.p-breadcrumbs li+li:before {
-					content: none;
-				}
-      		</style>';
-		echo $dynamic_css; 
-	}
+	// block.jsonのSupportsで設定したクラス名やスタイルを取得する
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $outer_classes ) );
+
+	$breadcrumb_options = array(
+		'id_outer'           => 'vk_breadcrumb',
+		'class_outer'        => 'vk_breadcrumb',
+		'wrapper_attributes' => $wrapper_attributes,
+		'class_inner'        => 'vk_breadcrumb_inner',
+		'class_list'         => 'vk_breadcrumb_list',
+		'class_list_item'    => 'vk_breadcrumb_list_item',
+	);
+
+	return $vk_breadcrumb->get_breadcrumb( $breadcrumb_options );
 }
-add_action( 'wp_footer', 'vk_blocks_register_breadcrumb_separator_style' );
- 
+
+/**
+ * Register block breadcrumb
+ *
+ * @return void
+ */
+function vk_blocks_register_block_breadcrumb() {
+	// Register Style.
+	if ( ! is_admin() ) {
+		wp_register_style(
+			'vk-blocks/breadcrumb',
+			VK_BLOCKS_DIR_URL . 'build/_pro/breadcrumb/style.css',
+			array(),
+			VK_BLOCKS_VERSION
+		);
+	}
+
+	wp_enqueue_script(
+		'vk-blocks/breadcrumb-script',
+		VK_BLOCKS_DIR_URL . 'build/vk-breadcrumb.min.js',
+		array(),
+		VK_BLOCKS_VERSION,
+		true
+	);
+
+	// セパレーターの値を JavaScript に渡す
+	$vk_blocks_options = VK_Blocks_Options::get_options();
+	$separator_design  = isset( $vk_blocks_options['vk_blocks_pro_breadcrumb_separator'] ) ? $vk_blocks_options['vk_blocks_pro_breadcrumb_separator'] : '';
+	wp_localize_script(
+		'vk-blocks/breadcrumb-script',
+		'vkBreadcrumbSeparator',
+		array(
+			'separator' => esc_attr( $separator_design ),
+		)
+	);	
+
+	global $vk_blocks_common_attributes;
+	register_block_type(
+		__DIR__,
+		array(
+			'style'           => 'vk-blocks/breadcrumb',
+			'editor_style'    => 'vk-blocks-build-editor-css',
+			'editor_script'   => 'vk-blocks-build-js',
+			'attributes'      => array_merge(
+				array(
+					'className' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+				$vk_blocks_common_attributes
+			),
+			'render_callback' => 'vk_blocks_breadcrumb_render_callback',
+		)
+	);
+}
+add_action( 'init', 'vk_blocks_register_block_breadcrumb', 99 );

--- a/src/blocks/_pro/breadcrumb/index.php
+++ b/src/blocks/_pro/breadcrumb/index.php
@@ -15,7 +15,7 @@ use VektorInc\VK_Breadcrumb\VkBreadcrumb;
  */
 function vk_blocks_breadcrumb_render_callback( $attributes ) {
 	if ( is_front_page() ) {
-		return '';
+		return;
 	}
 	$vk_breadcrumb = new VkBreadcrumb();
 
@@ -47,7 +47,7 @@ function vk_blocks_breadcrumb_render_callback( $attributes ) {
 
 	$breadcrumb_options = array(
 		'id_outer'           => 'vk_breadcrumb',
-		'class_outer'        => 'vk_breadcrumb',
+		'class_outer'        => 'vk_breadcrumb', // wrapper_attributesを設定した場合、この文字列はパンくずリスト前後のコメントアウトに表示される
 		'wrapper_attributes' => $wrapper_attributes,
 		'class_inner'        => 'vk_breadcrumb_inner',
 		'class_list'         => 'vk_breadcrumb_list',

--- a/src/blocks/_pro/breadcrumb/index.php
+++ b/src/blocks/_pro/breadcrumb/index.php
@@ -90,7 +90,7 @@ function vk_blocks_register_block_breadcrumb() {
 		array(
 			'separator' => esc_attr( $separator_design ),
 		)
-	);	
+	);
 
 	global $vk_blocks_common_attributes;
 	register_block_type(

--- a/src/blocks/_pro/breadcrumb/index.php
+++ b/src/blocks/_pro/breadcrumb/index.php
@@ -5,55 +5,99 @@
  * @package vk-blocks
  */
 
-use VektorInc\VK_Breadcrumb\VkBreadcrumb;
+ use VektorInc\VK_Breadcrumb\VkBreadcrumb;
+
+ /**
+  * Breadcrumb render callback
+  *
+  * @param array $attributes Block attributes.
+  * @return string
+  */
+ function vk_blocks_breadcrumb_render_callback( $attributes ) {
+	 if ( is_front_page() ) {
+		 return '';
+	 }
+	 $vk_breadcrumb = new VkBreadcrumb();
+ 
+	 $outer_classes = 'vk_breadcrumb';
+	 if ( isset( $attributes['vkb_hidden'] ) && $attributes['vkb_hidden'] ) {
+		 $outer_classes .= ' vk_hidden';
+	 }
+	 if ( isset( $attributes['vkb_hidden_xxl'] ) && $attributes['vkb_hidden_xxl'] ) {
+		 $outer_classes .= ' vk_hidden-xxl';
+	 }
+	 if ( isset( $attributes['vkb_hidden_xl_v2'] ) && $attributes['vkb_hidden_xl_v2'] ) {
+		 $outer_classes .= ' vk_hidden-xl';
+	 }
+	 if ( isset( $attributes['vkb_hidden_lg'] ) && $attributes['vkb_hidden_lg'] ) {
+		 $outer_classes .= ' vk_hidden-lg';
+	 }
+	 if ( isset( $attributes['vkb_hidden_md'] ) && $attributes['vkb_hidden_md'] ) {
+		 $outer_classes .= ' vk_hidden-md';
+	 }
+	 if ( isset( $attributes['vkb_hidden_sm'] ) && $attributes['vkb_hidden_sm'] ) {
+		 $outer_classes .= ' vk_hidden-sm';
+	 }
+	 if ( isset( $attributes['vkb_hidden_xs'] ) && $attributes['vkb_hidden_xs'] ) {
+		 $outer_classes .= ' vk_hidden-xs';
+	 }
+ 
+	 // block.jsonのSupportsで設定したクラス名やスタイルを取得する
+	 $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $outer_classes ) );
+ 
+	 $breadcrumb_options = array(
+		 'id_outer'           => 'vk_breadcrumb',
+		 'class_outer'        => 'vk_breadcrumb', // wrapper_attributesを設定した場合、この文字列はパンくずリスト前後のコメントアウトに表示される
+		 'wrapper_attributes' => $wrapper_attributes,
+		 'class_inner'        => 'vk_breadcrumb_inner',
+		 'class_list'         => 'vk_breadcrumb_list',
+		 'class_list_item'    => 'vk_breadcrumb_list_item',
+	 );
+ }
+ 
+ /**
+  * Register block breadcrumb
+  *
+  * @return void
+  */
+ function vk_blocks_register_block_breadcrumb() {
+ 
+	 // Register Style.
+	 if ( ! is_admin() ) {
+		 wp_register_style(
+			 'vk-blocks/breadcrumb',
+			 VK_BLOCKS_DIR_URL . 'build/_pro/breadcrumb/style.css',
+			 array(),
+			 VK_BLOCKS_VERSION
+		 );
+	 }
+ 
+	 global $vk_blocks_common_attributes;
+	 register_block_type(
+		 __DIR__,
+		 array(
+			 'style'           => 'vk-blocks/breadcrumb',
+			 'editor_style'    => 'vk-blocks-build-editor-css',
+			 'editor_script'   => 'vk-blocks-build-js',
+			 'attributes'      => array_merge(
+				 array(
+					 'className' => array(
+						 'type'    => 'string',
+						 'default' => '',
+					 ),
+				 ),
+				 $vk_blocks_common_attributes
+			 ),
+			 'render_callback' => 'vk_blocks_breadcrumb_render_callback',
+		 )
+	 );
+ }
+ add_action( 'init', 'vk_blocks_register_block_breadcrumb', 99 );
 
 /**
- * Breadcrumb render callback
- *
- * @param array $attributes Block attributes.
- * @return string
+ * Registers dynamic separator style globally
  */
-function vk_blocks_breadcrumb_render_callback( $attributes ) {
-	if ( is_front_page() ) {
-		return;
-	}
-	$vk_breadcrumb = new VkBreadcrumb();
-
-	$outer_classes = 'vk_breadcrumb';
-	if ( isset( $attributes['vkb_hidden'] ) && $attributes['vkb_hidden'] ) {
-		$outer_classes .= ' vk_hidden';
-	}
-	if ( isset( $attributes['vkb_hidden_xxl'] ) && $attributes['vkb_hidden_xxl'] ) {
-		$outer_classes .= ' vk_hidden-xxl';
-	}
-	if ( isset( $attributes['vkb_hidden_xl_v2'] ) && $attributes['vkb_hidden_xl_v2'] ) {
-		$outer_classes .= ' vk_hidden-xl';
-	}
-	if ( isset( $attributes['vkb_hidden_lg'] ) && $attributes['vkb_hidden_lg'] ) {
-		$outer_classes .= ' vk_hidden-lg';
-	}
-	if ( isset( $attributes['vkb_hidden_md'] ) && $attributes['vkb_hidden_md'] ) {
-		$outer_classes .= ' vk_hidden-md';
-	}
-	if ( isset( $attributes['vkb_hidden_sm'] ) && $attributes['vkb_hidden_sm'] ) {
-		$outer_classes .= ' vk_hidden-sm';
-	}
-	if ( isset( $attributes['vkb_hidden_xs'] ) && $attributes['vkb_hidden_xs'] ) {
-		$outer_classes .= ' vk_hidden-xs';
-	}
-
-	// block.jsonのSupportsで設定したクラス名やスタイルを取得する
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $outer_classes ) );
-
-	$breadcrumb_options = array(
-		'id_outer'           => 'vk_breadcrumb',
-		'class_outer'        => 'vk_breadcrumb', // wrapper_attributesを設定した場合、この文字列はパンくずリスト前後のコメントアウトに表示される
-		'wrapper_attributes' => $wrapper_attributes,
-		'class_inner'        => 'vk_breadcrumb_inner',
-		'class_list'         => 'vk_breadcrumb_list',
-		'class_list_item'    => 'vk_breadcrumb_list_item',
-	);
-
+function vk_blocks_register_breadcrumb_separator_style() {
 	// ブロックの属性からセパレーターデザインの値を取得
 	$vk_blocks_options = VK_Blocks_Options::get_options();
 
@@ -63,52 +107,13 @@ function vk_blocks_breadcrumb_render_callback( $attributes ) {
 		$separator_design = '';
 	}
 
-	if ( '' === $separator_design ) {
-		return $vk_breadcrumb->get_breadcrumb( $breadcrumb_options );
+	// セパレーターのデザインが設定されている場合に動的CSSを生成
+	if ( '' !== $separator_design ) {
+		// セパレーターの文字列を適切にエスケープ
+		$separator_escaped = addslashes( $separator_design );
+		$dynamic_css = '<style>li.vk_breadcrumb_list_item:after, .breadcrumb-list li:after { content: "' . $separator_escaped . '"; }</style>';
+		echo $dynamic_css; // グローバルにスタイルを出力
 	}
-
-	// パンくずリストにスタイルを追加
-	$style = 'li.vk_breadcrumb_list_item:after { content: "' . $separator_design . '"; }';
-	wp_add_inline_style( 'vk-blocks/breadcrumb', $style );
-
-	return $vk_breadcrumb->get_breadcrumb( $breadcrumb_options );
 }
-
-/**
- * Register block breadcrumb
- *
- * @return void
- */
-function vk_blocks_register_block_breadcrumb() {
-
-	// Register Style.
-	if ( ! is_admin() ) {
-		wp_register_style(
-			'vk-blocks/breadcrumb',
-			VK_BLOCKS_DIR_URL . 'build/_pro/breadcrumb/style.css',
-			array(),
-			VK_BLOCKS_VERSION
-		);
-	}
-
-	global $vk_blocks_common_attributes;
-	register_block_type(
-		__DIR__,
-		array(
-			'style'           => 'vk-blocks/breadcrumb',
-			'editor_style'    => 'vk-blocks-build-editor-css',
-			'editor_script'   => 'vk-blocks-build-js',
-			'attributes'      => array_merge(
-				array(
-					'className' => array(
-						'type'    => 'string',
-						'default' => '',
-					),
-				),
-				$vk_blocks_common_attributes
-			),
-			'render_callback' => 'vk_blocks_breadcrumb_render_callback',
-		)
-	);
-}
-add_action( 'init', 'vk_blocks_register_block_breadcrumb', 99 );
+add_action( 'wp_footer', 'vk_blocks_register_breadcrumb_separator_style' );
+ 

--- a/src/blocks/_pro/breadcrumb/index.php
+++ b/src/blocks/_pro/breadcrumb/index.php
@@ -78,7 +78,7 @@ function vk_blocks_register_block_breadcrumb() {
 		VK_BLOCKS_DIR_URL . 'build/vk-breadcrumb.min.js',
 		array(),
 		VK_BLOCKS_VERSION,
-		true
+		false
 	);
 
 	// セパレーターの値を JavaScript に渡す

--- a/src/blocks/_pro/breadcrumb/style.scss
+++ b/src/blocks/_pro/breadcrumb/style.scss
@@ -16,7 +16,7 @@
 			i {
 				margin-right:0.5em;
 			}
-            &:after {
+            &:not(.p-breadcrumbs_item):after { // Katawara対応
                 content : '/';
                 margin-left:0.5em;
                 margin-right:0.5em;

--- a/src/blocks/_pro/breadcrumb/view.js
+++ b/src/blocks/_pro/breadcrumb/view.js
@@ -1,0 +1,46 @@
+function addSeparatorClass() {
+    const breadcrumbItems = document.querySelectorAll('li.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li');
+    breadcrumbItems.forEach(function (item) {
+        item.classList.add('has-separator');
+    });
+}
+
+// vkBreadcrumbSeparator.separator が存在する場合のみ実行
+if (typeof vkBreadcrumbSeparator !== 'undefined' && vkBreadcrumbSeparator.separator) {
+    // requestAnimationFrameでブラウザの再描画前に実行
+    requestAnimationFrame(addSeparatorClass);
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+	if (typeof vkBreadcrumbSeparator !== 'undefined') {
+		const separator = vkBreadcrumbSeparator.separator;
+		const breadcrumbItems = document.querySelectorAll(
+			'li.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li'
+		);
+
+		if (separator && breadcrumbItems.length > 0) {
+			// 最初に `has-separator` クラスを追加
+			breadcrumbItems.forEach(function (item) {
+				item.classList.add('has-separator');
+			});
+
+			// 完全に読み込まれたら `loaded` クラスを追加
+			window.addEventListener('load', function () {
+				breadcrumbItems.forEach(function (item) {
+					item.classList.add('loaded');
+				});
+			});
+
+			// 動的にスタイルを作成して適用
+			const styleElement = document.createElement('style');
+			styleElement.innerHTML = `
+				li.vk_breadcrumb_list_item:not(:last-child).has-separator.loaded:after, 
+				.breadcrumb-list li:not(:last-child).has-separator.loaded:after, 
+				.breadSection .breadcrumb > li + li:not(:last-child).has-separator.loaded:before { 
+					content: "${separator}";
+				}
+			`;
+			document.head.appendChild(styleElement);
+		}
+	}
+});

--- a/src/blocks/_pro/breadcrumb/view.js
+++ b/src/blocks/_pro/breadcrumb/view.js
@@ -1,14 +1,21 @@
+/* global vkBreadcrumbSeparator, requestAnimationFrame */
+
 function addSeparatorClass() {
-    const breadcrumbItems = document.querySelectorAll('li.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li');
-    breadcrumbItems.forEach(function (item) {
-        item.classList.add('has-separator');
-    });
+	const breadcrumbItems = document.querySelectorAll(
+		'li.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li'
+	);
+	breadcrumbItems.forEach(function (item) {
+		item.classList.add('has-separator');
+	});
 }
 
 // vkBreadcrumbSeparator.separator が存在する場合のみ実行
-if (typeof vkBreadcrumbSeparator !== 'undefined' && vkBreadcrumbSeparator.separator) {
-    // requestAnimationFrameでブラウザの再描画前に実行
-    requestAnimationFrame(addSeparatorClass);
+if (
+	typeof vkBreadcrumbSeparator !== 'undefined' &&
+	vkBreadcrumbSeparator.separator
+) {
+	// requestAnimationFrameでブラウザの再描画前に実行
+	requestAnimationFrame(addSeparatorClass);
 }
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/src/blocks/_pro/breadcrumb/view.js
+++ b/src/blocks/_pro/breadcrumb/view.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', function () {
 			styleElement.innerHTML = `
 				li.vk_breadcrumb_list_item:not(:last-child).has-separator.loaded:after, 
 				.breadcrumb-list li:not(:last-child).has-separator.loaded:after, 
-				.breadSection .breadcrumb > li + li:not(:last-child).has-separator.loaded:before { 
+				.breadSection .breadcrumb > li + li.has-separator.loaded:before { 
 					content: "${separator}";
 				}
 			`;

--- a/src/blocks/_pro/breadcrumb/view.js
+++ b/src/blocks/_pro/breadcrumb/view.js
@@ -2,7 +2,7 @@
 
 function addSeparatorClass() {
 	const breadcrumbItems = document.querySelectorAll(
-		'li.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li'
+		'.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li'
 	);
 	breadcrumbItems.forEach(function (item) {
 		item.classList.add('has-separator');
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	if (typeof vkBreadcrumbSeparator !== 'undefined') {
 		const separator = vkBreadcrumbSeparator.separator;
 		const breadcrumbItems = document.querySelectorAll(
-			'li.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li'
+			'.vk_breadcrumb_list_item, .breadcrumb-list li, .breadSection .breadcrumb > li + li'
 		);
 
 		if (separator && breadcrumbItems.length > 0) {
@@ -41,7 +41,7 @@ document.addEventListener('DOMContentLoaded', function () {
 			// 動的にスタイルを作成して適用
 			const styleElement = document.createElement('style');
 			styleElement.innerHTML = `
-				li.vk_breadcrumb_list_item:not(:last-child).has-separator.loaded:after, 
+				.vk_breadcrumb_list_item:not(:last-child).has-separator.loaded:after, 
 				.breadcrumb-list li:not(:last-child).has-separator.loaded:after, 
 				.breadSection .breadcrumb > li + li.has-separator.loaded:before { 
 					content: "${separator}";

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -703,7 +703,13 @@ $xxl-min: 1400px;
 /* パンくずリスト
 /*-------------------------------------------*/
 /* セパレーター設定 */
-li.vk_breadcrumb_list_item.has-separator:after,
+.vk_breadcrumb_list_item.has-separator:after,
+.breadcrumb-list li.has-separator:after,
+.breadSection .breadcrumb > li + li.has-separator:before {
+    visibility: hidden;
+}
+
+.vk_breadcrumb_list_item.has-separator:after,
 .breadcrumb-list li.has-separator:after,
 .breadSection .breadcrumb > li + li.has-separator:before {
     visibility: hidden;
@@ -713,7 +719,7 @@ li.vk_breadcrumb_list_item.has-separator:after,
 	content: none;
 }
 
-li.has-separator:not(:last-child).loaded:after,
+.vk_breadcrumb_list_item.has-separator:not(:last-child).loaded:after,
 .breadcrumb-list li:not(:last-child).has-separator.loaded:after,
 .breadSection .breadcrumb > li + li.has-separator.loaded:before {
     visibility: visible;

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -698,3 +698,13 @@ $xxl-min: 1400px;
 		z-index: 10;
 	}
 }
+
+/*-------------------------------------------*/
+/* バンくずリスト
+/*-------------------------------------------*/
+/* セパレーター設定 */
+li.vk_breadcrumb_list_item.has-separator:after,
+.breadcrumb-list li.has-separator:after,
+.breadSection .breadcrumb > li + li.has-separator:before {
+    visibility: hidden;
+}

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -700,11 +700,21 @@ $xxl-min: 1400px;
 }
 
 /*-------------------------------------------*/
-/* バンくずリスト
+/* パンくずリスト
 /*-------------------------------------------*/
 /* セパレーター設定 */
 li.vk_breadcrumb_list_item.has-separator:after,
 .breadcrumb-list li.has-separator:after,
 .breadSection .breadcrumb > li + li.has-separator:before {
     visibility: hidden;
+}
+
+.p-breadcrumbs li+li.has-separator:before {
+	content: none;
+}
+
+li.has-separator:not(:last-child).loaded:after,
+.breadcrumb-list li:not(:last-child).has-separator.loaded:after,
+.breadSection .breadcrumb > li + li.has-separator.loaded:before {
+    visibility: visible;
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://vws.vektor-inc.co.jp/forums/topic/%e3%80%90vk-blocks-pro%e3%80%91%e3%83%91%e3%83%b3%e3%81%8f%e3%81%9a%e3%83%aa%e3%82%b9%e3%83%88%e8%a8%ad%e5%ae%9a%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6

## どういう変更をしたか？

ブロックのパンくずリスト設定で設定したセパレーターを、パンくずブロックだけでなくVektor Inc. 製品テーマのパンくずでも適用できるように、グローバルスタイルとして view.js に出力する処理を追加しました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/3ac2baa5-18bf-458c-8776-5b32dbe5d486)

#### 変更後 After
![image](https://github.com/user-attachments/assets/2fb79df9-2e8c-4f0c-8774-08b8e2a78ad7)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→CSSの出力場所をview.jsに変更しただけなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

Lightning(G3/G2)、X-T9、Lightning Pro、Katawaraで以下を確認しました。
1. 設定 > VK Blocks > パンくずリスト設定 でお好きなパンくずを入力
2. パンくずブロックがパンくずリスト設定で設定したパンくずが入っていることを確認
3. テーマのパンくずだけがが表示されているページで、パンくずリスト設定で設定したパンくずが入っていることを確認
4. 分割読み込みを有効にしても2、3の状態のままなことを確認
5. パンくずリスト設定から設定したパンくずを削除した時、標準のパンくずが表示されることを確認

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をしてください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
