### PR TITLE
分割読み込みが OFF でも分割読み込み用のスタイルが読み込まれていないことを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -105,7 +105,7 @@ e.g.
 1. VK Blocks examples.
 
 == Changelog ==
-
+[ Bug fix ] Fix load styles when separate load is enable.
 [ Bug fix ][ Tab (Pro) ] Added a process to dynamically calculate and set the iframe height when the tab becomes active.
 [ Bug Fix ] Fixed an issue where disabling separated loading caused all block CSS to load.
 [ Add function ] [ Fixed Display (Pro) ] Added an option for "Fixed display from the bottom."

--- a/src/blocks/_pro/accordion/block.json
+++ b/src/blocks/_pro/accordion/block.json
@@ -7,7 +7,7 @@
 	"category": "vk-blocks-cat",
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/accordion",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"containerClass": {
 			"type": "string",

--- a/src/blocks/_pro/animation/block.json
+++ b/src/blocks/_pro/animation/block.json
@@ -5,7 +5,7 @@
 	"title": "Animation",
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/animation",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"effect": {
 			"type": "string",

--- a/src/blocks/_pro/fixed-display/block.json
+++ b/src/blocks/_pro/fixed-display/block.json
@@ -5,7 +5,7 @@
 	"title": "Fixed display",
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/fixed-display",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"mode": {
 			"type": "string",

--- a/src/blocks/_pro/tab-item/block.json
+++ b/src/blocks/_pro/tab-item/block.json
@@ -5,7 +5,7 @@
 	"parent": ["vk-blocks/tab"],
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/tab",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"tabLabel": {
 			"type": "string",

--- a/src/blocks/_pro/tab/block.json
+++ b/src/blocks/_pro/tab/block.json
@@ -4,7 +4,7 @@
 	"category": "vk-blocks-cat",
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/tab",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"tabOptionJSON": {
 			"type": "string",

--- a/src/blocks/_pro/table-of-contents-new/block.json
+++ b/src/blocks/_pro/table-of-contents-new/block.json
@@ -7,7 +7,7 @@
 	"category": "vk-blocks-cat",
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/table-of-contents-new",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"style": {
 			"type": "string",

--- a/src/blocks/faq/block.json
+++ b/src/blocks/faq/block.json
@@ -7,7 +7,7 @@
 	"textdomain": "vk-blocks-pro",
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/faq",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"heading": {
 			"type": "string",

--- a/src/blocks/faq2/block.json
+++ b/src/blocks/faq2/block.json
@@ -12,7 +12,7 @@
 	},
 	"editorScript": "vk-blocks-build-js",
 	"editorStyle": "vk-blocks-build-editor-css",
-	"style": "vk-blocks/faq",
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"showContent": {
 			"type": "string",

--- a/src/blocks/slider/block.json
+++ b/src/blocks/slider/block.json
@@ -5,6 +5,9 @@
 	"description": "This slider allows you to place various items.Slider is do not move in edit screen.",
 	"textdomain": "vk-blocks-pro",
 	"category": "vk-blocks-cat-layout",
+	"editorScript": "vk-blocks-build-js",
+	"editorStyle": ["vk-swiper-style", "vk-blocks-build-editor-css"],
+	"style": "vk-blocks-build-css",
 	"attributes": {
 		"editorMode": {
 			"type": "string",

--- a/src/blocks/slider/index.php
+++ b/src/blocks/slider/index.php
@@ -44,14 +44,24 @@ function vk_blocks_register_block_slider() {
 		true
 	);
 
-	register_block_type(
-		__DIR__,
-		array(
+	// クラシックテーマ & 6.5 環境で $assets = array() のように空にしないと重複登録になるため
+	// ここで初期化しておく
+	$assets = array();
+	// Attend to load separate assets.
+	// 分割読み込みが有効な場合のみ、分割読み込み用のスクリプトを登録する
+	if ( method_exists( 'VK_Blocks_Block_Loader', 'should_load_separate_assets' ) && VK_Blocks_Block_Loader::should_load_separate_assets() ) {
+		$assets = array(
 			'style_handles'         => array( 'vk-blocks/slider' ),
 			'script_handles'        => array(),
 			'editor_style_handles'  => array( 'vk-swiper-style', 'vk-blocks-build-editor-css' ),
 			'editor_script_handles' => array( 'vk-blocks-build-js' ),
-		)
+		);
+	}
+
+	register_block_type(
+		__DIR__,
+		$assets
 	);
+
 }
 add_action( 'init', 'vk_blocks_register_block_slider', 99 );

--- a/src/blocks/slider/index.php
+++ b/src/blocks/slider/index.php
@@ -62,6 +62,5 @@ function vk_blocks_register_block_slider() {
 		__DIR__,
 		$assets
 	);
-
 }
 add_action( 'init', 'vk_blocks_register_block_slider', 99 );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/2242

## どういう変更をしたか？

分割読み込みが OFF でも分割読み込み用のスタイルが読み込まれるのを修正しました。


### スクリーンショットまたは動画

#### 変更前 Before

blovk.json

```
	"editorScript": "vk-blocks-build-js",
	"editorStyle": "vk-blocks-build-editor-css",
	"style": "vk-blocks/tab",
```

#### 変更後 After

block.json
```
	"editorScript": "vk-blocks-build-js",
	"editorStyle": "vk-blocks-build-editor-css",
	"style": "vk-blocks-build-css",
```

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
⇒ block.json を変更したのみなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

分割読み込みが OFF のときに下記ブロックの分割読み込み用のスタイルが読み込まれていないことを確認しました。

- 旧 FAQ
- 新 FAQ
- スライダー(swiperではなく)
- アコーディオン
- アニメーション
- 固定表示
- タブ
- 目次

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

分割読み込みが OFF のときに下記ブロックの分割読み込み用のスタイルが読み込まれていないことを確認お願いします。

- 旧 FAQ
- 新 FAQ
- スライダー(swiperではなく)
- アコーディオン
- アニメーション
- 固定表示
- タブ
- 目次

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
