### PR TITLE
[ カスタムCSS ] CSSの > や : が 正規表現になりCSSが認識されないのを修正しました

### DIFF
--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -162,9 +162,11 @@ function vk_blocks_output_custom_css() {
 	global $vk_blocks_custom_css_collection;
 
 	if ( ! empty( $vk_blocks_custom_css_collection ) ) {
-		// カスタムCSSをサニタイズしてエスケープして出力
+		// カスタムCSSをサニタイズ
 		$sanitized_css = vk_blocks_sanitize_custom_css( $vk_blocks_custom_css_collection );
-		echo '<style id="vk-blocks-custom-css">' . esc_html( $sanitized_css ) . '</style>';
+
+		// CSSのエスケープを行わずそのまま出力
+		echo '<style id="vk-blocks-custom-css">' . $sanitized_css . '</style>';
 	}
 }
 add_action( 'wp_footer', 'vk_blocks_output_custom_css', 20 );

--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -135,13 +135,36 @@ function vk_blocks_render_custom_css( $block_content, $block ) {
 add_filter( 'render_block', 'vk_blocks_render_custom_css', 10, 2 );
 
 /**
+ * カスタムCSSをサニタイズする
+ *
+ * @param string $css カスタムCSSの内容.
+ * @return string サニタイズされたCSS
+ */
+function vk_blocks_sanitize_custom_css( $css ) {
+	// コメントや余分なスペースを削除
+	$css = preg_replace( '!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $css );
+	$css = trim( $css );
+
+	// 許可するCSSプロパティやセレクタのルールを指定（ここでは一例）
+	$allowed_patterns = '/[^{};]+\s*{\s*[^{};]+:\s*[^{};]+;\s*}/';
+
+	// 許可されたパターンのみを抽出
+	preg_match_all( $allowed_patterns, $css, $matches );
+
+	// 抽出されたCSSを連結
+	return implode( ' ', $matches[0] );
+}
+
+/**
  * フッターで蓄積されたカスタムCSSを出力
  */
 function vk_blocks_output_custom_css() {
 	global $vk_blocks_custom_css_collection;
 
 	if ( ! empty( $vk_blocks_custom_css_collection ) ) {
-		echo '<style id="vk-blocks-custom-css">' . $vk_blocks_custom_css_collection . '</style>';
+		// カスタムCSSをサニタイズして出力
+		$sanitized_css = vk_blocks_sanitize_custom_css( $vk_blocks_custom_css_collection );
+		echo '<style id="vk-blocks-custom-css">' . $sanitized_css . '</style>';
 	}
 }
 add_action( 'wp_footer', 'vk_blocks_output_custom_css', 20 );

--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -162,9 +162,9 @@ function vk_blocks_output_custom_css() {
 	global $vk_blocks_custom_css_collection;
 
 	if ( ! empty( $vk_blocks_custom_css_collection ) ) {
-		// カスタムCSSをサニタイズして出力
+		// カスタムCSSをサニタイズしてエスケープして出力
 		$sanitized_css = vk_blocks_sanitize_custom_css( $vk_blocks_custom_css_collection );
-		echo '<style id="vk-blocks-custom-css">' . $sanitized_css . '</style>';
+		echo '<style id="vk-blocks-custom-css">' . esc_html( $sanitized_css ) . '</style>';
 	}
 }
 add_action( 'wp_footer', 'vk_blocks_output_custom_css', 20 );

--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -165,7 +165,7 @@ function vk_blocks_output_custom_css() {
 		// カスタムCSSをサニタイズ
 		$sanitized_css = vk_blocks_sanitize_custom_css( $vk_blocks_custom_css_collection );
 
-		// CSSのエスケープを行わずそのまま出力
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<style id="vk-blocks-custom-css">' . $sanitized_css . '</style>';
 	}
 }

--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -80,8 +80,6 @@ $vk_blocks_custom_css_collection = '';
 /**
  * Render Custom Css Extension css
  *
- * @see https://github.com/WordPress/gutenberg/blob/3358251ae150e33dd6c0e0fb15be110cca1b5c59/lib/block-supports/layout.php#L294
- *
  * @param string $block_content block_content.
  * @param array  $block block.
  * @return string
@@ -104,8 +102,9 @@ function vk_blocks_render_custom_css( $block_content, $block ) {
 	if ( strpos( $css, 'selector' ) !== false ) {
 		// Uniqueクラスを生成
 		$unique_class = wp_unique_id( 'vk_custom_css_' );
+		
 		// selectorをUniqueクラスに変換
-		$css = preg_replace( '/selector/', '.' . $unique_class, $css );
+		$css = str_replace( 'selector', '.' . $unique_class, $css );
 
 		// vk_custom_cssをUniqueクラスに変換
 		$block_content = preg_replace( '/(class="[^"]*)vk_custom_css([^"]*")/', '$1' . $unique_class . '$2', $block_content, 1 );
@@ -140,8 +139,7 @@ function vk_blocks_output_custom_css() {
 	global $vk_blocks_custom_css_collection;
 
 	if ( ! empty( $vk_blocks_custom_css_collection ) ) {
-		// wp_ksesで必要最低限のHTMLタグのみ許可して出力
-		echo '<style id="vk-blocks-custom-css">' . wp_kses( $vk_blocks_custom_css_collection, array( 'style' => array() ) ) . '</style>';
+		echo '<style id="vk-blocks-custom-css">' . $vk_blocks_custom_css_collection . '</style>';
 	}
 }
 add_action( 'wp_footer', 'vk_blocks_output_custom_css', 20 );

--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -104,7 +104,7 @@ function vk_blocks_render_custom_css( $block_content, $block ) {
 	if ( strpos( $css, 'selector' ) !== false ) {
 		// Uniqueクラスを生成
 		$unique_class = wp_unique_id( 'vk_custom_css_' );
-		
+
 		// selectorをUniqueクラスに変換
 		$css = preg_replace( '/selector/', '.' . $unique_class, $css );
 

--- a/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
+++ b/inc/vk-blocks-pro/extensions/common/custom-css-extension.php
@@ -80,6 +80,8 @@ $vk_blocks_custom_css_collection = '';
 /**
  * Render Custom Css Extension css
  *
+ * @see https://github.com/WordPress/gutenberg/blob/3358251ae150e33dd6c0e0fb15be110cca1b5c59/lib/block-supports/layout.php#L294
+ *
  * @param string $block_content block_content.
  * @param array  $block block.
  * @return string
@@ -104,7 +106,7 @@ function vk_blocks_render_custom_css( $block_content, $block ) {
 		$unique_class = wp_unique_id( 'vk_custom_css_' );
 		
 		// selectorをUniqueクラスに変換
-		$css = str_replace( 'selector', '.' . $unique_class, $css );
+		$css = preg_replace( '/selector/', '.' . $unique_class, $css );
 
 		// vk_custom_cssをUniqueクラスに変換
 		$block_content = preg_replace( '/(class="[^"]*)vk_custom_css([^"]*")/', '$1' . $unique_class . '$2', $block_content, 1 );

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][Custom CSS (Pro)] Replaced wp_kses with a sanitization function in vk_blocks_output_custom_css.
+
 = 1.84.0 =
 [ Add function ][ Column ] Add toolbar link for components.
 [ Specification change ][ Classic FAQ / New FAQ ] Support structured data.

--- a/test/phpunit/pro/test-custom-css-extension.php
+++ b/test/phpunit/pro/test-custom-css-extension.php
@@ -5,9 +5,40 @@
  * @package vk-blocks
  */
 
-class CustomCssExtensionTest extends VK_UnitTestCase {
+class CustomCssExtensionTest extends VK_UnitTestCase {public function test_footer_output_custom_css() {
+	global $vk_blocks_custom_css_collection;
 
-	public function test_block_content_preg_replace() {
+	// 初期化
+	$vk_blocks_custom_css_collection = '';
+
+	// ブロックの設定
+	$block = array(
+		'blockName' => 'core/paragraph',
+		'attrs'     => array(
+			'vkbCustomCss' => 'selector > p { color: red; }',
+		),
+	);
+
+	// カスタムCSSをレンダリングして蓄積
+	$block_content = '<p class="vk_custom_css">This is a test block.</p>';
+	vk_blocks_render_custom_css( $block_content, $block );
+
+	// 出力をキャプチャ
+	ob_start();
+	vk_blocks_output_custom_css();
+	$output = ob_get_clean();
+
+	// 正規表現を使用して柔軟なアサーション
+	$expected_pattern = '/<style id="vk-blocks-custom-css">\.vk_custom_css_\d+ > p { color: red; }<\/style>/';
+	$this->assertMatchesRegularExpression( $expected_pattern, $output );
+
+	print PHP_EOL;
+	print '------------------------------------' . PHP_EOL;
+	print 'vk_blocks_output_custom_css() Test' . PHP_EOL;
+	print '------------------------------------' . PHP_EOL;
+	print 'Actual Output: ' . $output . PHP_EOL;
+}
+public function test_footer_output_custom_css() {
 
 		// ブロックコンテナのCSSクラス内のvk_custom_cssだけを変える。ブロックコンテンツ内のspan class内の vk_custom_cssは変更しないようにする。
 		// correct内 %d の箇所が連番になります。
@@ -132,5 +163,5 @@ class CustomCssExtensionTest extends VK_UnitTestCase {
 		print '------------------------------------' . PHP_EOL;
 		print 'Actual Output: ' . $output . PHP_EOL;
 	}
-	
+
 }

--- a/test/phpunit/pro/test-custom-css-extension.php
+++ b/test/phpunit/pro/test-custom-css-extension.php
@@ -9,12 +9,11 @@ class CustomCssExtensionTest extends VK_UnitTestCase {
 
 	public function test_block_content_preg_replace() {
 
-        // ブロックコンテナのCSSクラス内のvk_custom_cssだけを変える。ブロックコンテンツ内のspan class内の vk_custom_cssは変更しないようにする。
-        // correct内 %d の箇所が連番になります。
+		// ブロックコンテナのCSSクラス内のvk_custom_cssだけを変える。ブロックコンテンツ内のspan class内の vk_custom_cssは変更しないようにする。
+		// correct内 %d の箇所が連番になります。
 		$test_data = array(
 
-
-            // ブロックCSSクラスの先頭に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
+			// ブロックCSSクラスの先頭に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
 			array(
 				'block_content' => '<p class="vk_custom_css vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 				'correct' => '<p class="vk_custom_css_%d vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
@@ -31,8 +30,8 @@ class CustomCssExtensionTest extends VK_UnitTestCase {
 				'block_content' => '<p class="vk_custom_css vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 				'correct' => '<p class="vk_custom_css_%d vk_test_1">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 			),          
-            
-            // ブロックCSSクラスの真ん中に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
+
+			// ブロックCSSクラスの真ん中に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
 			array(
 				'block_content' => '<p class="vk_test_1 vk_custom_css vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 				'correct' => '<p class="vk_test_1 vk_custom_css_%d vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
@@ -53,38 +52,47 @@ class CustomCssExtensionTest extends VK_UnitTestCase {
 				'correct' => '<p class="vk_test_1 vk_custom_css_%d vk_test_2">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 			),   
 
-            // ブロックCSSクラスの最後に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
+			// ブロックCSSクラスの最後に vk_custom_css が来るパターン、かつ内側のspan classの中身のパターンを変える
 			array(
 				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 			),
-            array(
+			array(
 				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 			),	           
-            array(
+			array(
 				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_test_3 vk_custom_css vk_test_4">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 			),
-            array(
+			array(
 				'block_content' => '<p class="vk_test_1 vk_custom_css">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
 				'correct' => '<p class="vk_test_1 vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="vk_custom_css vk_test_3">consectetur adipisci elit</span>, sed eiusmod tempor incidunt ut labore et dolore magna aliqua.</p>',
-			),	            	                               	
+			),	            
+
+			// CSS構文で > や : が正しく処理されるかのテスト
+			array(
+				'block_content' => '<p class="vk_custom_css">Lorem ipsum dolor sit amet, <span class="selector > p">consectetur adipisci elit</span></p>',
+				'correct' => '<p class="vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="selector > p">consectetur adipisci elit</span></p>',
+			),
+			array(
+				'block_content' => '<p class="vk_custom_css">Lorem ipsum dolor sit amet, <span class="selector:after">consectetur adipisci elit</span></p>',
+				'correct' => '<p class="vk_custom_css_%d">Lorem ipsum dolor sit amet, <span class="selector:after">consectetur adipisci elit</span></p>',
+			),
 		);
 		print PHP_EOL;
 		print '------------------------------------' . PHP_EOL;
 		print 'vk_blocks_render_custom_css()' . PHP_EOL;
 		print '------------------------------------' . PHP_EOL;
 
-        $block = array(
-            'blockName' => 'core/paragraph',
-            'attrs' => array(
-                'vkbCustomCss' => 'selector { color: red; }'
-            )
-        );
+		$block = array(
+			'blockName' => 'core/paragraph',
+			'attrs' => array(
+				'vkbCustomCss' => 'selector { color: red; }'
+			)
+		);
 	
 		// vk_blocks_render_custom_css は wp_unique_id で ナンバリングしているので、wp_unique_id で帰ってきた値に1足したものと比較するようにする
-  
 		foreach ( $test_data as $test_value ) {
 			$return  = vk_blocks_render_custom_css($test_value['block_content'], $block);
 			VkCustomAssert::assertStringMatchesNumericFormat($test_value['correct'], $return);
@@ -101,7 +109,7 @@ class CustomCssExtensionTest extends VK_UnitTestCase {
 		$block = array(
 			'blockName' => 'core/paragraph',
 			'attrs'     => array(
-				'vkbCustomCss' => 'selector { color: red; }',
+				'vkbCustomCss' => 'selector > p { color: red; }',
 			),
 		);
 	
@@ -115,7 +123,7 @@ class CustomCssExtensionTest extends VK_UnitTestCase {
 		$output = ob_get_clean();
 	
 		// 正規表現を使用して柔軟なアサーション
-		$expected_pattern = '/<style id="vk-blocks-custom-css">\.vk_custom_css_\d+ { color: red; }<\/style>/';
+		$expected_pattern = '/<style id="vk-blocks-custom-css">\.vk_custom_css_\d+ > p { color: red; }<\/style>/';
 		$this->assertMatchesRegularExpression( $expected_pattern, $output );
 	
 		print PHP_EOL;

--- a/test/phpunit/pro/test-custom-css-extension.php
+++ b/test/phpunit/pro/test-custom-css-extension.php
@@ -132,5 +132,44 @@ class CustomCssExtensionTest extends VK_UnitTestCase {
 		print '------------------------------------' . PHP_EOL;
 		print 'Actual Output: ' . $output . PHP_EOL;
 	}
-	
+
+	public function test_vk_blocks_sanitize_custom_css() {
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'vk_blocks_sanitize_custom_css() Test' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		$tests = array(
+			array(
+				'name'     => 'ふつう',
+				'css'      => '.selector { color: red; }',
+				'expected' => '.selector { color: red; }',
+			),
+			array(
+				'name'     => ': あり',
+				'css'      => '.selector:before { color: red; }',
+				'expected' => '.selector:before { color: red; }',
+			),
+			array(
+				'name'     => '::あり',
+				'css'      => '.selector::before { color: red; }',
+				'expected' => '.selector::before { color: red; }',
+			),
+			array(
+				'name'     => ' > あり',
+				'css'      => '.selector:before > p { color: red; }',
+				'expected' => '.selector:before > p { color: red; }',
+			),
+			array(
+				'name'     => 'XSS',
+				'css'      => '<script>location.href="https://www.youtube.com/"</script>',
+				'expected' => '',
+			),
+		);
+
+		foreach ( $tests as $test ) {
+			$actual = vk_blocks_sanitize_custom_css( $test['css'] );
+			$this->assertEquals( $test['expected'], $actual, $test['name'] );
+		}
+	}
 }

--- a/test/phpunit/pro/test-custom-css-extension.php
+++ b/test/phpunit/pro/test-custom-css-extension.php
@@ -5,40 +5,9 @@
  * @package vk-blocks
  */
 
-class CustomCssExtensionTest extends VK_UnitTestCase {public function test_footer_output_custom_css() {
-	global $vk_blocks_custom_css_collection;
+class CustomCssExtensionTest extends VK_UnitTestCase {
 
-	// 初期化
-	$vk_blocks_custom_css_collection = '';
-
-	// ブロックの設定
-	$block = array(
-		'blockName' => 'core/paragraph',
-		'attrs'     => array(
-			'vkbCustomCss' => 'selector > p { color: red; }',
-		),
-	);
-
-	// カスタムCSSをレンダリングして蓄積
-	$block_content = '<p class="vk_custom_css">This is a test block.</p>';
-	vk_blocks_render_custom_css( $block_content, $block );
-
-	// 出力をキャプチャ
-	ob_start();
-	vk_blocks_output_custom_css();
-	$output = ob_get_clean();
-
-	// 正規表現を使用して柔軟なアサーション
-	$expected_pattern = '/<style id="vk-blocks-custom-css">\.vk_custom_css_\d+ > p { color: red; }<\/style>/';
-	$this->assertMatchesRegularExpression( $expected_pattern, $output );
-
-	print PHP_EOL;
-	print '------------------------------------' . PHP_EOL;
-	print 'vk_blocks_output_custom_css() Test' . PHP_EOL;
-	print '------------------------------------' . PHP_EOL;
-	print 'Actual Output: ' . $output . PHP_EOL;
-}
-public function test_footer_output_custom_css() {
+	public function test_block_content_preg_replace() {
 
 		// ブロックコンテナのCSSクラス内のvk_custom_cssだけを変える。ブロックコンテンツ内のspan class内の vk_custom_cssは変更しないようにする。
 		// correct内 %d の箇所が連番になります。
@@ -163,5 +132,5 @@ public function test_footer_output_custom_css() {
 		print '------------------------------------' . PHP_EOL;
 		print 'Actual Output: ' . $output . PHP_EOL;
 	}
-
+	
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://vws.vektor-inc.co.jp/forums/topic/lightning-pro%e6%a9%9f%e8%83%bd%ef%bc%88%e5%b7%a5%e5%8b%99%e5%ba%97%e3%83%bb%e5%bb%ba%e7%af%89%ef%bc%89top%e3%83%9a%e3%83%bc%e3%82%b8%e3%80%90%e3%82%b3%e3%83%b3%e3%82%bb%e3%83%97%e3%83%88%e3%80%91#post-100878

## どういう変更をしたか？

元のコードでは、vk_blocks_output_custom_css関数内でwp_kses関数を使ってカスタムCSSをエスケープして出力していました。カスタムCSSを <style> タグ内に直接出力する際、通常のエスケープ関数を使うと、CSSの内容が意図しない形でエスケープされてしまうためです。
なお、vk_blocks_sanitize_custom_css() を追加しカスタムCSSをサニタイズしているため、エスケープを無視しても安全と判断し、phpcs の警告を無視するために、、// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped を使用しました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/8ffe33f0-a654-45bd-be22-22c8079088c7)

#### 変更後 After
![スクリーンショット 2024-09-14 11 10 02](https://github.com/user-attachments/assets/30fdc7b8-7679-4413-bb3e-8da68cc30782)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. 編集画面で > や : を含むCSSをカスタムCSSにて作成
2. 編集画面やフロントエンドで正規表現にならずに > や : のまま出力されることを確認
3. 複数のカスタムCSSに > や : を含むCSSを入れたとき、正常に処理されていることを確認
4. 編集画面で > や : を含まないCSSをカスタムCSSにて作成した時、正常に処理されていることを確認

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をしてください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
