### PR TITLE
[ icon ]パターンライブラリからコピペした時に、x-t9で has-vk-color-* クラスが白になるのでnotを追加

### DIFF
--- a/src/blocks/icon/style.scss
+++ b/src/blocks/icon/style.scss
@@ -43,8 +43,8 @@
 		}
 	}
 
-	.vk_icon_frame:not(.is-style-outline):not(.is-style-noline) {
-		.vk_icon_font {
+	.vk_icon_frame:where(:not(.is-style-outline)):where(:not(.is-style-noline)) {
+		.vk_icon_font:where(:not([class*="has-vk-color-"])) { // x-t9で has-vk-color-* クラスに白がつくのでnotを追加
 			color: #fff;
 		}
 	}
@@ -69,9 +69,9 @@
 		}
 	}
 
-	div:not(.is-style-outline):not(.is-style-noline) {
-		.vk_icon_border:not(.vk_icon_border_frame):not(.vk_icon_border_none) {
-			.vk_icon_font {
+	div:where(:not(.is-style-outline)):where(:not(.is-style-noline)) {
+		.vk_icon_border:where(:not(.vk_icon_border_frame)):where(:not(.vk_icon_border_none)) {
+			.vk_icon_font:where(:not([class*="has-vk-color-"])) { // x-t9で has-vk-color-* クラスに白がつくのでnotを追加
 				color: #fff;
 			}
 		}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://discord.com/channels/1010092469863587892/1010175825930367019/1286250345361707120

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->

パターンライブラリから、アイコンの色を（キーカラーなどに）指定してあるアイコンブロックをX-T9にコピペすると、`has-vk-color-*` を使ったカラーを設定してある部分が（以前はアイコンの色の設定がなかったため）白色になるので、not指定で `has-vk-color-* `を除外指定し、notは強い指定になるのでwhereで詳細度を下げました。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-09-25 13 45 02](https://github.com/user-attachments/assets/bdceaf0a-6a38-4560-8176-826dd942cb44)

#### 変更後 After
![スクリーンショット 2024-09-25 13 45 54](https://github.com/user-attachments/assets/ca2cb777-4a94-4ced-b01b-e5de723931cd)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

パターンライブラリからX-T9にコピペした場合の微修正になるため、ユーザーからは気づきにくいと思い、readmeには記載していませんが、必要そうでしたら書きます。

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

<!-- [ 実装者が確認した手順を箇条書きで記載してください。予備知識のないレビュワーが見て再現しやすい手順で記載してください。 ] -->

* X-T9テーマにして、[このパターンをコピペ](https://patterns.vektor-inc.co.jp/vk-patterns/18730/)して、キーカラーが設定してあるアイコンブロック部分に、キーカラーが入っていることを確認しました。
※アイコンの色を、Lightningのキーカラー暗or明やカスタムカラーにした場合は、X-T9にはないので黒になります。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

<!-- [ レビュワーがどういう手順で何を確認して欲しいかを記載してください。 ] -->

* X-T9テーマにして、[このパターンをコピペ](https://patterns.vektor-inc.co.jp/vk-patterns/18730/)して、キーカラーが設定してあるアイコンブロック部分に、キーカラーが入っていることを確認しました。
※アイコンの色を、Lightningのキーカラー暗or明やカスタムカラーにした場合は、X-T9にはないので黒になります。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
