### PR TITLE
【確認待ち】scssのビルド時warningを回避

### DIFF
--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -164,8 +164,8 @@ $colorPalette: (
 @each $colorClass, $color in $colorPalette {
 	:root {
 		// 一般的なカラー設定
-		.vk-has-#{$colorClass}-background-color,
-		.has-vk-#{$colorClass}-background-color {
+		.vk-has-#{"#{$colorClass}"}-background-color,
+		.has-vk-#{"#{$colorClass}"}-background-color {
 			@if $colorClass == color-primary {
 				// color-primaryに関する特殊処理
 				background-color: var(--wp--preset--color--vk-color-primary, #337ab7);
@@ -174,8 +174,8 @@ $colorPalette: (
 			}
 		}
 
-		.vk-has-#{$colorClass}-color,
-		.has-vk-#{$colorClass}-color {
+		.vk-has-#{"#{$colorClass}"}-color,
+		.has-vk-#{"#{$colorClass}"}-color {
 			@if $colorClass == color-primary {
 				// color-primaryに関する特殊処理
 				color: var(--wp--preset--color--vk-color-primary, #337ab7);
@@ -210,7 +210,7 @@ ol {
 		&-vk-numbered-circle-mark,
 		&-vk-numbered-square-mark {
 			padding-inline-start: 2em;
-			&:not(.has-text-color), 
+			&:not(.has-text-color),
 			&:not(.has-link-color) {
 				color: initial;
 			}
@@ -379,8 +379,8 @@ ol {
 	}
 
 	@each $colorClass, $color in $colorPalette {
-		&.vk-has-#{$colorClass}-color,
-		&.has-vk-#{$colorClass}-color {
+		&.vk-has-#{"#{$colorClass}"}-color,
+		&.has-vk-#{"#{$colorClass}"}-color {
 			li::marker {
 				color: $color;
 			}
@@ -391,8 +391,8 @@ ol {
 
 		&.is-style-vk-numbered-circle-mark,
 		&.is-style-vk-numbered-square-mark {
-			&.vk-has-#{$colorClass}-color,
-			&.has-vk-#{$colorClass}-color {
+			&.vk-has-#{"#{$colorClass}"}-color,
+			&.has-vk-#{"#{$colorClass}"}-color {
 				li::before {
 					color: #fff;
 					background-color: $color;
@@ -454,7 +454,7 @@ ol {
 	}
 	&-vk-link {
 		position: absolute;
-		top: 0; 
+		top: 0;
 		left: 0;
 		width: 100%;
 		height: 100%;
@@ -464,8 +464,8 @@ ol {
 	}
 
 	@each $colorClass, $color in $colorPalette {
-		&.vk-has-#{$colorClass}-color,
-		&.has-vk-#{$colorClass}-color {
+		&.vk-has-#{"#{$colorClass}"}-color,
+		&.has-vk-#{"#{$colorClass}"}-color {
 			color: initial;
 			border-color: $color;
 			.wp-block-group__inner-container {
@@ -665,7 +665,7 @@ $xxl-min: 1400px;
 		position: relative;
 		.wp-block-column-vk-link {
 			position: absolute;
-			top: 0; 
+			top: 0;
 			left: 0;
 			width: 100%;
 			height: 100%;
@@ -689,7 +689,7 @@ $xxl-min: 1400px;
 	}
 	&-vk-link {
 		position: absolute;
-		top: 0; 
+		top: 0;
 		left: 0;
 		width: 100%;
 		height: 100%;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
ビルドする時にCSSのビルドのwarningがつらつらでてくるのが気になるので回避

## どういう変更をしたか？
<img width="863" alt="image" src="https://github.com/user-attachments/assets/d444e88a-2048-4ae2-8a24-308fcdb6b19d">

<!-- [ このプルリクで変更した事を記載してください ] -->

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？
内部的変更なので不要
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
-テスト不要の修正と判断しています

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

レビュワー確認方法・確認内容同様

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* ビルド後のCSSに間違いなく出力されているか  ( vk-has-pink などで検索するとわかります）
* グループブロックのVK側の設定で枠線を追加して確認できます。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
