### PR TITLE
[ 目次 ] 初期表示状態CLOSE時、フロント画面でOPENボタンをクリックすると1回目のみCLOSE表記にならない現象を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== VK Blocks ===
+ === VK Blocks ===
 Contributors: vektor-inc,kurudrive,naoki0h,nc30,una9,kaorock72,rickaddison7634,mimitips,mthaichi,shimotomoki,sysbird,chiakikouno,doshimaf,mtdkei
 Donate link:
 Tags: Gutenberg,FAQ,alert
@@ -106,6 +106,7 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Table of Contents (Pro) ] Fixed "CLOSE" label not appearing after clicking the "OPEN" button when the initial state is set to "CLOSE".
 [ Bug fix ] The split loading option is now supported for core/heading, core/image, and core/table styles for block editor.
 [ Bug fix ][ Cover ] Fixed an issue where, after setting a link in the Cover block and adding two unstyled headings inside it, the content positioning would not apply upon returning to the editing screen (editing screen only).
 [ Add function ][ Outer (Pro) ] Add book and pyramid in divider style.

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
- === VK Blocks ===
+=== VK Blocks ===
 Contributors: vektor-inc,kurudrive,naoki0h,nc30,una9,kaorock72,rickaddison7634,mimitips,mthaichi,shimotomoki,sysbird,chiakikouno,doshimaf,mtdkei
 Donate link:
 Tags: Gutenberg,FAQ,alert

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -90,6 +90,19 @@ $toc-left-margin: 1rem;
 	.tab {
     width: 100%;
 		overflow: hidden;
+			// label
+			&.is-open {
+				.tab_content-open, .tab_content-close {
+					max-height: 100%;
+					padding: 1em;
+				}
+			}
+			&.is-close {
+				.tab_content-open, .tab_content-close {
+					max-height: 0;
+					padding: 0 1em;
+				}
+			}	
 			&_content-open {
 				max-height: auto;
 				padding: 1em;

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -91,7 +91,7 @@ $toc-left-margin: 1rem;
     width: 100%;
 		overflow: hidden;
 		&_content-open {
-			max-height: auto;
+			max-height: 100%;
 			padding: 1em;
 			transition: all 0.35s;
 		}
@@ -109,14 +109,26 @@ $toc-left-margin: 1rem;
 		}
 
 		// label
-		&.is-open {
-			.tab_content-open, .tab_content-close {
+		input:checked~.button_status-open {
+			~ .tab_content-open {
+				max-height: 0;
+				padding: 0 1em;
+			}
+		}
+		.button_status-open {
+			~ .tab_content-open {
 				max-height: 100%;
 				padding: 1em;
 			}
 		}
-		&.is-close {
-			.tab_content-open, .tab_content-close {
+		input:checked~.button_status-close {
+			~ .tab_content-close {
+				max-height: 100%;
+				padding: 1em;
+			}
+		}
+		.button_status-close {
+			~ .tab_content-close {
 				max-height: 0;
 				padding: 0 1em;
 			}

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -108,8 +108,7 @@ $toc-left-margin: 1rem;
 				cursor: pointer;
 			}
 	}
-
-	// label
+	// :checked
 	input:checked~.button_status-open {
 		~ .tab_content-open {
 			max-height: 100%;

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -90,36 +90,37 @@ $toc-left-margin: 1rem;
 	.tab {
     width: 100%;
 		overflow: hidden;
-			// label
-			&.is-open {
-				.tab_content-open, .tab_content-close {
-					max-height: 100%;
-					padding: 1em;
-				}
-			}
-			&.is-close {
-				.tab_content-open, .tab_content-close {
-					max-height: 0;
-					padding: 0 1em;
-				}
-			}	
-			&_content-open {
-				max-height: auto;
+		&_content-open {
+			max-height: auto;
+			padding: 1em;
+			transition: all 0.35s;
+		}
+		&_content-close {
+			max-height: 0;
+			padding: 0 1em;
+			transition: all 0.35s;
+		}
+		&-close {
+			display: flex;
+			justify-content: flex-end;
+			padding: 1em;
+			font-size: 0.75em;
+			cursor: pointer;
+		}
+
+		// label
+		&.is-open {
+			.tab_content-open, .tab_content-close {
+				max-height: 100%;
 				padding: 1em;
-				transition: all 0.35s;
 			}
-			&_content-close {
+		}
+		&.is-close {
+			.tab_content-open, .tab_content-close {
 				max-height: 0;
 				padding: 0 1em;
-				transition: all 0.35s;
 			}
-			&-close {
-				display: flex;
-				justify-content: flex-end;
-				padding: 1em;
-				font-size: 0.75em;
-				cursor: pointer;
-			}
+		}
 	}
 
 	.vk_tableOfContents_list {

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -107,31 +107,31 @@ $toc-left-margin: 1rem;
 			font-size: 0.75em;
 			cursor: pointer;
 		}
+	}
 
-		// label
-		input:checked~.button_status-open {
-			~ .tab_content-open {
-				max-height: 0;
-				padding: 0 1em;
-			}
+	// label
+	input:checked~.button_status-open {
+		~ .tab_content-open {
+			max-height: 100%;
+			padding: 1em;
 		}
-		.button_status-open {
-			~ .tab_content-open {
-				max-height: 100%;
-				padding: 1em;
-			}
+	}
+	.button_status-open {
+		~ .tab_content-open {
+			max-height: 0;
+			padding: 0 1em;
 		}
-		input:checked~.button_status-close {
-			~ .tab_content-close {
-				max-height: 100%;
-				padding: 1em;
-			}
+	}
+	input:checked~.button_status-close {
+		~ .tab_content-close {
+			max-height: 100%;
+			padding: 1em;
 		}
-		.button_status-close {
-			~ .tab_content-close {
-				max-height: 0;
-				padding: 0 1em;
-			}
+	}
+	.button_status-close {
+		~ .tab_content-close {
+			max-height: 0;
+			padding: 0 1em;
 		}
 	}
 
@@ -161,23 +161,6 @@ $toc-left-margin: 1rem;
 			&::before {
 				content: "CLOSE";
 			}
-		}
-	}
-}
-
-/*-------------------------------------------*/
-/*      編集画面
-/*-------------------------------------------*/
-.editor-styles-wrapper {
-	// :checked
-	input:checked {
-		~ .tab_content-open {
-			max-height: 0;
-			padding: 0 1em;
-		}
-		~ .tab_content-close {
-			max-height: 100%;
-			padding: 1em;
 		}
 	}
 }

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -90,19 +90,6 @@ $toc-left-margin: 1rem;
 	.tab {
     width: 100%;
 		overflow: hidden;
-			// label
-			&.is-open {
-				.tab_content-open, .tab_content-close {
-					max-height: 100%;
-					padding: 1em;
-				}
-			}
-			&.is-close {
-				.tab_content-open, .tab_content-close {
-					max-height: 0;
-					padding: 0 1em;
-				}
-			}	
 			&_content-open {
 				max-height: auto;
 				padding: 1em;
@@ -148,6 +135,23 @@ $toc-left-margin: 1rem;
 			&::before {
 				content: "CLOSE";
 			}
+		}
+	}
+}
+
+/*-------------------------------------------*/
+/*      編集画面
+/*-------------------------------------------*/
+.editor-styles-wrapper {
+	// :checked
+	input:checked {
+		~ .tab_content-open {
+			max-height: 0;
+			padding: 0 1em;
+		}
+		~ .tab_content-close {
+			max-height: 100%;
+			padding: 1em;
 		}
 	}
 }

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -90,23 +90,23 @@ $toc-left-margin: 1rem;
 	.tab {
     width: 100%;
 		overflow: hidden;
-		&_content-open {
-			max-height: 100%;
-			padding: 1em;
-			transition: all 0.35s;
-		}
-		&_content-close {
-			max-height: 0;
-			padding: 0 1em;
-			transition: all 0.35s;
-		}
-		&-close {
-			display: flex;
-			justify-content: flex-end;
-			padding: 1em;
-			font-size: 0.75em;
-			cursor: pointer;
-		}
+			&_content-open {
+				max-height: 100%;
+				padding: 1em;
+				transition: all 0.35s;
+			}
+			&_content-close {
+				max-height: 0;
+				padding: 0 1em;
+				transition: all 0.35s;
+			}
+			&-close {
+				display: flex;
+				justify-content: flex-end;
+				padding: 1em;
+				font-size: 0.75em;
+				cursor: pointer;
+			}
 	}
 
 	// label

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -163,3 +163,20 @@ $toc-left-margin: 1rem;
 		}
 	}
 }
+
+/*      編集画面
+/*-------------------------------------------*/
+.editor-styles-wrapper {
+	input:checked~.button_status-open {
+		~ .tab_content-open {
+			max-height: 0;
+			padding: 0 1em;
+		}
+	}
+	.button_status-open {
+		~ .tab_content-open {
+			max-height: 100%;
+			padding: 1em;
+		}
+	}
+}	

--- a/src/blocks/_pro/table-of-contents-new/style.scss
+++ b/src/blocks/_pro/table-of-contents-new/style.scss
@@ -90,6 +90,19 @@ $toc-left-margin: 1rem;
 	.tab {
     width: 100%;
 		overflow: hidden;
+			// label
+			&.is-open {
+				.tab_content-open, .tab_content-close {
+					max-height: 100%;
+					padding: 1em;
+				}
+			}
+			&.is-close {
+				.tab_content-open, .tab_content-close {
+					max-height: 0;
+					padding: 0 1em;
+				}
+			}	
 			&_content-open {
 				max-height: auto;
 				padding: 1em;
@@ -107,17 +120,6 @@ $toc-left-margin: 1rem;
 				font-size: 0.75em;
 				cursor: pointer;
 			}
-	}
-	// :checked
-	input:checked {
-		~ .tab_content-open {
-			max-height: 0;
-			padding: 0 1em;
-		}
-		~ .tab_content-close {
-			max-height: 100%;
-			padding: 1em;
-		}
 	}
 
 	.vk_tableOfContents_list {

--- a/src/blocks/_pro/table-of-contents-new/view.js
+++ b/src/blocks/_pro/table-of-contents-new/view.js
@@ -6,31 +6,40 @@ document.addEventListener('DOMContentLoaded', () => {
 	});
 
 	// 開/閉 切り替え (:before 疑似要素のアクセシビリティ問題に対応 #2087)
-    document.querySelectorAll('#vk-tab-label').forEach((item) => {
-        const status = item.previousElementSibling; // チェックボックス
-        const tabContent = item.closest('.tab').querySelector('.tab_content-open, .tab_content-close');
-        const initialStateOpen = tabContent.classList.contains('tab_content-open');
+	document.querySelectorAll('#vk-tab-label').forEach((item) => {
+		const status = item.previousElementSibling; // チェックボックス
+		const tabContent = item
+			.closest('.tab')
+			.querySelector('.tab_content-open, .tab_content-close');
+		const initialStateOpen =
+			tabContent.classList.contains('tab_content-open');
 
-        // 初期状態に基づいてボタンのテキストとチェックボックスの状態を設定
-        if (initialStateOpen) {
-            item.textContent = 'CLOSE';
-            status.checked = true; // チェックボックスをチェック状態に
-            item.closest('.tab').classList.add('is-open'); // 開いた状態のクラスを追加
-        } else {
-            item.textContent = 'OPEN';
-            status.checked = false; // チェックボックスを非チェック状態に
-            item.closest('.tab').classList.add('is-close'); // 閉じた状態のクラスを追加
-        }
+		// 初期状態に基づいてボタンのテキストとチェックボックスの状態を設定
+		if (initialStateOpen) {
+			item.textContent = 'CLOSE';
+			status.checked = true; // チェックボックスをチェック状態に
+			item.closest('.tab').classList.add('is-open'); // 開いた状態のクラスを追加
+		} else {
+			item.textContent = 'OPEN';
+			status.checked = false; // チェックボックスを非チェック状態に
+			item.closest('.tab').classList.add('is-close'); // 閉じた状態のクラスを追加
+		}
 
-        // ボタンクリック時にクラスをトグル
-        item.addEventListener('click', function () {
-            if (status && status.type === 'checkbox') {
-                setTimeout(() => {
-                    item.textContent = status.checked ? 'CLOSE' : 'OPEN';
-                    item.closest('.tab').classList.toggle('is-open', status.checked);
-                    item.closest('.tab').classList.toggle('is-close', !status.checked);
-                }, 0);
-            }
-        });
-    });
+		// ボタンクリック時にクラスをトグル
+		item.addEventListener('click', function () {
+			if (status && status.type === 'checkbox') {
+				setTimeout(() => {
+					item.textContent = status.checked ? 'CLOSE' : 'OPEN';
+					item.closest('.tab').classList.toggle(
+						'is-open',
+						status.checked
+					);
+					item.closest('.tab').classList.toggle(
+						'is-close',
+						!status.checked
+					);
+				}, 0);
+			}
+		});
+	});
 });

--- a/src/blocks/_pro/table-of-contents-new/view.js
+++ b/src/blocks/_pro/table-of-contents-new/view.js
@@ -8,7 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
 	// 開/閉 切り替え (:before 疑似要素のアクセシビリティ問題に対応 #2087)
     document.querySelectorAll('#vk-tab-label').forEach((item) => {
         const status = item.previousElementSibling; // チェックボックス
-        const initialStateOpen = status.getAttribute('data-initial-open') === 'open';
+        const tabContent = item.closest('.tab').querySelector('.tab_content-open, .tab_content-close');
+        const initialStateOpen = tabContent.classList.contains('tab_content-open');
 
         // 初期状態に基づいてボタンのテキストとチェックボックスの状態を設定
         if (initialStateOpen) {

--- a/src/blocks/_pro/table-of-contents-new/view.js
+++ b/src/blocks/_pro/table-of-contents-new/view.js
@@ -18,26 +18,16 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (initialStateOpen) {
 			item.textContent = 'CLOSE';
 			status.checked = true;
-			item.closest('.tab').classList.add('is-open');
 		} else {
 			item.textContent = 'OPEN';
 			status.checked = false;
-			item.closest('.tab').classList.add('is-close');
 		}
 
-		// ボタンクリック時にクラスをトグル
+		// ボタンクリック時にテキストをトグル
 		item.addEventListener('click', function () {
 			if (status && status.type === 'checkbox') {
 				setTimeout(() => {
 					item.textContent = status.checked ? 'CLOSE' : 'OPEN';
-					item.closest('.tab').classList.toggle(
-						'is-open',
-						status.checked
-					);
-					item.closest('.tab').classList.toggle(
-						'is-close',
-						!status.checked
-					);
 				}, 0);
 			}
 		});

--- a/src/blocks/_pro/table-of-contents-new/view.js
+++ b/src/blocks/_pro/table-of-contents-new/view.js
@@ -6,17 +6,30 @@ document.addEventListener('DOMContentLoaded', () => {
 	});
 
 	// 開/閉 切り替え (:before 疑似要素のアクセシビリティ問題に対応 #2087)
-	document.querySelectorAll('#vk-tab-label').forEach((item) => {
-		const status = item.previousElementSibling; // チェックボックス
-		
-		// 初期状態の設定: チェックボックスの状態に基づいてテキストを設定
-		item.textContent = status.checked ? 'CLOSE' : 'OPEN';
+    document.querySelectorAll('#vk-tab-label').forEach((item) => {
+        const status = item.previousElementSibling; // チェックボックス
+        const initialStateOpen = status.getAttribute('data-initial-open') === 'open';
 
-		item.addEventListener('click', function () {
-			// チェックボックスの状態に応じてテキストを切り替え
-			setTimeout(() => {
-				item.textContent = status.checked ? 'CLOSE' : 'OPEN';
-			}, 0);
-		});
-	});
+        // 初期状態に基づいてボタンのテキストとチェックボックスの状態を設定
+        if (initialStateOpen) {
+            item.textContent = 'CLOSE';
+            status.checked = true; // チェックボックスをチェック状態に
+            item.closest('.tab').classList.add('is-open'); // 開いた状態のクラスを追加
+        } else {
+            item.textContent = 'OPEN';
+            status.checked = false; // チェックボックスを非チェック状態に
+            item.closest('.tab').classList.add('is-close'); // 閉じた状態のクラスを追加
+        }
+
+        // ボタンクリック時にクラスをトグル
+        item.addEventListener('click', function () {
+            if (status && status.type === 'checkbox') {
+                setTimeout(() => {
+                    item.textContent = status.checked ? 'CLOSE' : 'OPEN';
+                    item.closest('.tab').classList.toggle('is-open', status.checked);
+                    item.closest('.tab').classList.toggle('is-close', !status.checked);
+                }, 0);
+            }
+        });
+    });
 });

--- a/src/blocks/_pro/table-of-contents-new/view.js
+++ b/src/blocks/_pro/table-of-contents-new/view.js
@@ -17,12 +17,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		// 初期状態に基づいてボタンのテキストとチェックボックスの状態を設定
 		if (initialStateOpen) {
 			item.textContent = 'CLOSE';
-			status.checked = true; // チェックボックスをチェック状態に
-			item.closest('.tab').classList.add('is-open'); // 開いた状態のクラスを追加
+			status.checked = true;
+			item.closest('.tab').classList.add('is-open');
 		} else {
 			item.textContent = 'OPEN';
-			status.checked = false; // チェックボックスを非チェック状態に
-			item.closest('.tab').classList.add('is-close'); // 閉じた状態のクラスを追加
+			status.checked = false;
+			item.closest('.tab').classList.add('is-close');
 		}
 
 		// ボタンクリック時にクラスをトグル

--- a/src/blocks/_pro/table-of-contents-new/view.js
+++ b/src/blocks/_pro/table-of-contents-new/view.js
@@ -7,16 +7,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	// 開/閉 切り替え (:before 疑似要素のアクセシビリティ問題に対応 #2087)
 	document.querySelectorAll('#vk-tab-label').forEach((item) => {
+		const status = item.previousElementSibling; // チェックボックス
+		
+		// 初期状態の設定: チェックボックスの状態に基づいてテキストを設定
+		item.textContent = status.checked ? 'CLOSE' : 'OPEN';
+
 		item.addEventListener('click', function () {
-			// 直前にあるチェックボックスで判断する
-			const status = item.previousElementSibling;
-			if (status && status.type === 'checkbox') {
-				if (status.checked) {
-					item.textContent = 'CLOSE';
-				} else {
-					item.textContent = 'OPEN';
-				}
-			}
+			// チェックボックスの状態に応じてテキストを切り替え
+			setTimeout(() => {
+				item.textContent = status.checked ? 'CLOSE' : 'OPEN';
+			}, 0);
 		});
 	});
 });


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2292 

## どういう変更をしたか？

- 初期状態を確認し、目次が閉じている場合にはボタンテキストを「OPEN」、目次が開いている場合には「CLOSE」に設定するロジックを追加しました。
- ボタンのクリック後に、チェックボックスの状態に応じてボタンテキストを即座に更新し、目次の状態と表示テキストが常に一致するようにしました。

### スクリーンショットまたは動画

#### 変更前 Before
https://github.com/user-attachments/assets/f39318cc-450b-4e08-b609-9ebc460c49e1

#### 変更後 After
https://github.com/user-attachments/assets/bdd4e695-c033-440f-a7c9-28bad4c479fa

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→view.jsのみの修正のためスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

新規、既存の目次ブロックで以下を確認しました。
なお、目次ブロックは編集画面で表示タイプ > 初期表示状態「CLOSE」になっていることが前提です。

- フロントエンドにある目次のOPENボタンをクリック後、テキストが適切に OPEN→CLOSE に切り替わることを確認。
- 2回目以降のクリックでも同じようにCLOSE→OPEN→CLOSE→OPENと変わることを確認。
- OPENをクリックした時に目次が表示されることを確認。

また、今回の変更により他の目次機能に影響がないことを確認済みです。
- 表示タイプ > 初期表示状態「OPEN」でもフロントエンドでCLOSE→OPENと切り替わることや目次が閉じることを確認。
- 編集画面でOPEN/CLOSEボタンが適切に変わることを確認。
- 表示タイプ > スタイル「枠なし」時のOPEN/CLOSEボタンが適切に変わることを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。
なお、このプルリクを確認するときは、`npm run build`で確認してください。
(編集画面でエラーになるため。このissueは #2273 に書いてあります。)

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
