### PR TITLE
目次テーブルの出力方法をReactDOMServerを使わない形に変更

### DIFF
--- a/src/blocks/_pro/table-of-contents-new/edit.js
+++ b/src/blocks/_pro/table-of-contents-new/edit.js
@@ -13,7 +13,7 @@ import {
 import { useCurrentBlocks, useBlocksByName } from '@vkblocks/utils/hooks';
 
 export default function TOCEdit(props) {
-	const { attributes, setAttributes, className, clientId } = props;
+	const { attributes, setAttributes, clientId } = props;
 	const { style, open, renderHtml } = attributes;
 	const blockProps = useBlockProps({
 		className: `vk_tableOfContents vk_tableOfContents-style-${style} tabs`,
@@ -81,12 +81,7 @@ export default function TOCEdit(props) {
 		});
 		allHeadingsSorted.sort((first, second) => first.index - second.index);
 
-		const render = returnHtml(
-			allHeadingsSorted,
-			attributes,
-			className,
-			attributes.open
-		);
+		const render = returnHtml(allHeadingsSorted);
 
 		updateBlockAttributes(clientId, {
 			renderHtml: render,

--- a/src/blocks/_pro/table-of-contents-new/toc-utils.js
+++ b/src/blocks/_pro/table-of-contents-new/toc-utils.js
@@ -58,9 +58,7 @@ export const returnHtml = (sources, attributes, className) => {
 	if (sources) {
 		returnHtmlContent = sources.map((source) => {
 			const baseClass = 'vk_tableOfContents_list_item';
-
 			const data = source.block;
-
 			const level = data.attributes.level;
 
 			let preNumber = '';
@@ -68,111 +66,54 @@ export const returnHtml = (sources, attributes, className) => {
 			if (level === 2) {
 				h2Count++;
 				preNumber = h2Count;
-
-				// Reset
 				h3Count = 0;
 				h4Count = 0;
 				h5Count = 0;
 				h6Count = 0;
-			}
-
-			if (level === 3) {
+			} else if (level === 3) {
 				h3Count++;
 				preNumber = h2Count + countSeparater + h3Count;
-
-				// Reset
 				h4Count = 0;
 				h5Count = 0;
 				h6Count = 0;
-			}
-
-			if (level === 4) {
+			} else if (level === 4) {
 				h4Count++;
-				preNumber =
-					h2Count +
-					countSeparater +
-					fixZero(h3Count) +
-					countSeparater +
-					h4Count;
-
-				// Reset
+				preNumber = h2Count + countSeparater + fixZero(h3Count) + countSeparater + h4Count;
 				h5Count = 0;
 				h6Count = 0;
-			}
-
-			if (level === 5) {
+			} else if (level === 5) {
 				h5Count++;
-				preNumber =
-					h2Count +
-					countSeparater +
-					fixZero(h3Count) +
-					countSeparater +
-					fixZero(h4Count) +
-					countSeparater +
-					h5Count;
-
-				// Reset
+				preNumber = h2Count + countSeparater + fixZero(h3Count) + countSeparater + fixZero(h4Count) + countSeparater + h5Count;
 				h6Count = 0;
-			}
-
-			if (level === 6) {
+			} else if (level === 6) {
 				h6Count++;
-				preNumber =
-					h2Count +
-					countSeparater +
-					fixZero(h3Count) +
-					countSeparater +
-					fixZero(h4Count) +
-					countSeparater +
-					fixZero(h5Count) +
-					countSeparater +
-					h6Count;
+				preNumber = h2Count + countSeparater + fixZero(h3Count) + countSeparater + fixZero(h4Count) + countSeparater + fixZero(h5Count) + countSeparater + h6Count;
 			}
 
 			preNumber = preNumber + '. ';
 
-			const content = data.attributes.content
-				? data.attributes.content
-				: data.attributes.title;
+			const content = data.attributes.content || data.attributes.title;
 
 			// タグ除去メソッド
-			const removeHtmlTags = (text) => {
-				return text.replace(
-					/(<|\[)("[^"]*"|'[^']*'|[^'">])*(>|\])/g,
-					''
-				);
-			};
+			const removeHtmlTags = (text) => text.replace(/(<|\[)("[^"]*"|'[^']*'|[^'">])*(>|\])/g, '');
 
-			let displayContent;
+			let displayContent = '';
 			if (typeof content === 'string') {
 				displayContent = removeHtmlTags(content);
-			} else if (
-				// 6.5 の関係で、見出し・段落ブロックからcontentを取得する場合、attributes.content.text を参照しなければならなくなったので、attributes.content でも attributes.content.text でも対応できるように
-				// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
-				typeof content === 'object' &&
-				typeof content.text === 'string'
-			) {
+			} else if (typeof content === 'object' && typeof content.text === 'string') {
 				displayContent = removeHtmlTags(content.text);
 			}
 
-			return (
-				<li
-					key={data.clientId}
-					className={`${baseClass} ${baseClass}-h-${level}`}
-				>
-					<a
-						href={`#${data.attributes.anchor}`}
-						className={`${baseClass}_link`}
-					>
-						<span className={`${baseClass}_link_preNumber`}>
-							{preNumber}
-						</span>
-						{displayContent}
+			return `
+				<li class="${baseClass} ${baseClass}-h-${level}">
+					<a href="#${data.attributes.anchor}" class="${baseClass}_link">
+						<span class="${baseClass}_link_preNumber">${preNumber}</span>
+						${displayContent}
 					</a>
 				</li>
-			);
-		});
+			`;
+		}).join(''); // Arrayを結合して、1つのHTML文字列に変換
 	}
-	//console.log(returnHtmlContent);
-	return ReactDOMServer.renderToString(returnHtmlContent);
+
+	return returnHtmlContent ? `<ul class="${className}">${returnHtmlContent}</ul>` : '';
 };

--- a/src/blocks/_pro/table-of-contents-new/toc-utils.js
+++ b/src/blocks/_pro/table-of-contents-new/toc-utils.js
@@ -28,17 +28,7 @@ export const getInnerHeadings = (headingBlocks, hasInnerBlocks) => {
 	return headings;
 };
 
-export const returnHtml = (sources, attributes, className) => {
-	const { style } = attributes;
-	if (!className) {
-		className = 'vk_tableOfContents';
-	} else {
-		className = className + ' vk_tableOfContents';
-	}
-
-	if (style) {
-		className = className + ' vk_tableOfContents-style-' + style;
-	}
+export const returnHtml = (sources) => {
 
 	const countSeparater = '.';
 	let h2Count = 0;
@@ -142,7 +132,5 @@ export const returnHtml = (sources, attributes, className) => {
 			.join(''); // Arrayを結合して、1つのHTML文字列に変換
 	}
 
-	return returnHtmlContent
-		? `<ul class="${className}">${returnHtmlContent}</ul>`
-		: '';
+	return returnHtmlContent || '';
 };

--- a/src/blocks/_pro/table-of-contents-new/toc-utils.js
+++ b/src/blocks/_pro/table-of-contents-new/toc-utils.js
@@ -29,7 +29,6 @@ export const getInnerHeadings = (headingBlocks, hasInnerBlocks) => {
 };
 
 export const returnHtml = (sources) => {
-
 	const countSeparater = '.';
 	let h2Count = 0;
 	let h3Count = 0;

--- a/src/blocks/_pro/table-of-contents-new/toc-utils.js
+++ b/src/blocks/_pro/table-of-contents-new/toc-utils.js
@@ -1,4 +1,3 @@
-import ReactDOMServer from 'react-dom/server';
 import { select } from '@wordpress/data';
 
 export const isAllowedBlock = (name, allowedBlocks) => {
@@ -56,55 +55,82 @@ export const returnHtml = (sources, attributes, className) => {
 
 	let returnHtmlContent = '';
 	if (sources) {
-		returnHtmlContent = sources.map((source) => {
-			const baseClass = 'vk_tableOfContents_list_item';
-			const data = source.block;
-			const level = data.attributes.level;
+		returnHtmlContent = sources
+			.map((source) => {
+				const baseClass = 'vk_tableOfContents_list_item';
+				const data = source.block;
+				const level = data.attributes.level;
 
-			let preNumber = '';
+				let preNumber = '';
 
-			if (level === 2) {
-				h2Count++;
-				preNumber = h2Count;
-				h3Count = 0;
-				h4Count = 0;
-				h5Count = 0;
-				h6Count = 0;
-			} else if (level === 3) {
-				h3Count++;
-				preNumber = h2Count + countSeparater + h3Count;
-				h4Count = 0;
-				h5Count = 0;
-				h6Count = 0;
-			} else if (level === 4) {
-				h4Count++;
-				preNumber = h2Count + countSeparater + fixZero(h3Count) + countSeparater + h4Count;
-				h5Count = 0;
-				h6Count = 0;
-			} else if (level === 5) {
-				h5Count++;
-				preNumber = h2Count + countSeparater + fixZero(h3Count) + countSeparater + fixZero(h4Count) + countSeparater + h5Count;
-				h6Count = 0;
-			} else if (level === 6) {
-				h6Count++;
-				preNumber = h2Count + countSeparater + fixZero(h3Count) + countSeparater + fixZero(h4Count) + countSeparater + fixZero(h5Count) + countSeparater + h6Count;
-			}
+				if (level === 2) {
+					h2Count++;
+					preNumber = h2Count;
+					h3Count = 0;
+					h4Count = 0;
+					h5Count = 0;
+					h6Count = 0;
+				} else if (level === 3) {
+					h3Count++;
+					preNumber = h2Count + countSeparater + h3Count;
+					h4Count = 0;
+					h5Count = 0;
+					h6Count = 0;
+				} else if (level === 4) {
+					h4Count++;
+					preNumber =
+						h2Count +
+						countSeparater +
+						fixZero(h3Count) +
+						countSeparater +
+						h4Count;
+					h5Count = 0;
+					h6Count = 0;
+				} else if (level === 5) {
+					h5Count++;
+					preNumber =
+						h2Count +
+						countSeparater +
+						fixZero(h3Count) +
+						countSeparater +
+						fixZero(h4Count) +
+						countSeparater +
+						h5Count;
+					h6Count = 0;
+				} else if (level === 6) {
+					h6Count++;
+					preNumber =
+						h2Count +
+						countSeparater +
+						fixZero(h3Count) +
+						countSeparater +
+						fixZero(h4Count) +
+						countSeparater +
+						fixZero(h5Count) +
+						countSeparater +
+						h6Count;
+				}
 
-			preNumber = preNumber + '. ';
+				preNumber = preNumber + '. ';
 
-			const content = data.attributes.content || data.attributes.title;
+				const content =
+					data.attributes.content || data.attributes.title;
 
-			// タグ除去メソッド
-			const removeHtmlTags = (text) => text.replace(/(<|\[)("[^"]*"|'[^']*'|[^'">])*(>|\])/g, '');
+				// タグ除去メソッド
+				const removeHtmlTags = (text) =>
+					text.replace(/(<|\[)("[^"]*"|'[^']*'|[^'">])*(>|\])/g, '');
 
-			let displayContent = '';
-			if (typeof content === 'string') {
-				displayContent = removeHtmlTags(content);
-			} else if (typeof content === 'object' && typeof content.text === 'string') {
-				displayContent = removeHtmlTags(content.text);
-			}
+				let displayContent = '';
+				if (typeof content === 'string') {
+					displayContent = removeHtmlTags(content);
+				} else if (
+					typeof content === 'object' &&
+					typeof content.text === 'string'
+				) {
+					displayContent = removeHtmlTags(content.text);
+				}
 
-			return `
+				return `
 				<li class="${baseClass} ${baseClass}-h-${level}">
 					<a href="#${data.attributes.anchor}" class="${baseClass}_link">
 						<span class="${baseClass}_link_preNumber">${preNumber}</span>
@@ -112,8 +138,11 @@ export const returnHtml = (sources, attributes, className) => {
 					</a>
 				</li>
 			`;
-		}).join(''); // Arrayを結合して、1つのHTML文字列に変換
+			})
+			.join(''); // Arrayを結合して、1つのHTML文字列に変換
 	}
 
-	return returnHtmlContent ? `<ul class="${className}">${returnHtmlContent}</ul>` : '';
+	return returnHtmlContent
+		? `<ul class="${className}">${returnHtmlContent}</ul>`
+		: '';
 };


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#2273 

## どういう変更をしたか？
- npm run build:cache時に目次ブロックがエラーになるため、目次ブロックの出力をReactDOMServer.renderToString()に頼らずに出力するように変更（JSXを使わず最初からHTMLを組み立てる）
- 出力に一切利用されていない処理を削除 (className関連)

今までと同じ出力結果になります。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ →内部的変更のため記述なし
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
→テストは不要と判断  （npm run test-unit が通ればOK）

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

<!-- [ 実装者が確認した手順を箇条書きで記載してください。予備知識のないレビュワーが見て再現しやすい手順で記載してください。 ] -->

レビュワーに同じ



## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

<!-- [ レビュワーがどういう手順で何を確認して欲しいかを記載してください。 ] -->

* 目次ブロックがエディター側フロント側で正常に表示されることを確認
* 過去に利用した目次ブロックを使ったページを貼り付けて問題なく表示されることを確認
* 見出しに[br-xxl]などモバイル改行を入れて正常に表示されるか確認 (#2368の修正反映の確認） 
* npm run build:cache でビルドした時にエディタに目次を追加してエラーにならないことを確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
