### PR TITLE
【2人目確認待ち】Pro アイコンをカテゴリーバッジに追加

### DIFF
--- a/editor-css/_editor_before.scss
+++ b/editor-css/_editor_before.scss
@@ -22,6 +22,8 @@
 	.editor-block-list-item-vk-blocks-button-outer:after,
 	.editor-block-list-item-vk-blocks-card:after,
 	.editor-block-list-item-vk-blocks-child-page:after,
+	.editor-block-list-item-vk-blocks-post-category-badge\/category-badge:after,
+	[class*="editor-block-list-item-vk-blocks-post-category-badge"]:after,
 	.editor-block-list-item-vk-blocks-dynamic-text:after,
 	.editor-block-list-item-vk-blocks-timeline:after,
 	.editor-block-list-item-vk-blocks-step:after,

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ e.g.
 1. VK Blocks examples.
 
 == Changelog ==
+[ Bug fix ][ Category Badge (Pro) ] Added Pro label to the inserter. 
 [ Bug fix ] Fix load styles when separate load is enable.
 [ Bug fix ][ Tab (Pro) ] Added a process to dynamically calculate and set the iframe height when the tab becomes active.
 [ Bug Fix ] Fixed an issue where disabling separated loading caused all block CSS to load.


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-blocks-pro/issues/2233

## どういう変更をしたか？
カテゴリーバッチはPro版なので、編集画面ブロック一覧画面に「Pro」マークをつける。

### スクリーンショットまたは動画
![image](https://github.com/user-attachments/assets/3b7507ce-59a7-404f-a24f-77f87e73e567)

#### 変更前 Before

#### 変更後 After
![image](https://github.com/user-attachments/assets/3b7507ce-59a7-404f-a24f-77f87e73e567)

## 実装者の確認事項

- [○] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [○] Files changed (変更ファイル)の内容は目視で確認したか？
- [○] readme.txt に変更内容は書いたか？
- [○] 本当にちゃんと確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* 記事の登録または編集画面を表示
* 左上の青い＋（ Toggle block inserter ）をクリック
* クリックすると表示されるリストのうち、下記メニューの右上に、
赤枠の "Pro" アイコンが表示されること確認
"カテゴリーバッジ"、 "Category Badge / Categories"、 "Category Badge / Tags"

## レビュワーに回す前の確認事項

- [○] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* 記事の登録または編集画面を表示
* 左上の青い＋（ Toggle block inserter ）をクリック
* クリックすると表示されるリストのうち、下記メニューの右上に、
赤枠の "Pro" アイコンが表示されること確認
"カテゴリーバッジ"、 "Category Badge / Categories"、 "Category Badge / Tags"

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
