### PR TITLE
[ CSS微修正 ] グリッドカラムカードアイテム内で区切りのドット以外が表示されないのを修正しました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,8 @@ e.g.
 
 == Changelog ==
 
+[ Design Bug Fix ] [ Grid Column Card ( Pro ) ] Fixed only dots being displayed as separators.
+
 = 1.91.2 =
 [ Bug fix ] Fix checkbox misalignment in the admin panel.
 

--- a/src/blocks/_pro/gridcolcard/style.scss
+++ b/src/blocks/_pro/gridcolcard/style.scss
@@ -46,11 +46,15 @@
 		&_body{
 			display: grid;
 			align-content: start;
+			width: 100%;
 			&-valign-center{
 				align-content: center;
 			}
 			&-valign-bottom{
 				align-content: end;
+			}
+			hr{ //widthが効かないため
+				width:inherit;
 			}
 			> .swiper{ //スライダーがはみ出すため打消し用
 				margin-left: unset;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-patterns/issues/371#issuecomment-2467049040 の
> [スタッフインタビュー](https://patterns.vektor-inc.co.jp/vk-patterns/1150/)
> 　- グリッドカラムカードアイテム内で、区切りの幅広が表示されていない

## どういう変更をしたか？
.vk_gridcolcard_item_body に `display: grid` のため、区切り線のwidthが自動計算されないようになってました。
そのため、vk_gridcolcard_item_bodyやvk_gridcolcard_item_body内のhrのCSSを追加しました。(テーマによってはデフォルトのwidthが設定されていないため、より広義な書き方にしてます。)

CSS微修正のため1人でいいかと思います。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-11-19 15 10 19](https://github.com/user-attachments/assets/e3bc655a-114d-440a-9fd7-0ec005908e6e)

#### 変更後 After
![スクリーンショット 2024-11-19 15 10 04](https://github.com/user-attachments/assets/b1aace1f-9c1c-493b-847e-eccbc2ea257d)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→ CSSのみなのでスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* このブランチで[スタッフインタビュー](https://patterns.vektor-inc.co.jp/vk-patterns/1150/) をコピペし、編集画面、フロントエンドで区切り線が見えることを確認しました。
* https://patterns.vektor-inc.co.jp/vk-patterns/lp-online-en-school-custom-css/ をコピペし、`width: 100%`の影響がないかの確認を確認しました。
* Lightining、X-T9、TT5で確認しました。
* 分割読み込み、Tree Shaking(Lightinigのみ)、Preload(Lightinigのみ)のON、OFFともに確認しました。

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。
他に気になるところがありましたら適宜ご確認いただけたら幸いです。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
