### PR TITLE
[ グリッドカラムカード ] ボディの中にスライダーを入れるとスライダーがはみ出すのを修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Grid Column Card (Pro) ] Fixed slider overflow in Grid Column Card Item Body.
+
 = 1.88.0 =
 [ Specification change ][ Grid Column Card (Pro) ] Changed the default settings of headerDisplay and footerDisplay from "Delete" to "Display".
 [ Specification change ] Add filter vk_post_taxonomies_html ( Update VK Components 1.6.1 )

--- a/src/blocks/_pro/gridcolcard/style.scss
+++ b/src/blocks/_pro/gridcolcard/style.scss
@@ -52,6 +52,10 @@
 			&-valign-bottom{
 				align-content: end;
 			}
+			> .swiper{ //スライダーがはみ出すため打消し用
+				margin-left: unset;
+				margin-right: unset
+			}
 		}
 		&_footer{
 			display: grid;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2279 

## どういう変更をしたか？

.swiperにかかってる margin-left:auto とmargin-right:autoを打ち消すことで、スライダーの幅が自動判定されるようになりました。width: 100%;でも対応できたのですが、おそらくmarginの方が影響範囲が少ない気がしたのでそのようにしています。
なお、スライダーブロックだけでなく、swiperを使っているブロック等が入るときなどを考えてこのようにしています。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-10-23 15 25 55](https://github.com/user-attachments/assets/c8582977-1355-4a9d-854a-0ed658801907)

#### 変更後 After
![スクリーンショット 2024-10-23 15 25 37](https://github.com/user-attachments/assets/894dada5-3560-4e1f-87e5-4c4f7b6ce239)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→CSSのみなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* グリッドカラムカードボディの中にスライダーを入れてフロントエンドではみ出さないことを確認。
```
<!-- wp:vk-blocks/gridcolcard {"containerSpace":{"top":"0px","left":"0px","right":"0px","bottom":"0px"},"headerDisplay":"delete","footerDisplay":"delete","blockId":"37aa4daf-b74f-452f-8728-bf0ef920e914"} -->
<div class="wp-block-vk-blocks-gridcolcard vk_gridcolcard vk_gridcolcard-37aa4daf-b74f-452f-8728-bf0ef920e914"><!-- wp:vk-blocks/gridcolcard-item {"containerSpace":{"top":"0px","left":"0px","right":"0px","bottom":"0px"},"headerDisplay":"delete","footerDisplay":"delete"} -->
<div class="wp-block-vk-blocks-gridcolcard-item vk_gridcolcard_item vk_gridcolcard_item-noHeader vk_gridcolcard_item-noFooter"><div class="vk_gridcolcard_item_container" style="padding-top:0px;padding-bottom:0px;padding-left:0px;padding-right:0px"><!-- wp:vk-blocks/gridcolcard-item-header {"containerSpace":{"top":"0px","left":"0px","right":"0px","bottom":"0px"},"headerDisplay":"delete"} /-->

<!-- wp:vk-blocks/gridcolcard-item-body -->
<div class="wp-block-vk-blocks-gridcolcard-item-body vk_gridcolcard_item_body"><!-- wp:vk-blocks/slider {"pagination":"hide","navigationPosition":"center","blockId":"95d9996e-20be-42f6-8588-cba57d04193d","className":"top-topics-boder-none"} -->
<div class="wp-block-vk-blocks-slider swiper swiper-container vk_slider vk_slider_95d9996e-20be-42f6-8588-cba57d04193d top-topics-boder-none" data-vkb-slider="{&quot;autoPlay&quot;:true,&quot;autoPlayStop&quot;:false,&quot;autoPlayDelay&quot;:2500,&quot;pagination&quot;:&quot;hide&quot;,&quot;blockId&quot;:&quot;95d9996e-20be-42f6-8588-cba57d04193d&quot;,&quot;loop&quot;:true,&quot;effect&quot;:&quot;slide&quot;,&quot;speed&quot;:500,&quot;slidesPerViewMobile&quot;:1,&quot;slidesPerViewTablet&quot;:1,&quot;slidesPerViewPC&quot;:1,&quot;slidesPerGroup&quot;:&quot;one-by-one&quot;,&quot;centeredSlides&quot;:false}"><div class="swiper-wrapper"><!-- wp:vk-blocks/slider-item {"verticalAlignment":"top","opacity":0,"padding_left_and_right":"2","blockId":"f40e0318-9cb7-40cd-a5ae-83606323f623"} -->
<div class="wp-block-vk-blocks-slider-item vk_slider_item swiper-slide vk_valign-top vk_slider_item-f40e0318-9cb7-40cd-a5ae-83606323f623  vk_slider_item-paddingLR-zero vk_slider_item-paddingVertical-none"><div class="vk_slider_item-background-area has-background-dim has-background-dim-0" style="padding-left:0;padding-right:0"></div><div class="vk_slider_item_container"><!-- wp:vk-blocks/post-list {"name":"vk-blocks/post-list","col_sm":1,"col_md":1,"col_lg":1,"col_xl":1,"col_xxl":1,"display_image_overlay_term":false,"display_excerpt":true,"numberPosts":1,"isCheckedPostType":"[\u0022information\u0022,\u0022post\u0022]","isCheckedTerms":"[67,69]","offset":1,"className":"vk_block-margin-0\u002d\u002dmargin-top vk_block-margin-0\u002d\u002dmargin-bottom top-topics"} /--></div></div>
<!-- /wp:vk-blocks/slider-item -->

<!-- wp:vk-blocks/slider-item {"verticalAlignment":"top","opacity":0,"padding_left_and_right":"2","blockId":"c9cb678a-b1f1-4781-a4f5-ae983c79bd93"} -->
<div class="wp-block-vk-blocks-slider-item vk_slider_item swiper-slide vk_valign-top vk_slider_item-c9cb678a-b1f1-4781-a4f5-ae983c79bd93  vk_slider_item-paddingLR-zero vk_slider_item-paddingVertical-none"><div class="vk_slider_item-background-area has-background-dim has-background-dim-0" style="padding-left:0;padding-right:0"></div><div class="vk_slider_item_container"><!-- wp:vk-blocks/post-list {"name":"vk-blocks/post-list","col_sm":1,"col_md":1,"col_lg":1,"col_xl":1,"col_xxl":1,"display_image_overlay_term":false,"display_excerpt":true,"numberPosts":1,"isCheckedPostType":"[\u0022information\u0022,\u0022post\u0022]","isCheckedTerms":"[67,69]","offset":2,"className":"vk_block-margin-0\u002d\u002dmargin-top vk_block-margin-0\u002d\u002dmargin-bottom top-topics"} /--></div></div>
<!-- /wp:vk-blocks/slider-item --></div><div class="swiper-button-next swiper-button-center"></div><div class="swiper-button-prev swiper-button-center"></div></div>
<!-- /wp:vk-blocks/slider --></div>
<!-- /wp:vk-blocks/gridcolcard-item-body -->

<!-- wp:vk-blocks/gridcolcard-item-footer {"footerDisplay":"delete"} /--></div></div>
<!-- /wp:vk-blocks/gridcolcard-item -->

<!-- wp:vk-blocks/gridcolcard-item {"containerSpace":{"top":"0px","left":"0px","right":"0px","bottom":"0px"},"headerDisplay":"delete","footerDisplay":"delete"} -->
<div class="wp-block-vk-blocks-gridcolcard-item vk_gridcolcard_item vk_gridcolcard_item-noHeader vk_gridcolcard_item-noFooter"><div class="vk_gridcolcard_item_container" style="padding-top:0px;padding-bottom:0px;padding-left:0px;padding-right:0px"><!-- wp:vk-blocks/gridcolcard-item-header {"containerSpace":{"top":"0px","left":"0px","right":"0px","bottom":"0px"},"headerDisplay":"delete"} /-->

<!-- wp:vk-blocks/gridcolcard-item-body -->
<div class="wp-block-vk-blocks-gridcolcard-item-body vk_gridcolcard_item_body"><!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph --></div>
<!-- /wp:vk-blocks/gridcolcard-item-body -->

<!-- wp:vk-blocks/gridcolcard-item-footer {"footerDisplay":"delete"} /--></div></div>
<!-- /wp:vk-blocks/gridcolcard-item --><style>
				.vk_gridcolcard-37aa4daf-b74f-452f-8728-bf0ef920e914 {
					grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));
					gap:30px;
				}
				@media (min-width: 576px) {
					.vk_gridcolcard-37aa4daf-b74f-452f-8728-bf0ef920e914 {
						grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));
					}
				}
				@media (min-width: 992px) {
					.vk_gridcolcard-37aa4daf-b74f-452f-8728-bf0ef920e914 {
						grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));
					}
				}
				</style></div>
<!-- /wp:vk-blocks/gridcolcard -->
```
* LightningG3/G2、X-T9、TT4、TT5で確認しました。
   X-T9ではスライダーの中に投稿リストが入っている時、右側のborderが見切れます。[スライダーブロックのwidth:100% はTT4 TT5 の対応](https://github.com/vektor-inc/vk-blocks-pro/pull/2271/files)のwidth:100%を戻しても同じ状況だったので今回はその対応等はスキップしました。
* スライダーが幅広、全幅状態の時の確認しました。(はみ出しはするのですが #2279 のように通常幅の時に幅が適切に判定されないという現象はなかったです。)
* 6.7、6.6で確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認をしてください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
