### PR TITLE
[ Core/group ] 横並びブロックの時にリンクをつけると横並びにならないのを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ core/roup ] Fixed an issue where unwanted classes were assigned when links were present in the group block.
+
 = 1.88.0 =
 [ Specification change ][ Grid Column Card (Pro) ] Changed the default settings of headerDisplay and footerDisplay from "Delete" to "Display".
 [ Specification change ] Add filter vk_post_taxonomies_html ( Update VK Components 1.6.1 )

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -190,9 +190,13 @@ const save = (props) => {
 					rel={relAttribute}
 					aria-label={__('Group link', 'vk-blocks-pro')}
 					className={`${prefix}-vk-link`}
-				></a>
+				>
+					<InnerBlocks.Content />
+				</a>
 			)}
-			<InnerBlocks.Content />
+			{!linkUrl && (
+				<InnerBlocks.Content />
+			)}
 		</CustomTag>
 	);
 };

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -453,14 +453,7 @@ ol {
 		position: relative;
 	}
 	&-vk-link {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		color: transparent;
-		cursor: pointer;
-		z-index: 10;
+		color: inherit;
 	}
 
 	@each $colorClass, $color in $colorPalette {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

横並びブロックの時にリンク機能を使うと横並びにならなくなってしまっていた。

## どういう変更をしたか？

他のブロックでのリンク処理と同様にaタグとInnerBlocks を横並びにしてましたが、上記の理由、また、Groupブロックの使い方的にも <a> タグの中に InnerBlocks を含める方式の方が理にかなっていたためそうしました。
なお、リンク設定がない場合は現行通りInnerBlocks のコンテンツが親要素内に直接挿入されます。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-10-22 16 21 52](https://github.com/user-attachments/assets/c69fdcf3-03bf-438c-b7a1-9d802fcab344)

#### 変更後 After
![スクリーンショット 2024-10-22 16 21 12](https://github.com/user-attachments/assets/09660751-fa60-4c8c-8794-57e5402451d8)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ groupのstyle.jsのreturnのみの修正をしているのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* 横並びブロックを作成しリンクを設定し、フロントエンドでも横並びの状態が保たれているのかを確認。
* 既存の横並びブロックの場合でも新たにリンクを設定した時、フロントエンドでも横並びの状態が保たれているのかを確認。(既存の横並びブロックかつリンク設定済みの場合も新たにリンクを設定いただくことで変更後の状態になります。) 
* グルーブブロック、縦並びブロック、グリッドブロックでも並びに影響がないかを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
