### PR TITLE
投稿リストスライダーが複数設置されたときに連動しないように

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -107,6 +107,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Post List Slider (Pro) ] Fixed sliding behavior when multiple post-list-slider blocks are present.
+
 = 1.93.1 =
 [ Bug fix ][ Post List (Pro) / Post List Slider (Pro) ] Fix the issue where posts are always displayed from the first post regardless of the "Display from the first post always" setting.
 [ Bug fix ][ Post List (Pro) / Post List Slider (Pro) ] Fixed missing "No relevant posts." message when no post types are selected.

--- a/src/blocks/_pro/post-list-slider/block.json
+++ b/src/blocks/_pro/post-list-slider/block.json
@@ -4,13 +4,8 @@
 	"category": "vk-blocks-cat",
 	"title": "Post List Slider",
 	"styleHandles": ["vk-blocks-build-css"],
-	"scriptHandles": ["vk-swiper-script", "vk-blocks/post-list-slider-script"],
 	"editorStyleHandles": ["vk-swiper-style", "vk-blocks-build-editor-css"],
-	"editorScriptHandles": [
-		"vk-blocks-build-js",
-		"vk-swiper-script",
-		"vk-blocks/post-list-slider-script"
-	],
+	"editorScriptHandles": ["vk-blocks-build-js"],
 	"attributes": {
 		"layout": {
 			"type": "string",

--- a/src/blocks/_pro/post-list-slider/edit.js
+++ b/src/blocks/_pro/post-list-slider/edit.js
@@ -20,9 +20,10 @@ import { DisplayItemsControl } from '@vkblocks/components/display-items-control'
 import { DisplayCondition } from '@vkblocks/components/display-condition';
 import { AdvancedToggleControl } from '@vkblocks/components/advanced-toggle-control';
 import { MultiItemSetting } from './multi-item-setting.js';
+import { isParentReusableBlock } from '@vkblocks/utils/is-parent-reusable-block';
 
 export default function PostListSliderEdit(props) {
-	const { attributes, setAttributes } = props;
+	const { attributes, setAttributes, clientId } = props;
 
 	const postTypesProps = vk_block_post_type_params.post_type_option;
 	const termsByTaxonomyName = vk_block_post_type_params.term_by_taxonomy_name;
@@ -38,9 +39,21 @@ export default function PostListSliderEdit(props) {
 		effect,
 		speed,
 		navigationPosition,
+		blockId,
 	} = attributes;
 
 	const blockProps = useBlockProps();
+
+	useEffect(() => {
+		// blockID が定義されていない場合は blockID に clientID を挿入
+		// 再利用ブロックのインナーブロックではない場合 blockID を更新
+		if (
+			blockId === undefined ||
+			isParentReusableBlock(clientId) === false
+		) {
+			setAttributes({ blockId: clientId });
+		}
+	}, [clientId]);
 
 	useEffect(() => {
 		if (layout === 'postListText') {

--- a/src/blocks/_pro/post-list-slider/index.php
+++ b/src/blocks/_pro/post-list-slider/index.php
@@ -5,6 +5,8 @@
  * @package vk-blocks
  */
 
+ use VektorInc\VK_Swiper\VkSwiper;
+
 /**
  * Post List Get Block Data
  *
@@ -227,6 +229,15 @@ function vk_blocks_register_block_post_list_slider() {
 		);
 	}
 
+	VkSwiper::register_swiper();
+
+	wp_register_script(
+		'vk-blocks/post-list-slider-script',
+		VK_BLOCKS_DIR_URL . 'build/vk-post-list-slider.min.js',
+		array( 'vk-swiper-script' ),
+		VK_BLOCKS_VERSION,
+		true
+	);
 	// クラシックテーマ & 6.5 環境で $assets = array() のように空にしないと重複登録になるため
 	// ここで初期化しておく
 	$assets = array(
@@ -237,7 +248,7 @@ function vk_blocks_register_block_post_list_slider() {
 	if ( method_exists( 'VK_Blocks_Block_Loader', 'should_load_separate_assets' ) && VK_Blocks_Block_Loader::should_load_separate_assets() ) {
 		$assets = array(
 			'style_handles'         => array( 'vk-blocks/post-list-slider' ),
-			'script_handles'        => array(),
+			'script_handles'        => array( 'vk-blocks/post-list-slider-script' ),
 			'editor_style_handles'  => array( 'vk-swiper-style', 'vk-blocks-build-editor-css' ),
 			'editor_script_handles' => array( 'vk-blocks-build-js' ),
 			'render_callback'       => 'vk_blocks_post_list_slider_render_callback',

--- a/src/blocks/_pro/post-list-slider/index.php
+++ b/src/blocks/_pro/post-list-slider/index.php
@@ -5,7 +5,7 @@
  * @package vk-blocks
  */
 
- use VektorInc\VK_Swiper\VkSwiper;
+use VektorInc\VK_Swiper\VkSwiper;
 
 /**
  * Post List Get Block Data


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/2385

## どういう変更をしたか？

投稿リストスライダーが複数設置されたときに連動しないようにしました。

### スクリーンショットまたは動画

#### 変更前 Before

#### 変更後 After

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？
⇒ フロントに出力される JS を修正しただけなので省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. 投稿リストスライダーを複数設置
2. スライダーの設定及び複数枚設定をそれぞれ異なる設定にする
3. 上下に配置した投稿リストスライダーが異なる挙動になるのを確認しました。

以上を確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

1. 投稿リストスライダーを複数設置
2. スライダーの設定及び複数枚設定をそれぞれ異なる設定にする
3. 上下に配置した投稿リストスライダーが異なる挙動になるのを確認しました。

以上を確認お願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
