### PR TITLE
[ Outer ] リンクのaria-label属性削除 & targetとrel=が空の場合は出力しない方式に変更

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification change ][ Outer (Pro) ] Removed the aria-label attribute from links, and updated to exclude target and rel attributes when they are empty.
+
 = 1.93.0 =
 [ Add function ][ Link toolbar ][ Outer (Pro) ] Added settings for "rel" and link description.
 [ Add function ][ Ballon ] Add default avatar.

--- a/src/blocks/_pro/outer/deprecated/hooks/index.js
+++ b/src/blocks/_pro/outer/deprecated/hooks/index.js
@@ -7,6 +7,7 @@ import OuterHook1_0_13 from './1.0.13/'
 // saveの数分必要
 export default [
 	// 後方互換
+	OuterHook1_60_0, // 1.93.0
 	OuterHook1_60_0, // 1.92.1
 	OuterHook1_60_0, // 1.89.0
 	OuterHook1_60_0, // 1.76.0

--- a/src/blocks/_pro/outer/deprecated/save/1.93.0/GenerateBgImage.js
+++ b/src/blocks/_pro/outer/deprecated/save/1.93.0/GenerateBgImage.js
@@ -1,0 +1,103 @@
+const GenerateBgImage = (props) => {
+	const { attributes, prefix } = props;
+	const { bgImageMobile, bgImageTablet, bgImage, bgSize, blockId } =
+		attributes;
+
+	const mobileViewport = 'max-width: 575.98px';
+	const tabletViewport = 'min-width: 576px';
+	const pcViewport = 'min-width: 992px';
+	const underPcViewport = 'max-width: 992.98px';
+
+	let backgroundStyle;
+	const backgroundPosition = 'background-position:center!important;';
+	if ('cover' === bgSize) {
+		backgroundStyle = `background-size:${bgSize}!important; ${backgroundPosition}`;
+	} else if ('repeat' === bgSize) {
+		backgroundStyle = `background-repeat:${bgSize}!important; background-size: auto; ${backgroundPosition}`;
+	} else {
+		backgroundStyle = ``;
+	}
+
+	//moible only
+	if (bgImageMobile && !bgImageTablet && !bgImage) {
+		return (
+			<style>{`.${prefix}-${blockId}{background-image: url(${bgImageMobile}); ${backgroundStyle}}`}</style>
+		);
+	}
+	//tablet only
+	if (!bgImageMobile && bgImageTablet && !bgImage) {
+		return (
+			<style>{`.${prefix}-${blockId}{background-image: url(${bgImageTablet}); ${backgroundStyle}}`}</style>
+		);
+	}
+	//pc only
+	if (!bgImageMobile && !bgImageTablet && bgImage) {
+		return (
+			<style>{`.${prefix}-${blockId}{background-image: url(${bgImage}); ${backgroundStyle}}`}</style>
+		);
+	}
+	//pc -mobile
+	if (bgImageMobile && !bgImageTablet && bgImage) {
+		return (
+			<style>
+				{`
+          @media screen and (${underPcViewport}) {
+            .${prefix}-${blockId}{background-image: url(${bgImageMobile}); ${backgroundStyle}}
+         }
+          @media screen and (${pcViewport}) {
+            .${prefix}-${blockId}{background-image: url(${bgImage}); ${backgroundStyle}}
+         }
+          `}
+			</style>
+		);
+	}
+	//pc -tablet
+	if (!bgImageMobile && bgImageTablet && bgImage) {
+		return (
+			<style>
+				{`
+          @media screen and (${underPcViewport}) {
+            .${prefix}-${blockId}{background-image: url(${bgImageTablet}); ${backgroundStyle}}
+         }
+          @media screen and (${pcViewport}) {
+            .${prefix}-${blockId}{background-image: url(${bgImage}); ${backgroundStyle}}
+         }
+          `}
+			</style>
+		);
+	}
+	//tablet - mobile
+	if (bgImageMobile && bgImageTablet && !bgImage) {
+		return (
+			<style>
+				{`
+          @media screen and (${mobileViewport}) {
+            .${prefix}-${blockId}{background-image: url(${bgImageMobile}); ${backgroundStyle}}
+         }
+          @media screen and (${tabletViewport}) {
+            .${prefix}-${blockId}{background-image: url(${bgImageTablet}); ${backgroundStyle}}
+         }
+        `}
+			</style>
+		);
+	}
+	//pc -tablet - mobile
+	if (bgImageMobile && bgImageTablet && bgImage) {
+		return (
+			<style>
+				{`
+        @media screen and (${mobileViewport}) {
+          .${prefix}-${blockId}{background-image: url(${bgImageMobile}); ${backgroundStyle}}
+       }
+        @media screen and (${tabletViewport}) {
+          .${prefix}-${blockId}{background-image: url(${bgImageTablet}); ${backgroundStyle}}
+       }
+        @media screen and (${pcViewport}) {
+          .${prefix}-${blockId}{background-image: url(${bgImage}); ${backgroundStyle}}
+       }
+        `}
+			</style>
+		);
+	}
+};
+export default GenerateBgImage;

--- a/src/blocks/_pro/outer/deprecated/save/1.93.0/component-divider.js
+++ b/src/blocks/_pro/outer/deprecated/save/1.93.0/component-divider.js
@@ -1,0 +1,390 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { isHexColor } from '@vkblocks/utils/is-hex-color';
+
+const componentDivider = (
+	level,
+	color,
+	whichSide,
+	dividerType,
+	levelSettingPerDevice,
+	level_mobile,
+	level_tablet,
+	level_pc
+) => {
+	let sectionPadding;
+	let sectionClass;
+	let lenderDivider;
+
+	const pathClassNames = classnames({
+		[`has-text-color`]: color !== undefined,
+		[`has-${color}-color`]: color !== undefined && !isHexColor(color),
+	});
+
+	// eslint-disable-next-line no-shadow
+	const tiltSectionStyle = (level, color) => {
+		if (level > 0) {
+			return (
+				<path
+					d={`m0,${100 - level} L100,100 L0,100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		} else if (level < 0) {
+			const absLevel = Math.abs(level);
+			return (
+				<path
+					d={`m100,${100 - absLevel} L0,100 L100,100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		}
+	};
+
+	// eslint-disable-next-line no-shadow
+	const curveSectionStyle = (level, color) => {
+		if (level > 0) {
+			return (
+				<path
+					d={`m0,${100 - level} q50,${level * 2},100,0 V100 L0,100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		} else if (level < 0) {
+			return (
+				<path
+					d={`m0,100 q50,${level * 2},100,0 V100 L0,100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		}
+	};
+
+	// eslint-disable-next-line no-shadow
+	const waveSectionStyle = (level, color) => {
+		if (level > 0) {
+			return (
+				<path
+					d={`m0,${
+						100 - level / 2
+					} q20,${level},40,0 t40,0 t40,0 V100 L0,100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		} else if (level < 0) {
+			return (
+				<path
+					d={`m0,${
+						level / 2 + 100
+					} q20,${level},40,0 t40,0 t40,0 V100 L0,100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		}
+	};
+
+	// eslint-disable-next-line no-shadow
+	const triangleSectionStyle = (level, color) => {
+		const absLevel = Math.abs(level);
+		const DivideAbs4 = absLevel / 4;
+
+		if (level > 0) {
+			return (
+				<path
+					d={`m0,100 h${
+						50 - DivideAbs4
+					} l${DivideAbs4},-${absLevel} l${DivideAbs4},${absLevel} h${DivideAbs4} v100 h-100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		} else if (level < 0) {
+			return (
+				<path
+					d={`m0,${100 - absLevel} h${
+						50 - DivideAbs4
+					} l${DivideAbs4},${absLevel} l${DivideAbs4},-${absLevel} h${
+						50 - DivideAbs4
+					} v${absLevel + 1} h-100 z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		}
+	};
+
+	// eslint-disable-next-line no-shadow
+	const largeTriangleSectionStyle = (level, color) => {
+		const absLevel = Math.abs(level);
+
+		if (level > 0) {
+			return (
+				<path
+					d={`M50,${100 - absLevel} H50 L50,${100 - absLevel} 100,100 H100 V100 H0 Z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		} else if (level < 0) {
+			return (
+				<path
+					d={`M0,${100 - absLevel} H0 L50,100 100,${100 - absLevel} H100 V100 H0 Z`}
+					strokeWidth="0"
+					fill={isHexColor(color) ? color : 'currentColor'}
+					className={pathClassNames}
+				/>
+			);
+		}
+	};
+
+	// eslint-disable-next-line no-shadow
+	const serratedSectionStyle = (level, color) => {
+		const absLevel = Math.abs(level);
+		const baseSerrationCount = 40;
+		const serrationCount =
+			level >= 0
+				? baseSerrationCount + Math.floor(absLevel / 5)
+				: Math.max(baseSerrationCount - Math.floor(absLevel / 5), 5);
+		const step = 100 / serrationCount;
+		const height = 10;
+
+		const pathData = Array.from({ length: serrationCount + 1 })
+			.map((_, i) => {
+				const x = i * step;
+				const y = i % 2 === 0 ? 100 - height : 100;
+				return `${x},${y}`;
+			})
+			.join(' L ');
+
+		return (
+			<path
+				d={`M0,100 L ${pathData} L100,100 Z`}
+				strokeWidth="0"
+				fill={isHexColor(color) ? color : 'currentColor'}
+				className={pathClassNames}
+			/>
+		);
+	};
+
+	// eslint-disable-next-line no-shadow
+	const bookSectionStyle = (level, color) => {
+		const absLevel = Math.abs(level);
+		let pathData;
+
+		if (level > 0) {
+			const controlPoint1X = 40;
+			const controlPoint1Y = 100 - level * 0.1;
+			const peakX = 50;
+			const peakY = 100 - level;
+			const controlPoint2X = 60;
+			const controlPoint2Y = 100 - level * 0.1;
+
+			pathData = `M0,100 H0 C${controlPoint1X},${controlPoint1Y} ${peakX},${peakY} ${peakX},${peakY} C${peakX},${peakY} ${controlPoint2X},${controlPoint2Y} 100,100 H100 V100 H0 Z`;
+		} else if (level === 0) {
+			const controlPoint1X = 40;
+			const controlPoint1Y = 100;
+			const peakX = 50;
+			const peakY = 100;
+			const controlPoint2X = 60;
+			const controlPoint2Y = 100;
+
+			pathData = `M0,100 H0 C${controlPoint1X},${controlPoint1Y} ${peakX},${peakY} ${peakX},${peakY} C${peakX},${peakY} ${controlPoint2X},${controlPoint2Y} 100,100 H100 V100 H0 Z`;
+		} else {
+			const controlPoint1X = 40;
+			const controlPoint1Y = absLevel === 100 ? 30 : 100 - absLevel * 0.9;
+			const peakX = 50;
+			const peakY = 100;
+			const controlPoint2X = 60;
+			const controlPoint2Y = absLevel === 100 ? 30 : 100 - absLevel * 0.9;
+			const startY = absLevel === 100 ? 0 : 100 - absLevel;
+
+			pathData = `M0,${startY} H0 C${controlPoint1X},${controlPoint1Y} ${peakX},${peakY} ${peakX},${peakY} C${peakX},${peakY} ${controlPoint2X},${controlPoint2Y} 100,${startY} H100 V100 H0 Z`;
+		}
+
+		return (
+			<path
+				d={pathData}
+				strokeWidth="0"
+				fill={isHexColor(color) ? color : 'currentColor'}
+				className={classnames({
+					[`has-text-color`]: color !== undefined,
+					[`has-${color}-color`]:
+						color !== undefined && !isHexColor(color),
+				})}
+			/>
+		);
+	};
+
+	// eslint-disable-next-line no-shadow
+	const pyramidSectionStyle = (level, color) => {
+		const absLevel = Math.abs(level);
+		let pathData;
+
+		if (level < 0) {
+			const firstPeakX = 25;
+			const firstPeakY = 100 - absLevel * 0.6;
+			const dipX = 40;
+			const dipY = 100 - absLevel * 0.2;
+			const secondPeakX = 75;
+			const secondPeakY = 100 - absLevel;
+			const rightEndY = 100 - absLevel * 0.5;
+
+			pathData = `M0,100 H0 L${firstPeakX},${firstPeakY} ${dipX},${dipY} ${secondPeakX},${secondPeakY} 100,${rightEndY} H100 V100 H0 Z`;
+		} else if (level === 0) {
+			pathData = `M0,100 H0 L0,100 35,100 65,100 85,100 100,100 H100 V100 H0 Z`;
+		} else {
+			const firstPeakX = 75;
+			const firstPeakY = 100 - level * 0.6;
+			const dipX = 60;
+			const dipY = 100 - level * 0.2;
+			const secondPeakX = 25;
+			const secondPeakY = 100 - level;
+			const leftEndY = 100 - level * 0.5;
+
+			pathData = `M0,${leftEndY} H0 L${secondPeakX},${secondPeakY} ${dipX},${dipY} ${firstPeakX},${firstPeakY} 100,100 H100 V100 H0 Z`;
+		}
+
+		return (
+			<path
+				d={pathData}
+				strokeWidth="0"
+				fill={isHexColor(color) ? color : 'currentColor'}
+				className={classnames({
+					[`has-text-color`]: color !== undefined,
+					[`has-${color}-color`]:
+						color !== undefined && !isHexColor(color),
+				})}
+			/>
+		);
+	};
+	//背景色をクリアした時は、白に変更
+	if (!color) {
+		color = '#fff';
+	}
+
+	//Paddingの条件分岐を追加
+	const getSectionStyle = (lvl) => {
+		if (dividerType === 'tilt') {
+			sectionPadding = Math.abs(lvl);
+			return tiltSectionStyle(lvl, color);
+		} else if (dividerType === 'curve') {
+			sectionPadding = lvl > 0 ? Math.abs(lvl) : Math.abs(lvl) * 2;
+			return curveSectionStyle(lvl, color);
+		} else if (dividerType === 'wave') {
+			sectionPadding = Math.abs(lvl);
+			return waveSectionStyle(lvl, color);
+		} else if (dividerType === 'triangle') {
+			sectionPadding = Math.abs(lvl);
+			return triangleSectionStyle(lvl, color);
+		} else if (dividerType === 'largeTriangle') {
+			sectionPadding = Math.abs(lvl);
+			return largeTriangleSectionStyle(lvl, color);
+		} else if (dividerType === 'serrated') {
+			sectionPadding = 10;
+			return serratedSectionStyle(lvl, color);
+		} else if (dividerType === 'book') {
+			sectionPadding = Math.abs(lvl);
+			return bookSectionStyle(lvl, color);
+		} else if (dividerType === 'pyramid') {
+			sectionPadding = Math.abs(lvl);
+			return pyramidSectionStyle(lvl, color);
+		}
+	};
+
+	lenderDivider = getSectionStyle(level);
+
+	//classにdividerTypeを追加
+	// eslint-disable-next-line prefer-const
+	sectionClass = dividerType;
+
+	// vk_outerのクラス名をデバイスタイプに基づいて追加する
+
+	const renderSVG = (lvl, side, deviceType) => {
+		lenderDivider = getSectionStyle(lvl);
+		const style =
+			side === 'upper'
+				? { paddingBottom: sectionPadding + `px` }
+				: { paddingTop: sectionPadding + `px` };
+
+		let displayDeviceTypeClass;
+		if (deviceType === undefined) {
+			displayDeviceTypeClass = '';
+		} else {
+			displayDeviceTypeClass = ` vk_outer-display-${deviceType}`;
+		}
+
+		return (
+			<div
+				className={`vk_outer_separator vk_outer_separator-position-${side} vk_outer_separator-type-${sectionClass}${displayDeviceTypeClass}`}
+				style={style}
+			>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 100 100"
+					preserveAspectRatio="none"
+				>
+					{lenderDivider}
+				</svg>
+			</div>
+		);
+	};
+
+	if (whichSide === 'upper') {
+		if (levelSettingPerDevice) {
+			return (
+				<>
+					{level_pc !== 0 &&
+						level_pc &&
+						renderSVG(level_pc, 'upper', 'pc')}
+					{level_tablet !== 0 &&
+						level_tablet &&
+						renderSVG(level_tablet, 'upper', 'tablet')}
+					{level_mobile !== 0 &&
+						level_mobile &&
+						renderSVG(level_mobile, 'upper', 'mobile')}
+				</>
+			);
+		}
+		return renderSVG(level, 'upper');
+	} else if (whichSide === 'lower') {
+		if (levelSettingPerDevice) {
+			return (
+				<>
+					{level_pc !== 0 &&
+						level_pc &&
+						renderSVG(level_pc, 'lower', 'pc')}
+					{level_tablet !== 0 &&
+						level_tablet &&
+						renderSVG(level_tablet, 'lower', 'tablet')}
+					{level_mobile !== 0 &&
+						level_mobile &&
+						renderSVG(level_mobile, 'lower', 'mobile')}
+				</>
+			);
+		}
+		return renderSVG(level, 'lower');
+	}
+};
+
+export { componentDivider };

--- a/src/blocks/_pro/outer/deprecated/save/1.93.0/save.js
+++ b/src/blocks/_pro/outer/deprecated/save/1.93.0/save.js
@@ -1,0 +1,294 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { componentDivider } from './component-divider';
+import GenerateBgImage from './GenerateBgImage';
+import { isHexColor } from '@vkblocks/utils/is-hex-color';
+const prefix = 'vkb-outer';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export default function save(props) {
+	const { attributes } = props;
+	const {
+		bgColor,
+		bgPosition,
+		bgImageMobile,
+		bgImageTablet,
+		bgImage,
+		outerWidth,
+		padding_left_and_right, //eslint-disable-line camelcase
+		padding_top_and_bottom, //eslint-disable-line camelcase
+		opacity,
+		levelSettingPerDevice,
+		upper_level, //eslint-disable-line camelcase
+		upper_level_mobile, //eslint-disable-line camelcase
+		upper_level_tablet, //eslint-disable-line camelcase
+		upper_level_pc, //eslint-disable-line camelcase
+		lower_level, //eslint-disable-line camelcase
+		lower_level_mobile, //eslint-disable-line camelcase
+		lower_level_tablet, //eslint-disable-line camelcase
+		lower_level_pc, //eslint-disable-line camelcase
+		upperDividerBgColor,
+		lowerDividerBgColor,
+		dividerType,
+		borderWidth,
+		borderStyle,
+		borderColor,
+		borderRadius,
+		minHeightValuePC,
+		minHeightValueTablet,
+		minHeightValueMobile,
+		minHeightUnit,
+		blockId,
+		linkUrl,
+		linkTarget,
+		relAttribute,
+		linkDescription,
+	} = attributes;
+
+	let classPaddingLR;
+	let classPaddingVertical;
+	let classBgPosition;
+	let whichSideUpper;
+	let whichSideLower;
+
+	const bgColorClasses = classnames({
+		[`has-background`]: bgColor !== undefined,
+		[`has-${bgColor}-background-color`]:
+			bgColor !== undefined && !isHexColor(bgColor),
+		[`has-background-dim`]: opacity !== undefined,
+	});
+
+	const bgColorStyles = {
+		backgroundColor: isHexColor(bgColor) ? bgColor : undefined,
+		opacity: opacity !== undefined ? opacity : undefined,
+	};
+
+	const GetBgImage = (
+		<>
+			{(bgImage || bgImageTablet || bgImageMobile) && (
+				<GenerateBgImage prefix={prefix} blockId={blockId} {...props} />
+			)}
+			<span
+				className={`vk_outer-background-area ${bgColorClasses}`}
+				style={bgColorStyles}
+			></span>
+		</>
+	);
+
+	//幅のクラス切り替え
+	const classWidth =
+		outerWidth === 'full' || outerWidth === 'wide'
+			? `vk_outer-width-${outerWidth} align${outerWidth}`
+			: 'vk_outer-width-normal';
+
+	//classBgPositionのクラス切り替え
+	if (bgPosition === 'parallax') {
+		classBgPosition = 'vk_outer-bgPosition-parallax vk-prlx';
+	} else if (bgPosition === 'fixed') {
+		classBgPosition = 'vk_outer-bgPosition-fixed';
+	} else if (bgPosition === 'repeat') {
+		classBgPosition = 'vk_outer-bgPosition-repeat';
+	} else {
+		classBgPosition = 'vk_outer-bgPosition-normal';
+	}
+
+	//classPaddingLRのクラス切り替え
+	classPaddingLR = '';
+	//eslint-disable-next-line camelcase
+	if (padding_left_and_right === '0') {
+		classPaddingLR = 'vk_outer-paddingLR-none';
+		//eslint-disable-next-line camelcase
+	} else if (padding_left_and_right === '1') {
+		classPaddingLR = 'vk_outer-paddingLR-use';
+		//eslint-disable-next-line camelcase
+	} else if (padding_left_and_right === '2') {
+		// Fit to content area width
+		classPaddingLR = 'vk_outer-paddingLR-zero';
+	}
+
+	//classPaddingVerticalのクラス切り替
+	//eslint-disable-next-line camelcase
+	if (padding_top_and_bottom === '1') {
+		classPaddingVertical = 'vk_outer-paddingVertical-use';
+	} else {
+		classPaddingVertical = 'vk_outer-paddingVertical-none';
+	}
+
+	// 上側セクションの傾き切り替え
+	//eslint-disable-next-line camelcase
+	if (!levelSettingPerDevice) {
+		if (upper_level) {
+			whichSideUpper = 'upper';
+		}
+	} else if (upper_level_mobile || upper_level_tablet || upper_level_pc) {
+		whichSideUpper = 'upper';
+	}
+
+	// 下側セクションの傾き切り替え
+	//eslint-disable-next-line camelcase
+	if (!levelSettingPerDevice) {
+		if (lower_level) {
+			whichSideLower = 'lower';
+		}
+	} else if (lower_level_mobile || lower_level_tablet || lower_level_pc) {
+		whichSideLower = 'lower';
+	}
+
+	// 編集画面とサイト上の切り替え
+	const containerClass = 'vk_outer_container';
+
+	// Dividerエフェクトがない時のみ枠線を追
+	let borderStyleProperty = {};
+	//eslint-disable-next-line camelcase
+	if (!levelSettingPerDevice) {
+		if (
+			upper_level === 0 && //eslint-disable-line camelcase
+			lower_level === 0 && //eslint-disable-line camelcase
+			borderWidth > 0 &&
+			borderStyle !== 'none'
+		) {
+			borderStyleProperty = {
+				borderWidth: `${borderWidth}px`,
+				borderStyle: `${borderStyle}`,
+				borderColor:
+					isHexColor(borderColor) && borderColor
+						? borderColor
+						: undefined,
+				borderRadius: `${borderRadius}px`,
+			};
+			//eslint-disable-next-line camelcase
+		} else if (upper_level !== 0 || lower_level !== 0) {
+			//eslint-disable-line camelcase
+			borderStyleProperty = {
+				border: `none`,
+				borderRadius: `0px`,
+			};
+		}
+	} else if (
+		upper_level_mobile === 0 && //eslint-disable-line camelcase
+		upper_level_tablet === 0 && //eslint-disable-line camelcase
+		upper_level_pc === 0 && //eslint-disable-line camelcase
+		lower_level_mobile === 0 && //eslint-disable-line camelcase
+		lower_level_tablet === 0 && //eslint-disable-line camelcase
+		lower_level_pc === 0 && //eslint-disable-line camelcase
+		borderWidth > 0 &&
+		borderStyle !== 'none'
+	) {
+		borderStyleProperty = {
+			borderWidth: `${borderWidth}px`,
+			borderStyle: `${borderStyle}`,
+			borderColor:
+				isHexColor(borderColor) && borderColor
+					? borderColor
+					: undefined,
+			borderRadius: `${borderRadius}px`,
+		};
+		//eslint-disable-next-line camelcase
+	} else if (
+		upper_level_mobile !== 0 ||
+		upper_level_tablet !== 0 ||
+		upper_level_pc !== 0 ||
+		lower_level_mobile !== 0 ||
+		lower_level_tablet !== 0 ||
+		lower_level_pc !== 0
+	) {
+		//eslint-disable-line camelcase
+		borderStyleProperty = {
+			border: `none`,
+			borderRadius: `0px`,
+		};
+	}
+
+	const blockProps = useBlockProps.save({
+		className: classnames(
+			`vkb-outer-${blockId} vk_outer ${classWidth} ${classPaddingLR} ${classPaddingVertical} ${classBgPosition}`,
+			{
+				[`has-border-color`]:
+					borderStyle !== 'none' && borderColor !== undefined,
+				[`has-${borderColor}-border-color`]:
+					borderStyle !== 'none' &&
+					borderColor !== undefined &&
+					!isHexColor(borderColor),
+				[`vk_outer-minHeight`]:
+					minHeightValuePC > 0 ||
+					minHeightValueTablet > 0 ||
+					minHeightValueMobile > 0,
+			}
+		),
+		style: {
+			...borderStyleProperty,
+			'--min-height-mobile': minHeightValueMobile
+				? `${minHeightValueMobile}${minHeightUnit}`
+				: undefined,
+			'--min-height-tablet': minHeightValueTablet
+				? `${minHeightValueTablet}${minHeightUnit}`
+				: undefined,
+			'--min-height-pc': minHeightValuePC
+				? `${minHeightValuePC}${minHeightUnit}`
+				: undefined,
+		},
+	});
+
+	const GetLinkUrl = (
+		<a
+			href={linkUrl}
+			target={linkTarget}
+			className={`${prefix}-link`}
+			rel={relAttribute}
+			aria-label={
+				linkDescription
+					? linkDescription
+					: __('Outer link', 'vk-blocks-pro')
+			}
+		>
+			<span className="screen-reader-text">
+				{linkDescription
+					? linkDescription
+					: __('Outer link', 'vk-blocks-pro')}
+			</span>
+		</a>
+	);
+
+	return (
+		<div {...blockProps}>
+			{linkUrl && GetLinkUrl}
+			{GetBgImage}
+			<div>
+				{componentDivider(
+					upper_level,
+					upperDividerBgColor,
+					whichSideUpper,
+					dividerType,
+					levelSettingPerDevice,
+					upper_level_mobile,
+					upper_level_tablet,
+					upper_level_pc
+				)}
+				<div className={containerClass}>
+					<InnerBlocks.Content />
+				</div>
+				{componentDivider(
+					lower_level,
+					lowerDividerBgColor,
+					whichSideLower,
+					dividerType,
+					levelSettingPerDevice,
+					lower_level_mobile,
+					lower_level_tablet,
+					lower_level_pc
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/blocks/_pro/outer/deprecated/save/index.js
+++ b/src/blocks/_pro/outer/deprecated/save/index.js
@@ -10,6 +10,7 @@ import save1_71_0 from './1.71.0/save';
 import save1_76_0 from './1.76.0/save';
 import save1_89_0 from './1.89.0/save';
 import save1_92_1 from './1.92.1/save';
+import save1_93_0 from './1.93.0/save';
 
 const blockAttributes = {
 	bgColor: {
@@ -186,6 +187,10 @@ const blockAttributes7 = {
 };
 
 const deprecated = [
+	{
+		attributes: blockAttributes7,
+		save: save1_93_0,
+	},
 	{
 		attributes: blockAttributes7,
 		save: save1_92_1,

--- a/src/blocks/_pro/outer/edit.js
+++ b/src/blocks/_pro/outer/edit.js
@@ -415,11 +415,11 @@ export default function OuterEdit(props) {
 						setLinkUrl={(url) => setAttributes({ linkUrl: url })}
 						linkTarget={linkTarget}
 						setLinkTarget={(target) =>
-							setAttributes({ linkTarget: target || undefined })
+							setAttributes({ linkTarget: target })
 						}
 						relAttribute={relAttribute}
 						setRelAttribute={(rel) =>
-							setAttributes({ relAttribute: rel || undefined })
+							setAttributes({ relAttribute: rel })
 						}
 						linkDescription={linkDescription}
 						setLinkDescription={(description) =>

--- a/src/blocks/_pro/outer/edit.js
+++ b/src/blocks/_pro/outer/edit.js
@@ -414,18 +414,13 @@ export default function OuterEdit(props) {
 						linkUrl={linkUrl}
 						setLinkUrl={(url) => setAttributes({ linkUrl: url })}
 						linkTarget={linkTarget}
-						setLinkTarget={(target) =>
-							setAttributes({ linkTarget: target })
-						}
+						setLinkTarget={(target) => setAttributes({ linkTarget: target || undefined })}
 						relAttribute={relAttribute}
-						setRelAttribute={(rel) =>
-							setAttributes({ relAttribute: rel })
-						}
+						setRelAttribute={(rel) => setAttributes({ relAttribute: rel || undefined })}
 						linkDescription={linkDescription}
 						setLinkDescription={(description) =>
 							setAttributes({ linkDescription: description })
 						}
-						aria-label={__('Outer link', 'vk-blocks-pro')}
 					/>
 				</ToolbarGroup>
 			</BlockControls>

--- a/src/blocks/_pro/outer/edit.js
+++ b/src/blocks/_pro/outer/edit.js
@@ -414,9 +414,13 @@ export default function OuterEdit(props) {
 						linkUrl={linkUrl}
 						setLinkUrl={(url) => setAttributes({ linkUrl: url })}
 						linkTarget={linkTarget}
-						setLinkTarget={(target) => setAttributes({ linkTarget: target || undefined })}
+						setLinkTarget={(target) =>
+							setAttributes({ linkTarget: target || undefined })
+						}
 						relAttribute={relAttribute}
-						setRelAttribute={(rel) => setAttributes({ relAttribute: rel || undefined })}
+						setRelAttribute={(rel) =>
+							setAttributes({ relAttribute: rel || undefined })
+						}
 						linkDescription={linkDescription}
 						setLinkDescription={(description) =>
 							setAttributes({ linkDescription: description })

--- a/src/blocks/_pro/outer/save.js
+++ b/src/blocks/_pro/outer/save.js
@@ -243,14 +243,9 @@ export default function save(props) {
 	const GetLinkUrl = (
 		<a
 			href={linkUrl}
-			target={linkTarget}
+			{...(linkTarget ? { target: linkTarget } : {})}
+			{...(relAttribute ? { rel: relAttribute } : {})}
 			className={`${prefix}-link`}
-			rel={relAttribute}
-			aria-label={
-				linkDescription
-					? linkDescription
-					: __('Outer link', 'vk-blocks-pro')
-			}
 		>
 			<span className="screen-reader-text">
 				{linkDescription

--- a/test/e2e-tests/fixtures/blocks/vk-blocks__outer__default.html
+++ b/test/e2e-tests/fixtures/blocks/vk-blocks__outer__default.html
@@ -1,27 +1,27 @@
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":43,"lower_level":-56,"borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"32647eac-6c19-464a-b3f0-e0106a133257"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":43,"lower_level":-56,"borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"f4fc542d-aaf2-46ab-bb45-b0980a81ecab"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-f4fc542d-aaf2-46ab-bb45-b0980a81ecab vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-f4fc542d-aaf2-46ab-bb45-b0980a81ecab{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-f4fc542d-aaf2-46ab-bb45-b0980a81ecab{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-f4fc542d-aaf2-46ab-bb45-b0980a81ecab{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-tilt" style="padding-bottom:43px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="m0,57 L100,100 L0,100 z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-tilt" style="padding-top:56px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="m100,44 L0,100 L100,100 z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 > div > .vk_outer_container{
+.vk_outer.vkb-outer-f4fc542d-aaf2-46ab-bb45-b0980a81ecab > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-f4fc542d-aaf2-46ab-bb45-b0980a81ecab > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-f4fc542d-aaf2-46ab-bb45-b0980a81ecab > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}

--- a/test/e2e-tests/fixtures/blocks/vk-blocks__outer__deprecated-1-93-0.html
+++ b/test/e2e-tests/fixtures/blocks/vk-blocks__outer__deprecated-1-93-0.html
@@ -1,0 +1,30 @@
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":43,"lower_level":-56,"borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"32647eac-6c19-464a-b3f0-e0106a133257"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
+	@media screen and (max-width: 575.98px) {
+	  .vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 576px) {
+	  .vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 992px) {
+	  .vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+   }
+	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-tilt" style="padding-bottom:43px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="m0,57 L100,100 L0,100 z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-tilt" style="padding-top:56px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="m100,44 L0,100 L100,100 z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
+.vk_outer.vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 > div > .vk_outer_container{
+	padding-left:4.3px!important;
+	padding-right:4.3px!important;
+}
+@media (min-width: 576px) {
+	.vk_outer.vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 > div > .vk_outer_container{
+		padding-left:5.9px!important;
+		padding-right:5.9px!important;
+	}
+}
+@media (min-width: 992px) {
+	.vk_outer.vkb-outer-32647eac-6c19-464a-b3f0-e0106a133257 > div > .vk_outer_container{
+		padding-left:15.1px!important;
+		padding-right:15.1px!important;
+	}
+}
+</style>
+<!-- /wp:vk-blocks/outer -->

--- a/test/e2e-tests/fixtures/blocks/vk-blocks__outer__divider.html
+++ b/test/e2e-tests/fixtures/blocks/vk-blocks__outer__divider.html
@@ -1,29 +1,29 @@
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-89,"lower_level_mobile":-89,"lower_level_tablet":-89,"lower_level_pc":-89,"dividerType":"largeTriangle","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"83ef8f52-7d7d-45f0-bf21-15d6676b0b31"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-89,"lower_level_mobile":-89,"lower_level_tablet":-89,"lower_level_pc":-89,"dividerType":"largeTriangle","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"8bd6f77a-3ec7-4489-99f3-257ff86ec48d"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-8bd6f77a-3ec7-4489-99f3-257ff86ec48d vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-8bd6f77a-3ec7-4489-99f3-257ff86ec48d{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-8bd6f77a-3ec7-4489-99f3-257ff86ec48d{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-8bd6f77a-3ec7-4489-99f3-257ff86ec48d{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-largeTriangle" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M50,0 H50 L50,0 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-largeTriangle" style="padding-top:89px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,11 H0 L50,100 100,11 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 > div > .vk_outer_container{
+.vk_outer.vkb-outer-8bd6f77a-3ec7-4489-99f3-257ff86ec48d > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-8bd6f77a-3ec7-4489-99f3-257ff86ec48d > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-8bd6f77a-3ec7-4489-99f3-257ff86ec48d > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}
@@ -31,32 +31,32 @@
 </style>
 <!-- /wp:vk-blocks/outer -->
 
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"serrated","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"6bceebb1-d346-40cf-afae-ba27e495e4dc"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"lower_level_mobile":-56,"lower_level_tablet":-56,"lower_level_pc":-56,"dividerType":"serrated","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"ac998956-eeb5-4ee4-bff3-c3c267458f0f"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-ac998956-eeb5-4ee4-bff3-c3c267458f0f vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-ac998956-eeb5-4ee4-bff3-c3c267458f0f{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-ac998956-eeb5-4ee4-bff3-c3c267458f0f{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-ac998956-eeb5-4ee4-bff3-c3c267458f0f{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-serrated" style="padding-bottom:10px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 L 0,90 L 1.6666666666666667,100 L 3.3333333333333335,90 L 5,100 L 6.666666666666667,90 L 8.333333333333334,100 L 10,90 L 11.666666666666668,100 L 13.333333333333334,90 L 15,100 L 16.666666666666668,90 L 18.333333333333336,100 L 20,90 L 21.666666666666668,100 L 23.333333333333336,90 L 25,100 L 26.666666666666668,90 L 28.333333333333336,100 L 30,90 L 31.666666666666668,100 L 33.333333333333336,90 L 35,100 L 36.66666666666667,90 L 38.333333333333336,100 L 40,90 L 41.66666666666667,100 L 43.333333333333336,90 L 45,100 L 46.66666666666667,90 L 48.333333333333336,100 L 50,90 L 51.66666666666667,100 L 53.333333333333336,90 L 55,100 L 56.66666666666667,90 L 58.333333333333336,100 L 60,90 L 61.66666666666667,100 L 63.333333333333336,90 L 65,100 L 66.66666666666667,90 L 68.33333333333334,100 L 70,90 L 71.66666666666667,100 L 73.33333333333334,90 L 75,100 L 76.66666666666667,90 L 78.33333333333334,100 L 80,90 L 81.66666666666667,100 L 83.33333333333334,90 L 85,100 L 86.66666666666667,90 L 88.33333333333334,100 L 90,90 L 91.66666666666667,100 L 93.33333333333334,90 L 95,100 L 96.66666666666667,90 L 98.33333333333334,100 L 100,90 L100,100 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-serrated" style="padding-top:10px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 L 0,90 L 3.4482758620689653,100 L 6.896551724137931,90 L 10.344827586206897,100 L 13.793103448275861,90 L 17.241379310344826,100 L 20.689655172413794,90 L 24.137931034482758,100 L 27.586206896551722,90 L 31.034482758620687,100 L 34.48275862068965,90 L 37.93103448275862,100 L 41.37931034482759,90 L 44.82758620689655,100 L 48.275862068965516,90 L 51.72413793103448,100 L 55.172413793103445,90 L 58.62068965517241,100 L 62.068965517241374,90 L 65.51724137931033,100 L 68.9655172413793,90 L 72.41379310344827,100 L 75.86206896551724,90 L 79.3103448275862,100 L 82.75862068965517,90 L 86.20689655172413,100 L 89.6551724137931,90 L 93.10344827586206,100 L 96.55172413793103,90 L 100,100 L100,100 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc > div > .vk_outer_container{
+.vk_outer.vkb-outer-ac998956-eeb5-4ee4-bff3-c3c267458f0f > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc > div > .vk_outer_container{
+	.vk_outer.vkb-outer-ac998956-eeb5-4ee4-bff3-c3c267458f0f > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc > div > .vk_outer_container{
+	.vk_outer.vkb-outer-ac998956-eeb5-4ee4-bff3-c3c267458f0f > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}
@@ -64,32 +64,32 @@
 </style>
 <!-- /wp:vk-blocks/outer -->
 
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"book","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"fd5bdd9b-d858-44d2-a7e5-193169bb8172"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"lower_level_mobile":-56,"lower_level_tablet":-56,"lower_level_pc":-56,"dividerType":"book","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"9d00f78a-94db-4894-87c1-3682ac5fc048"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-9d00f78a-94db-4894-87c1-3682ac5fc048 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-9d00f78a-94db-4894-87c1-3682ac5fc048{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-9d00f78a-94db-4894-87c1-3682ac5fc048{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-9d00f78a-94db-4894-87c1-3682ac5fc048{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-book" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 H0 C40,90 50,0 50,0 C50,0 60,90 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-book" style="padding-top:56px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,44 H0 C40,49.6 50,100 50,100 C50,100 60,49.6 100,44 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 > div > .vk_outer_container{
+.vk_outer.vkb-outer-9d00f78a-94db-4894-87c1-3682ac5fc048 > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-9d00f78a-94db-4894-87c1-3682ac5fc048 > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-9d00f78a-94db-4894-87c1-3682ac5fc048 > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}
@@ -97,32 +97,32 @@
 </style>
 <!-- /wp:vk-blocks/outer -->
 
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-100,"lower_level_mobile":-100,"lower_level_tablet":-100,"lower_level_pc":-100,"dividerType":"pyramid","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"ac5aeede-fa45-4a1e-a8d8-27559d168230"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-100,"lower_level_mobile":-100,"lower_level_tablet":-100,"lower_level_pc":-100,"dividerType":"pyramid","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"f444e944-bec2-47a0-a258-b8a1fbea48fa"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-f444e944-bec2-47a0-a258-b8a1fbea48fa vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-f444e944-bec2-47a0-a258-b8a1fbea48fa{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-f444e944-bec2-47a0-a258-b8a1fbea48fa{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-f444e944-bec2-47a0-a258-b8a1fbea48fa{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-pyramid" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,50 H0 L25,0 60,80 75,40 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-pyramid" style="padding-top:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 H0 L25,40 40,80 75,0 100,50 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 > div > .vk_outer_container{
+.vk_outer.vkb-outer-f444e944-bec2-47a0-a258-b8a1fbea48fa > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-f444e944-bec2-47a0-a258-b8a1fbea48fa > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-f444e944-bec2-47a0-a258-b8a1fbea48fa > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}

--- a/test/e2e-tests/fixtures/blocks/vk-blocks__outer__divider__deprecated-1-93-0.html
+++ b/test/e2e-tests/fixtures/blocks/vk-blocks__outer__divider__deprecated-1-93-0.html
@@ -1,0 +1,131 @@
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-89,"lower_level_mobile":-89,"lower_level_tablet":-89,"lower_level_pc":-89,"dividerType":"largeTriangle","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"08c7293f-984b-4b16-96d0-616d054b5cbe"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+	@media screen and (max-width: 575.98px) {
+	  .vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 576px) {
+	  .vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 992px) {
+	  .vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+   }
+	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-largeTriangle" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M50,0 H50 L50,0 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-largeTriangle" style="padding-top:89px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,11 H0 L50,100 100,11 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
+.vk_outer.vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe > div > .vk_outer_container{
+	padding-left:4.3px!important;
+	padding-right:4.3px!important;
+}
+@media (min-width: 576px) {
+	.vk_outer.vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe > div > .vk_outer_container{
+		padding-left:5.9px!important;
+		padding-right:5.9px!important;
+	}
+}
+@media (min-width: 992px) {
+	.vk_outer.vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe > div > .vk_outer_container{
+		padding-left:15.1px!important;
+		padding-right:15.1px!important;
+	}
+}
+</style>
+<!-- /wp:vk-blocks/outer -->
+
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"serrated","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"1a01efa8-9b78-4e3c-b1d7-019d731984fd"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+	@media screen and (max-width: 575.98px) {
+	  .vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 576px) {
+	  .vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 992px) {
+	  .vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+   }
+	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-serrated" style="padding-bottom:10px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 L 0,90 L 1.6666666666666667,100 L 3.3333333333333335,90 L 5,100 L 6.666666666666667,90 L 8.333333333333334,100 L 10,90 L 11.666666666666668,100 L 13.333333333333334,90 L 15,100 L 16.666666666666668,90 L 18.333333333333336,100 L 20,90 L 21.666666666666668,100 L 23.333333333333336,90 L 25,100 L 26.666666666666668,90 L 28.333333333333336,100 L 30,90 L 31.666666666666668,100 L 33.333333333333336,90 L 35,100 L 36.66666666666667,90 L 38.333333333333336,100 L 40,90 L 41.66666666666667,100 L 43.333333333333336,90 L 45,100 L 46.66666666666667,90 L 48.333333333333336,100 L 50,90 L 51.66666666666667,100 L 53.333333333333336,90 L 55,100 L 56.66666666666667,90 L 58.333333333333336,100 L 60,90 L 61.66666666666667,100 L 63.333333333333336,90 L 65,100 L 66.66666666666667,90 L 68.33333333333334,100 L 70,90 L 71.66666666666667,100 L 73.33333333333334,90 L 75,100 L 76.66666666666667,90 L 78.33333333333334,100 L 80,90 L 81.66666666666667,100 L 83.33333333333334,90 L 85,100 L 86.66666666666667,90 L 88.33333333333334,100 L 90,90 L 91.66666666666667,100 L 93.33333333333334,90 L 95,100 L 96.66666666666667,90 L 98.33333333333334,100 L 100,90 L100,100 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-serrated" style="padding-top:10px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 L 0,90 L 3.4482758620689653,100 L 6.896551724137931,90 L 10.344827586206897,100 L 13.793103448275861,90 L 17.241379310344826,100 L 20.689655172413794,90 L 24.137931034482758,100 L 27.586206896551722,90 L 31.034482758620687,100 L 34.48275862068965,90 L 37.93103448275862,100 L 41.37931034482759,90 L 44.82758620689655,100 L 48.275862068965516,90 L 51.72413793103448,100 L 55.172413793103445,90 L 58.62068965517241,100 L 62.068965517241374,90 L 65.51724137931033,100 L 68.9655172413793,90 L 72.41379310344827,100 L 75.86206896551724,90 L 79.3103448275862,100 L 82.75862068965517,90 L 86.20689655172413,100 L 89.6551724137931,90 L 93.10344827586206,100 L 96.55172413793103,90 L 100,100 L100,100 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
+.vk_outer.vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd > div > .vk_outer_container{
+	padding-left:4.3px!important;
+	padding-right:4.3px!important;
+}
+@media (min-width: 576px) {
+	.vk_outer.vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd > div > .vk_outer_container{
+		padding-left:5.9px!important;
+		padding-right:5.9px!important;
+	}
+}
+@media (min-width: 992px) {
+	.vk_outer.vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd > div > .vk_outer_container{
+		padding-left:15.1px!important;
+		padding-right:15.1px!important;
+	}
+}
+</style>
+<!-- /wp:vk-blocks/outer -->
+
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"book","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"b7a55e22-4827-4c20-a69b-309695d46845"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+	@media screen and (max-width: 575.98px) {
+	  .vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 576px) {
+	  .vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 992px) {
+	  .vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+   }
+	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-book" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 H0 C40,90 50,0 50,0 C50,0 60,90 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-book" style="padding-top:56px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,44 H0 C40,49.6 50,100 50,100 C50,100 60,49.6 100,44 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
+.vk_outer.vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 > div > .vk_outer_container{
+	padding-left:4.3px!important;
+	padding-right:4.3px!important;
+}
+@media (min-width: 576px) {
+	.vk_outer.vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 > div > .vk_outer_container{
+		padding-left:5.9px!important;
+		padding-right:5.9px!important;
+	}
+}
+@media (min-width: 992px) {
+	.vk_outer.vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 > div > .vk_outer_container{
+		padding-left:15.1px!important;
+		padding-right:15.1px!important;
+	}
+}
+</style>
+<!-- /wp:vk-blocks/outer -->
+
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-100,"lower_level_mobile":-100,"lower_level_tablet":-100,"lower_level_pc":-100,"dividerType":"pyramid","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"d2782750-9428-49f2-be1b-99fdf62f551b"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+	@media screen and (max-width: 575.98px) {
+	  .vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 576px) {
+	  .vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+   }
+	@media screen and (min-width: 992px) {
+	  .vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+   }
+	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-pyramid" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,50 H0 L25,0 60,80 75,40 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-pyramid" style="padding-top:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 H0 L25,40 40,80 75,0 100,50 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
+.vk_outer.vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b > div > .vk_outer_container{
+	padding-left:4.3px!important;
+	padding-right:4.3px!important;
+}
+@media (min-width: 576px) {
+	.vk_outer.vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b > div > .vk_outer_container{
+		padding-left:5.9px!important;
+		padding-right:5.9px!important;
+	}
+}
+@media (min-width: 992px) {
+	.vk_outer.vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b > div > .vk_outer_container{
+		padding-left:15.1px!important;
+		padding-right:15.1px!important;
+	}
+}
+</style>
+<!-- /wp:vk-blocks/outer -->

--- a/test/e2e-tests/fixtures/blocks/vk-blocks__outer__divider__deprecated-1-93-0.html
+++ b/test/e2e-tests/fixtures/blocks/vk-blocks__outer__divider__deprecated-1-93-0.html
@@ -1,29 +1,29 @@
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-89,"lower_level_mobile":-89,"lower_level_tablet":-89,"lower_level_pc":-89,"dividerType":"largeTriangle","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"08c7293f-984b-4b16-96d0-616d054b5cbe"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-89,"lower_level_mobile":-89,"lower_level_tablet":-89,"lower_level_pc":-89,"dividerType":"largeTriangle","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"83ef8f52-7d7d-45f0-bf21-15d6676b0b31"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-largeTriangle" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M50,0 H50 L50,0 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-largeTriangle" style="padding-top:89px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,11 H0 L50,100 100,11 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe > div > .vk_outer_container{
+.vk_outer.vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe > div > .vk_outer_container{
+	.vk_outer.vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-08c7293f-984b-4b16-96d0-616d054b5cbe > div > .vk_outer_container{
+	.vk_outer.vkb-outer-83ef8f52-7d7d-45f0-bf21-15d6676b0b31 > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}
@@ -31,32 +31,32 @@
 </style>
 <!-- /wp:vk-blocks/outer -->
 
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"serrated","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"1a01efa8-9b78-4e3c-b1d7-019d731984fd"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"serrated","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"6bceebb1-d346-40cf-afae-ba27e495e4dc"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-serrated" style="padding-bottom:10px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 L 0,90 L 1.6666666666666667,100 L 3.3333333333333335,90 L 5,100 L 6.666666666666667,90 L 8.333333333333334,100 L 10,90 L 11.666666666666668,100 L 13.333333333333334,90 L 15,100 L 16.666666666666668,90 L 18.333333333333336,100 L 20,90 L 21.666666666666668,100 L 23.333333333333336,90 L 25,100 L 26.666666666666668,90 L 28.333333333333336,100 L 30,90 L 31.666666666666668,100 L 33.333333333333336,90 L 35,100 L 36.66666666666667,90 L 38.333333333333336,100 L 40,90 L 41.66666666666667,100 L 43.333333333333336,90 L 45,100 L 46.66666666666667,90 L 48.333333333333336,100 L 50,90 L 51.66666666666667,100 L 53.333333333333336,90 L 55,100 L 56.66666666666667,90 L 58.333333333333336,100 L 60,90 L 61.66666666666667,100 L 63.333333333333336,90 L 65,100 L 66.66666666666667,90 L 68.33333333333334,100 L 70,90 L 71.66666666666667,100 L 73.33333333333334,90 L 75,100 L 76.66666666666667,90 L 78.33333333333334,100 L 80,90 L 81.66666666666667,100 L 83.33333333333334,90 L 85,100 L 86.66666666666667,90 L 88.33333333333334,100 L 90,90 L 91.66666666666667,100 L 93.33333333333334,90 L 95,100 L 96.66666666666667,90 L 98.33333333333334,100 L 100,90 L100,100 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-serrated" style="padding-top:10px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 L 0,90 L 3.4482758620689653,100 L 6.896551724137931,90 L 10.344827586206897,100 L 13.793103448275861,90 L 17.241379310344826,100 L 20.689655172413794,90 L 24.137931034482758,100 L 27.586206896551722,90 L 31.034482758620687,100 L 34.48275862068965,90 L 37.93103448275862,100 L 41.37931034482759,90 L 44.82758620689655,100 L 48.275862068965516,90 L 51.72413793103448,100 L 55.172413793103445,90 L 58.62068965517241,100 L 62.068965517241374,90 L 65.51724137931033,100 L 68.9655172413793,90 L 72.41379310344827,100 L 75.86206896551724,90 L 79.3103448275862,100 L 82.75862068965517,90 L 86.20689655172413,100 L 89.6551724137931,90 L 93.10344827586206,100 L 96.55172413793103,90 L 100,100 L100,100 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd > div > .vk_outer_container{
+.vk_outer.vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd > div > .vk_outer_container{
+	.vk_outer.vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-1a01efa8-9b78-4e3c-b1d7-019d731984fd > div > .vk_outer_container{
+	.vk_outer.vkb-outer-6bceebb1-d346-40cf-afae-ba27e495e4dc > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}
@@ -64,32 +64,32 @@
 </style>
 <!-- /wp:vk-blocks/outer -->
 
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"book","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"b7a55e22-4827-4c20-a69b-309695d46845"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-56,"dividerType":"book","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"fd5bdd9b-d858-44d2-a7e5-193169bb8172"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-book" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 H0 C40,90 50,0 50,0 C50,0 60,90 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-book" style="padding-top:56px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,44 H0 C40,49.6 50,100 50,100 C50,100 60,49.6 100,44 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 > div > .vk_outer_container{
+.vk_outer.vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-b7a55e22-4827-4c20-a69b-309695d46845 > div > .vk_outer_container{
+	.vk_outer.vkb-outer-fd5bdd9b-d858-44d2-a7e5-193169bb8172 > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}
@@ -97,32 +97,32 @@
 </style>
 <!-- /wp:vk-blocks/outer -->
 
-<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-100,"lower_level_mobile":-100,"lower_level_tablet":-100,"lower_level_pc":-100,"dividerType":"pyramid","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"d2782750-9428-49f2-be1b-99fdf62f551b"} -->
-<div class="wp-block-vk-blocks-outer vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link"><span class="screen-reader-text">Outer link</span></a><style>
+<!-- wp:vk-blocks/outer {"bgColor":"#8ed1fc","bgImage":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png","bgImageTablet":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","bgImageMobile":"https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png","upper_level":100,"upper_level_mobile":100,"upper_level_tablet":100,"upper_level_pc":100,"lower_level":-100,"lower_level_mobile":-100,"lower_level_tablet":-100,"lower_level_pc":-100,"dividerType":"pyramid","borderColor":"#000","innerSideSpaceValuePC":15.1,"innerSideSpaceValueTablet":5.9,"innerSideSpaceValueMobile":4.3,"linkUrl":"http://localhost:8888/","linkTarget":"_blank","blockId":"ac5aeede-fa45-4a1e-a8d8-27559d168230"} -->
+<div class="wp-block-vk-blocks-outer vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 vk_outer vk_outer-width-normal vk_outer-paddingLR-none vk_outer-paddingVertical-use vk_outer-bgPosition-normal" style="border:none;border-radius:0px"><a href="http://localhost:8888/" target="_blank" class="vkb-outer-link" rel="" aria-label="Outer link"><span class="screen-reader-text">Outer link</span></a><style>
 	@media screen and (max-width: 575.98px) {
-	  .vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 576px) {
-	  .vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
+	  .vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/08/vk-blocks-logo_og.png); }
    }
 	@media screen and (min-width: 992px) {
-	  .vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
+	  .vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230{background-image: url(https://www.vektor-inc.co.jp/wp-content/uploads/2020/04/vws_logo_2020_og.png); }
    }
 	</style><span class="vk_outer-background-area has-background has-background-dim" style="background-color:#8ed1fc;opacity:0.5"></span><div><div class="vk_outer_separator vk_outer_separator-position-upper vk_outer_separator-type-pyramid" style="padding-bottom:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,50 H0 L25,0 60,80 75,40 100,100 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div><div class="vk_outer_container"><!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph --></div><div class="vk_outer_separator vk_outer_separator-position-lower vk_outer_separator-type-pyramid" style="padding-top:100px"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none"><path d="M0,100 H0 L25,40 40,80 75,0 100,50 H100 V100 H0 Z" stroke-width="0" fill="#fff" class="has-text-color"></path></svg></div></div></div><style type="text/css">
-.vk_outer.vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b > div > .vk_outer_container{
+.vk_outer.vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 > div > .vk_outer_container{
 	padding-left:4.3px!important;
 	padding-right:4.3px!important;
 }
 @media (min-width: 576px) {
-	.vk_outer.vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b > div > .vk_outer_container{
+	.vk_outer.vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 > div > .vk_outer_container{
 		padding-left:5.9px!important;
 		padding-right:5.9px!important;
 	}
 }
 @media (min-width: 992px) {
-	.vk_outer.vkb-outer-d2782750-9428-49f2-be1b-99fdf62f551b > div > .vk_outer_container{
+	.vk_outer.vkb-outer-ac5aeede-fa45-4a1e-a8d8-27559d168230 > div > .vk_outer_container{
 		padding-left:15.1px!important;
 		padding-right:15.1px!important;
 	}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

#2380 

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2024-12-20 9 57 28](https://github.com/user-attachments/assets/22721084-0b02-4da8-9187-d0f5da9f8f86)

#### 変更後 After
![スクリーンショット 2024-12-20 9 56 12](https://github.com/user-attachments/assets/fae2fe9e-aef5-4aab-b4d8-595da1d2327b)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [ ] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

Outerブロックとリンクを設置した状態で保存し、フロントエンドで以下を確認しました。
*  aria-label属性が削除されていることを確認しました。
* 「リンクを別ウィンドウで開く」のチェックがない場合、targetの出力がないことを確認しました。
* 「リンクを別ウィンドウで開く」のチェックがある場合、targetが出力され、「_blank」が入ることを確認しました。
* 「noreferrer を追加」「nofollow を追加」のチェックがない場合、relの出力がないことを確認しました。
* 「noreferrer を追加」「nofollow を追加」のチェックがある場合、relが出力され、「noreferrer」「nofollow」がそれぞれ入ることを確認しました。
* developブランチで作ったリンク設定付きのOuterブロックを`fix/link-toolbar/empty-target-rel`の編集画面で開いた時「復旧を試みる」が出ないことを確認しました。

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
