### PR TITLE
[ カバー ] 編集画面で装飾なしの見出しを2つ入れてリンクを設定&保存&リロード後編集画面でコンテンツ位置が効かなくなる現象を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Cover ] Fixed an issue where, after setting a link in the Cover block and adding two unstyled headings inside it, the content positioning would not apply upon returning to the editing screen (editing screen only).
 [ Add function ][ Outer (Pro) ] Add book and pyramid in divider style.
 [ Bug fix ][ Slider ] Add alert message.
 

--- a/src/extensions/core/cover/style.js
+++ b/src/extensions/core/cover/style.js
@@ -5,7 +5,7 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import LinkToolbar from '@vkblocks/components/link-toolbar';
@@ -79,7 +79,8 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 
 	// `element` から既存のクラスを取得し、リンクがある場合にのみ `has-link` を追加
 	const existingClassName = element.props.className || '';
-	const classNameWithLink = `${existingClassName} ${linkUrl ? 'has-link' : ''}`.trim();
+	const classNameWithLink =
+		`${existingClassName} ${linkUrl ? 'has-link' : ''}`.trim();
 
 	// rel 属性の設定
 	const relAttribute =

--- a/src/extensions/core/cover/style.js
+++ b/src/extensions/core/cover/style.js
@@ -77,19 +77,16 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 		return element;
 	}
 
-	const blockProps = useBlockProps.save({
-		className: linkUrl
-			? `${element.props.className} has-link`
-			: element.props.className,
-		style: element.props.style,
-	});
+	// `element` から既存のクラスを取得
+	const existingClassName = element.props.className || '';
 
-	// rel 属性の設定
+	// リンク属性の rel 設定
 	const relAttribute =
 		linkTarget === '_blank' ? 'noopener noreferrer' : 'noopener';
 
+	// `element` の中に `<a>` タグを追加し、クラス名の変更を避ける
 	return (
-		<div {...blockProps}>
+		<div className={`${existingClassName} has-link`}>
 			{element.props.children}
 			<a
 				href={linkUrl}
@@ -97,6 +94,7 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 				rel={relAttribute}
 				aria-label={__('Cover link', 'vk-blocks-pro')}
 				className="wp-block-cover-vk-link"
+				style={{ position: 'absolute', inset: 0, zIndex: 10 }}
 			></a>
 		</div>
 	);

--- a/src/extensions/core/cover/style.js
+++ b/src/extensions/core/cover/style.js
@@ -77,16 +77,16 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 		return element;
 	}
 
-	// `element` から既存のクラスを取得
+	// `element` から既存のクラスを取得し、リンクがある場合にのみ `has-link` を追加
 	const existingClassName = element.props.className || '';
+	const classNameWithLink = `${existingClassName} ${linkUrl ? 'has-link' : ''}`.trim();
 
-	// リンク属性の rel 設定
+	// rel 属性の設定
 	const relAttribute =
 		linkTarget === '_blank' ? 'noopener noreferrer' : 'noopener';
 
-	// `element` の中に `<a>` タグを追加し、クラス名の変更を避ける
 	return (
-		<div className={`${existingClassName} has-link`}>
+		<div className={classNameWithLink}>
 			{element.props.children}
 			<a
 				href={linkUrl}
@@ -94,11 +94,11 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 				rel={relAttribute}
 				aria-label={__('Cover link', 'vk-blocks-pro')}
 				className="wp-block-cover-vk-link"
-				style={{ position: 'absolute', inset: 0, zIndex: 10 }}
 			></a>
 		</div>
 	);
 };
+
 
 addFilter('editor.BlockEdit', 'custom/enhance-cover-block', enhanceCoverBlock);
 addFilter(

--- a/src/extensions/core/cover/style.js
+++ b/src/extensions/core/cover/style.js
@@ -90,6 +90,7 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 
 	return (
 		<div {...blockProps}>
+			{element.props.children}
 			<a
 				href={linkUrl}
 				target={linkTarget}
@@ -97,7 +98,6 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 				aria-label={__('Cover link', 'vk-blocks-pro')}
 				className="wp-block-cover-vk-link"
 			></a>
-			{element.props.children}
 		</div>
 	);
 };

--- a/src/extensions/core/cover/style.js
+++ b/src/extensions/core/cover/style.js
@@ -99,7 +99,6 @@ const insertLinkIntoCoverBlock = (element, blockType, attributes) => {
 	);
 };
 
-
 addFilter('editor.BlockEdit', 'custom/enhance-cover-block', enhanceCoverBlock);
 addFilter(
 	'blocks.registerBlockType',


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2290 

## どういう変更をしたか？

装飾なしの見出しが2つある状態でカバーブロックにリンクを設定し、再度編集画面に戻るとコンテンツ位置が適切に表示されない不具合を修正しました。
a タグと element.props.children の位置を入れ替え、見出しブロックのクラス名が正しく適用されるよう修正

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-11-01 17 46 47](https://github.com/user-attachments/assets/90d6187b-9826-4c91-a21d-02ef9d149846)

#### 変更後 After
![スクリーンショット 2024-11-01 17 46 56](https://github.com/user-attachments/assets/60f432fe-eca3-48fd-84ae-0e71f7c32a20)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
returnのaタグの位置を変えただけなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. 以下の再現手順でもコンテンツ位置が効くようになっていることを確認。 
   - カバーブロックを設置してリンクを設定する（コンテンツ位置は何もしないので中央になっている状態）
   - 見出しを設置して、スタイルを装飾なしにして、複製して2つにする
   - 保存してフロント画面を確認し、再び編集画面に戻るとコンテンツ位置が効かなくなっている（編集画面でのみ）
2. フロントエンドでも同様の状態が保たれているのかを確認。
3. リンクが機能していることを確認。
4. 上記の変更を理由にカバーブロックで影響がないことを確認。

なお、既存のブロックで上記の状態の時はすみませんが新しくカバーブロックから作り直していただくことになります。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
