### PR TITLE
【確認待ち】[ 吹き出し ] icon_displayをOFFにした時フロントエンドで80px分の空のスペースができてしまうので修正【1人でOK】

### DIFF
--- a/src/blocks/balloon/style.scss
+++ b/src/blocks/balloon/style.scss
@@ -22,6 +22,9 @@
 	flex-basis: 80px;
 	flex-shrink: 0;
 	text-align: center;
+	&:not(:empty) {
+	flex-basis: 80px;
+	}
 	&_image:not(.has-text-color) {
 		color: #ccc;
 	}

--- a/src/blocks/balloon/style.scss
+++ b/src/blocks/balloon/style.scss
@@ -19,7 +19,6 @@
 }
 
 .vk_balloon_icon {
-	flex-basis: 80px;
 	flex-shrink: 0;
 	text-align: center;
 	&:not(:empty) {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2362 をマージした後ですみませんが、iconがない時でもフロントエンドで80px分のスペースが割り当てられておりましたので微調整しました。

## どういう変更をしたか？

iconがない時でも80px分のスペースが割り当てられていたため、80px分のスペースが割り当てられられるときの条件を:not:emptyに限定して修正しました。
ご確認は1人でOKです。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-12-12 10 38 43](https://github.com/user-attachments/assets/ab64ebbb-26e5-4aac-a90b-1cc3c6a6877a)

#### 変更後 After
![スクリーンショット 2024-12-12 10 38 20](https://github.com/user-attachments/assets/ac000549-2c16-4c85-a2ad-c5de003fcc40)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ →配信前なのでスキップ
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？ →CSSのみのためスキップ。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

このブランチでicon_displayをOFFにした吹き出しアイコンを設置したとき、フロントエンドで80px分のスペースができていないことを確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認方法

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
