### PR TITLE
[ Core/group ] 横並び、縦積み、グリッド表示時にリンクあり/なしの状態で並び方が異なっているのを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ core/roup ] Fixed an issue where unwanted classes were assigned when links were present in the group block.
+
 = 1.88.0 =
 [ Specification change ][ Grid Column Card (Pro) ] Changed the default settings of headerDisplay and footerDisplay from "Delete" to "Display".
 [ Specification change ] Add filter vk_post_taxonomies_html ( Update VK Components 1.6.1 )

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -183,6 +183,7 @@ const save = (props) => {
 
 	return (
 		<CustomTag {...blockProps}>
+			<InnerBlocks.Content />
 			{linkUrl && (
 				<a
 					href={linkUrl}
@@ -190,12 +191,7 @@ const save = (props) => {
 					rel={relAttribute}
 					aria-label={__('Group link', 'vk-blocks-pro')}
 					className={`${prefix}-vk-link`}
-				>
-					<InnerBlocks.Content />
-				</a>
-			)}
-			{!linkUrl && (
-				<InnerBlocks.Content />
+				></a>
 			)}
 		</CustomTag>
 	);

--- a/src/extensions/core/group/style.js
+++ b/src/extensions/core/group/style.js
@@ -190,9 +190,13 @@ const save = (props) => {
 					rel={relAttribute}
 					aria-label={__('Group link', 'vk-blocks-pro')}
 					className={`${prefix}-vk-link`}
-				></a>
+				>
+					<InnerBlocks.Content />
+				</a>
 			)}
-			<InnerBlocks.Content />
+			{!linkUrl && (
+				<InnerBlocks.Content />
+			)}
 		</CustomTag>
 	);
 };

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -452,14 +452,14 @@ ol {
 	&.has-link {
 		position: relative;
 	}
-	&-vk-link {	
-		position: absolute;	
-		top: 0;	
-		left: 0;	
-		width: 100%;	
-		height: 100%;	
-		color: transparent;	
-		cursor: pointer;	
+	&-vk-link {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		color: transparent;
+		cursor: pointer;
 		z-index: 10;
 	}
 

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -453,14 +453,7 @@ ol {
 		position: relative;
 	}
 	&-vk-link {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		color: transparent;
-		cursor: pointer;
-		z-index: 10;
+		color: inherit;
 	}
 
 	@each $colorClass, $color in $colorPalette {

--- a/src/utils/common.scss
+++ b/src/utils/common.scss
@@ -452,8 +452,15 @@ ol {
 	&.has-link {
 		position: relative;
 	}
-	&-vk-link {
-		color: inherit;
+	&-vk-link {	
+		position: absolute;	
+		top: 0;	
+		left: 0;	
+		width: 100%;	
+		height: 100%;	
+		color: transparent;	
+		cursor: pointer;	
+		z-index: 10;
 	}
 
 	@each $colorClass, $color in $colorPalette {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

横並び、縦積み、グリッド表示時でリンク機能を使うと、フロントエンドでグリッド表示時にリンクあり/なしの状態で並び方が異なっているのを修正

## どういう変更をしたか？

現在のaタグが先でInnerBlocksが後に来るようになってます。この並び順の影響で、本来横並び、縦積み、グリッド表示時のグループブロックに入るはずのクラス名がaタグに入ってしまいました。
aタグとInnerBlocksの位置を入れ替えることでそのような現象は無くなりました。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-10-22 17 41 39](https://github.com/user-attachments/assets/6904967f-76ef-4d88-8038-0336e76651a4)

#### 変更後 After
![スクリーンショット 2024-10-22 17 40 09](https://github.com/user-attachments/assets/3ff81aa2-1e10-4359-af5b-87c77d23c26d)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ スキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* 横並び、縦積み、グリッドを作成しリンクを設定し、フロントエンドでも同様の状態が保たれているのかを確認。
* 既存の上記のブロックの場合でも新たにリンクを設定した時、フロントエンドでも横並びの状態が保たれているのかを確認。(既存の上記のブロックかつリンク設定済みの場合も新たにリンクを設定いただくことで変更後の状態になります。なおリカバリーエラーが発生しないことは確認済み。) 
* リンクが機能していることを確認。
* 上記の変更を理由にグルーブブロックで影響がないことを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
