### PR TITLE
【確認待ち】GithubのActionで必ずPlaywright Testsが引っ掛かってしまうのを修正していただきました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,3 @@
-!!!TEST WORK ACTION for Github!!!
-
 === VK Blocks ===
 Contributors: vektor-inc,kurudrive,naoki0h,nc30,una9,kaorock72,rickaddison7634,mimitips,mthaichi,shimotomoki,sysbird,chiakikouno,doshimaf,mtdkei
 Donate link:

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,5 @@
+!!!TEST WORK ACTION for Github!!!
+
 === VK Blocks ===
 Contributors: vektor-inc,kurudrive,naoki0h,nc30,una9,kaorock72,rickaddison7634,mimitips,mthaichi,shimotomoki,sysbird,chiakikouno,doshimaf,mtdkei
 Donate link:

--- a/test/e2e/heading-transform.spec.ts
+++ b/test/e2e/heading-transform.spec.ts
@@ -52,7 +52,7 @@ test.describe( 'Block', () => {
 
 		// 変換内容
 		await expect( page.locator( '.wp-block-heading' ) ).toHaveClass(
-			'block-editor-rich-text__editable block-editor-block-list__block wp-block is-multi-selected wp-elements-0 has-contrast-color has-text-color wp-block-heading rich-text'
+			'block-editor-rich-text__editable block-editor-block-list__block wp-block is-multi-selected wp-elements-0 has-accent-1-color has-text-color wp-block-heading rich-text'
 		);
 		await expect( page.locator( '.wp-block-heading' ) ).toHaveCSS(
 			'margin-bottom',
@@ -60,10 +60,10 @@ test.describe( 'Block', () => {
 		);
 		await expect( page.locator( 'p.has-text-color' ) ).toHaveCSS(
 			'font-size',
-			'32px'
+			'31.2896px'
 		);
 		await expect( page.locator( '.wp-block-heading' ) ).toHaveClass(
-			'block-editor-rich-text__editable block-editor-block-list__block wp-block is-multi-selected wp-elements-0 has-contrast-color has-text-color wp-block-heading rich-text'
+			'block-editor-rich-text__editable block-editor-block-list__block wp-block is-multi-selected wp-elements-0 has-accent-1-color has-text-color wp-block-heading rich-text'
 		);
 		await expect( page.locator( '.wp-block-heading' ) ).toHaveCSS(
 			'margin-bottom',
@@ -71,7 +71,7 @@ test.describe( 'Block', () => {
 		);
 		await expect( page.locator( 'p.has-text-color' ) ).toHaveCSS(
 			'font-size',
-			'32px'
+			'31.2896px'
 		);
 
 	} );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2315 

## どういう変更をしたか？

GithubのActionで必ずPlaywright Testsが引っ掛かるようになるのを修正していただきました。
テスト内の期待するクラス名をやフォントサイズが変更となっていたようです。

### スクリーンショットまたは動画

#### 変更前 Before

#### 変更後 After

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ →内部の変更のためスキップ
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

このブランチではGIthubにプルリクをアップした時にPlaywrightでチェックがつくことを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行なってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
