### PR TITLE
[ core/table ] 特定の条件の時にスクロールモードにすると完全に解除できないのを修正しました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,7 @@ e.g.
 
 == Changelog ==
 
-[ Bug fix ][ Core/table ] Fixed an issue where the class was not removed when table scrolling was disabled
+[ Bug fix ][ Core/table ] Fixed the class was not removed when table scrolling was disabled.
 
 = 1.85.1 =
 [ Bug fix ] Due to an issue where the hidden setting does not function properly when TreeShaking is enabled and CSS splitting is disabled, TreeShaking has been temporarily disabled as a workaround.

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Core/table ] Fixed an issue where the class was not removed when table scrolling was disabled
+
 = 1.85.1 =
 [ Bug fix ] Due to an issue where the hidden setting does not function properly when TreeShaking is enabled and CSS splitting is disabled, TreeShaking has been temporarily disabled as a workaround.
 

--- a/src/extensions/core/table/style.js
+++ b/src/extensions/core/table/style.js
@@ -271,12 +271,15 @@ addFilter('editor.BlockEdit', 'vk-blocks/table-style', addBlockControl);
 // 保存時に追加のプロパティを設定
 const addExtraProps = (saveElementProps, blockType, attributes) => {
 	if (isValidBlockType(blockType.name)) {
-		saveElementProps.className = `${saveElementProps.className || ''} ${
-			attributes.scrollable ? 'is-style-vk-table-scrollable' : ''
-		}`.trim();
-
-		saveElementProps['data-scroll-breakpoint'] =
-			attributes.scrollBreakpoint;
+		// 'scrollable' が true の場合のみ 'is-style-vk-table-scrollable' クラスと 'data-scroll-breakpoint' を設定
+		if (attributes.scrollable) {
+			saveElementProps.className = `${saveElementProps.className || ''} is-style-vk-table-scrollable`.trim();
+			saveElementProps['data-scroll-breakpoint'] = attributes.scrollBreakpoint;
+		} else {
+			// 'scrollable' が false の場合、クラスと属性を削除
+			saveElementProps.className = saveElementProps.className.replace('is-style-vk-table-scrollable', '').trim();
+			delete saveElementProps['data-scroll-breakpoint'];
+		}
 
 		// 'showScrollMessage' が true の場合のみ 'data-output-scroll-hint' を追加
 		if (attributes.showScrollMessage) {
@@ -299,6 +302,7 @@ const addExtraProps = (saveElementProps, blockType, attributes) => {
 			delete saveElementProps['data-icon-output-right'];
 		}
 	} else {
+		// scrollable が false の場合に不要な属性を削除
 		delete saveElementProps['data-scroll-breakpoint'];
 		delete saveElementProps['data-output-scroll-hint'];
 		delete saveElementProps['data-icon-output-left'];

--- a/src/extensions/core/table/style.js
+++ b/src/extensions/core/table/style.js
@@ -113,46 +113,61 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 
 		// コンポーネントのマウントまたは更新後に属性を更新
 		useEffect(() => {
+			// 初期ロード時にクラスや属性を確認して scrollable を ON にする
+			const checkTableScrollAttributes = () => {
+				const tables = document.querySelectorAll('.wp-block-table');
+				tables.forEach((table) => {
+					// もし is-style-vk-table-scrollable クラスや data-scroll-breakpoint 属性がついていたら scrollable を ON に設定
+					if (
+						table.classList.contains('is-style-vk-table-scrollable') ||
+						table.hasAttribute('data-scroll-breakpoint')
+					) {
+						setAttributes({ scrollable: true });
+					}
+				});
+			};
+		
+			// コンポーネントの初回レンダリング時に実行
+			checkTableScrollAttributes();
+		}, []); // 初期レンダリング時のみ実行
+		
+		// scrollable の状態が確定したら処理を実行
+		useEffect(() => {
 			const updateTableScrollAttributes = () => {
 				const tables = document.querySelectorAll(
 					'.wp-block-table.is-style-vk-table-scrollable'
 				);
 				tables.forEach((table) => {
-					if (scrollable) {
+					if (!scrollable) {
+						table.classList.remove('is-style-vk-table-scrollable');
+						table.removeAttribute('data-scroll-breakpoint');
+					} else {
 						const breakpoint =
 							table.getAttribute('data-scroll-breakpoint') ||
 							'table-scrollable-mobile';
-						table.setAttribute(
-							'data-scroll-breakpoint',
-							breakpoint
-						);
-					} else {
-						// scrollable が off の場合クラスを外す
-						table.classList.remove('is-style-vk-table-scrollable');
-						table.removeAttribute('data-scroll-breakpoint');
+						table.setAttribute('data-scroll-breakpoint', breakpoint);
 					}
-
-					// data-output-scroll-hintがない場合、自動でfalseを設定
+		
 					table.setAttribute(
 						'data-output-scroll-hint',
 						showScrollMessage ? 'true' : 'false'
 					);
-
-					// iconOutputLeftの制御
+		
 					table.setAttribute(
 						'data-icon-output-left',
 						iconOutputLeft ? 'true' : 'false'
 					);
-
-					// iconOutputRightの制御
+		
 					table.setAttribute(
 						'data-icon-output-right',
 						iconOutputRight ? 'true' : 'false'
 					);
 				});
 			};
-
-			updateTableScrollAttributes();
+		
+			if (typeof scrollable !== 'undefined') {
+				updateTableScrollAttributes();
+			}
 		}, [
 			scrollable,
 			scrollBreakpoint,
@@ -161,7 +176,7 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 			scrollIconRight,
 			iconOutputLeft,
 			iconOutputRight,
-		]);
+		]);				
 
 		if (isValidBlockType(name) && props.isSelected) {
 			const blockEditContent = <BlockEdit {...props} />;
@@ -302,7 +317,7 @@ const addExtraProps = (saveElementProps, blockType, attributes) => {
 			delete saveElementProps['data-icon-output-right'];
 		}
 	} else {
-		// scrollable が false の場合に不要な属性を削除
+		// 他のブロックでは不要な属性を削除
 		delete saveElementProps['data-scroll-breakpoint'];
 		delete saveElementProps['data-output-scroll-hint'];
 		delete saveElementProps['data-icon-output-left'];

--- a/src/extensions/core/table/style.js
+++ b/src/extensions/core/table/style.js
@@ -270,8 +270,12 @@ const addExtraProps = (saveElementProps, blockType, attributes) => {
 			attributes.scrollable ? 'is-style-vk-table-scrollable' : ''
 		}`.trim();
 
-		saveElementProps['data-scroll-breakpoint'] =
-			attributes.scrollBreakpoint;
+		// 'scrollable' が true の場合のみ 'data-scroll-breakpoint' を設定
+		if (attributes.scrollable) {
+			saveElementProps['data-scroll-breakpoint'] = attributes.scrollBreakpoint;
+		} else {
+			delete saveElementProps['data-scroll-breakpoint'];
+		}
 
 		// 'showScrollMessage' が true の場合のみ 'data-output-scroll-hint' を追加
 		if (attributes.showScrollMessage) {
@@ -294,6 +298,7 @@ const addExtraProps = (saveElementProps, blockType, attributes) => {
 			delete saveElementProps['data-icon-output-right'];
 		}
 	} else {
+		// scrollable が false の場合に不要な属性を削除
 		delete saveElementProps['data-scroll-breakpoint'];
 		delete saveElementProps['data-output-scroll-hint'];
 		delete saveElementProps['data-icon-output-left'];

--- a/src/extensions/core/table/style.js
+++ b/src/extensions/core/table/style.js
@@ -122,25 +122,28 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 						const breakpoint =
 							table.getAttribute('data-scroll-breakpoint') ||
 							'table-scrollable-mobile';
-						table.setAttribute('data-scroll-breakpoint', breakpoint);
+						table.setAttribute(
+							'data-scroll-breakpoint',
+							breakpoint
+						);
 					} else {
 						// scrollable が off の場合クラスを外す
 						table.classList.remove('is-style-vk-table-scrollable');
 						table.removeAttribute('data-scroll-breakpoint');
 					}
-		
+
 					// data-output-scroll-hintがない場合、自動でfalseを設定
 					table.setAttribute(
 						'data-output-scroll-hint',
 						showScrollMessage ? 'true' : 'false'
 					);
-		
+
 					// iconOutputLeftの制御
 					table.setAttribute(
 						'data-icon-output-left',
 						iconOutputLeft ? 'true' : 'false'
 					);
-		
+
 					// iconOutputRightの制御
 					table.setAttribute(
 						'data-icon-output-right',
@@ -148,7 +151,7 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 					);
 				});
 			};
-		
+
 			updateTableScrollAttributes();
 		}, [
 			scrollable,
@@ -158,7 +161,7 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 			scrollIconRight,
 			iconOutputLeft,
 			iconOutputRight,
-		]);	
+		]);
 
 		if (isValidBlockType(name) && props.isSelected) {
 			const blockEditContent = <BlockEdit {...props} />;

--- a/src/extensions/core/table/style.js
+++ b/src/extensions/core/table/style.js
@@ -272,7 +272,8 @@ const addExtraProps = (saveElementProps, blockType, attributes) => {
 
 		// 'scrollable' が true の場合のみ 'data-scroll-breakpoint' を設定
 		if (attributes.scrollable) {
-			saveElementProps['data-scroll-breakpoint'] = attributes.scrollBreakpoint;
+			saveElementProps['data-scroll-breakpoint'] =
+				attributes.scrollBreakpoint;
 		} else {
 			delete saveElementProps['data-scroll-breakpoint'];
 		}

--- a/src/extensions/core/table/style.js
+++ b/src/extensions/core/table/style.js
@@ -118,27 +118,29 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 					'.wp-block-table.is-style-vk-table-scrollable'
 				);
 				tables.forEach((table) => {
-					const breakpoint =
-						table.getAttribute('data-scroll-breakpoint') ||
-						'table-scrollable-mobile';
-					table.setAttribute('data-scroll-breakpoint', breakpoint);
-
-					// data-output-scroll-hintがない場合、自動でfalseを設定
-					if (!table.hasAttribute('data-output-scroll-hint')) {
-						table.setAttribute('data-output-scroll-hint', 'false');
+					if (scrollable) {
+						const breakpoint =
+							table.getAttribute('data-scroll-breakpoint') ||
+							'table-scrollable-mobile';
+						table.setAttribute('data-scroll-breakpoint', breakpoint);
+					} else {
+						// scrollable が off の場合クラスを外す
+						table.classList.remove('is-style-vk-table-scrollable');
+						table.removeAttribute('data-scroll-breakpoint');
 					}
-
+		
+					// data-output-scroll-hintがない場合、自動でfalseを設定
 					table.setAttribute(
 						'data-output-scroll-hint',
 						showScrollMessage ? 'true' : 'false'
 					);
-
+		
 					// iconOutputLeftの制御
 					table.setAttribute(
 						'data-icon-output-left',
 						iconOutputLeft ? 'true' : 'false'
 					);
-
+		
 					// iconOutputRightの制御
 					table.setAttribute(
 						'data-icon-output-right',
@@ -146,7 +148,7 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 					);
 				});
 			};
-
+		
 			updateTableScrollAttributes();
 		}, [
 			scrollable,
@@ -156,7 +158,7 @@ export const addBlockControl = createHigherOrderComponent((BlockEdit) => {
 			scrollIconRight,
 			iconOutputLeft,
 			iconOutputRight,
-		]);
+		]);	
 
 		if (isValidBlockType(name) && props.isSelected) {
 			const blockEditContent = <BlockEdit {...props} />;
@@ -270,13 +272,8 @@ const addExtraProps = (saveElementProps, blockType, attributes) => {
 			attributes.scrollable ? 'is-style-vk-table-scrollable' : ''
 		}`.trim();
 
-		// 'scrollable' が true の場合のみ 'data-scroll-breakpoint' を設定
-		if (attributes.scrollable) {
-			saveElementProps['data-scroll-breakpoint'] =
-				attributes.scrollBreakpoint;
-		} else {
-			delete saveElementProps['data-scroll-breakpoint'];
-		}
+		saveElementProps['data-scroll-breakpoint'] =
+			attributes.scrollBreakpoint;
 
 		// 'showScrollMessage' が true の場合のみ 'data-output-scroll-hint' を追加
 		if (attributes.showScrollMessage) {
@@ -299,7 +296,6 @@ const addExtraProps = (saveElementProps, blockType, attributes) => {
 			delete saveElementProps['data-icon-output-right'];
 		}
 	} else {
-		// scrollable が false の場合に不要な属性を削除
 		delete saveElementProps['data-scroll-breakpoint'];
 		delete saveElementProps['data-output-scroll-hint'];
 		delete saveElementProps['data-icon-output-left'];


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2224

## どういう変更をしたか？

テーブルブロックにおいて、スクロールモードを解除した際に is-style-vk-table-scrollable クラスが削除されない問題を修正しました。
具体的には、scrollable 属性が false の場合、クラスおよび関連するデータ属性を削除するロジックを追加しました。

### スクリーンショットまたは動画

#### 変更前 Before
https://github.com/user-attachments/assets/7a4e193c-05ea-40e5-a154-0edaf539eb5e

#### 変更後 After
https://github.com/user-attachments/assets/8058b1d9-9475-48a9-a99c-bb722080be22

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ スキップしました。もし必要でしたら作ります。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

<!-- [ 実装者が確認した手順を箇条書きで記載してください。予備知識のないレビュワーが見て再現しやすい手順で記載してください。 ] -->

1. 1.84.2.0 `git checkout fe2c185` で以下のテーブルを配置
```
<!-- wp:table {"hasFixedLayout":false,"className":"is-style-vk-table-border vk_block-margin-0\u002d\u002dmargin-top is-style-vk-table-scrollable vk_block-margin-md\u002d\u002dmargin-bottom","style":{"border":{"width":"1px"}},"scrollable":false} -->
<figure class="wp-block-table is-style-vk-table-border vk_block-margin-0--margin-top is-style-vk-table-scrollable vk_block-margin-md--margin-bottom" data-scroll-breakpoint="table-scrollable-mobile"><table style="border-width:1px"><thead><tr><th>ヘッダータイトルA</th><th>ヘッダータイトルB</th><th>ヘッダータイトルC</th><th>ヘッダータイトルD</th><th>ヘッダータイトルE</th><th>ヘッダータイトルF</th></tr></thead><tbody><tr><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td></tr><tr><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td><td>テーブルセル内のテキストが入ります</td></tr></tbody></table></figure>
<!-- /wp:table -->
```
2. 水平スクロールに指定
3. 1.85.0.2 `git checkout bf30b39d06a4760d64dbc923279636ce980f06c0` に切り替えてビルド
4. 1のテーブルを配置した編集画面を再読み込みで修正前の状態を再現
5. このブランチに切り替えてビルド
6. 1のテーブルを配置した編集画面を再読み込み
7. スクロールをON/OFFして横スクロールのバーが切り替わることを確認
8. 保存し、フロントエンドで横スクロールにならないことを画面幅を縮めて確認

また、今回の変更により横スクロールのテキストやアイコンに悪影響がないことを確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を確認してください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
