### PR TITLE
分割読み込みがOFF(→ではなくでONかつ編集画面)かつdevelopブランチの時: VK Blocks のレスポンシブスペーサーを設置すると高さがでないのを修正

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-block-loader.php
+++ b/inc/vk-blocks/class-vk-blocks-block-loader.php
@@ -103,13 +103,13 @@ class VK_Blocks_Block_Loader {
 		wp_enqueue_style( 'vk-blocks-utils-common-css' );
 
 		// 分割読み込みが有効かどうかをチェック
-		if ( self::should_load_separate_assets() ) {
+		if ( self::should_load_separate_assets() && ! is_admin() ) {
 			// 分割読み込みが有効な場合は個別のスタイルを読み込む
 			wp_enqueue_style( 'vk-blocks/core-table', VK_BLOCKS_DIR_URL . 'build/extensions/core/table/style.css', array(), VK_BLOCKS_VERSION );
 			wp_enqueue_style( 'vk-blocks/core-heading', VK_BLOCKS_DIR_URL . 'build/extensions/core/heading/style.css', array(), VK_BLOCKS_VERSION );
 			wp_enqueue_style( 'vk-blocks/core-image', VK_BLOCKS_DIR_URL . 'build/extensions/core/image/style.css', array(), VK_BLOCKS_VERSION );
 		} else {
-			// 分割読み込みが無効な場合は結合スタイルのみを読み込む
+			// 分割読み込みが無効な場合はフロントエンド画面では結合スタイルを読み込まない
 			wp_enqueue_style( 'vk-blocks-build-css' );
 		}
 	}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2296 

## どういう変更をしたか？

#2293 の影響で、「分割読み込み」をOFFにしている時、レスポンシブスペーサーが効かなくなっているのを修正しました。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-11-08 10 21 33](https://github.com/user-attachments/assets/1c2f8e75-b6b9-45c3-885e-ce068240e0a9)

#### 変更後 After
![スクリーンショット 2024-11-08 10 21 10](https://github.com/user-attachments/assets/7af05e25-c860-449d-9258-4d690c5a03f8)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ → まだ #2293 が配信されていないためスキップ
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

以下をLightning、X-T9で確認しました。

1. developブランチで分割読み込みをOFFにし、編集画面でレスポンシブスペーサーの余白が反映されていない事を確認。
2. このブランチに切り替え、編集画面で上記のレスポンシブスペーサーの余白が反映されている事を確認。
3. フロントエンド、分割読み込みがONの時にも反映されていることを確認。
4. 以下のブロックを固定ページにコピーアンドペーストし、 #2293 の修正部分のメインである、コアの見出し、画像、テーブルのスタイルに影響がないことを確認。
```
<!-- wp:heading {"className":"is-style-vk-heading-solid_black"} -->
<h2 class="wp-block-heading is-style-vk-heading-solid_black">aaaaa</h2>
<!-- /wp:heading -->

<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-vk-image-shadow"} -->
<figure class="wp-block-image size-large is-style-vk-image-shadow"><img src="https://patterns.vektor-inc.co.jp/wp-content/uploads/2023/11/vws_v2_logo_og.png" alt=""/></figure>
<!-- /wp:image -->

<!-- wp:table {"className":"is-style-vk-table-scrollable is-style-vk-table-border-stripes","scrollable":false} -->
<figure class="wp-block-table  is-style-vk-table-border-stripes"><table class="has-fixed-layout"><tbody><tr><td>w</td><td>www</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr><tr><td>www</td><td>www</td><td>wwwwwwwwwwwwww</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr></tbody></table></figure>
<!-- /wp:table -->
```

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。
開発の方はコードの確認をお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
