### PR TITLE
【丸山さん確認中】[ Outer ] depreatedの記述を直しました

### DIFF
--- a/src/blocks/_pro/outer/deprecated/save/index.js
+++ b/src/blocks/_pro/outer/deprecated/save/index.js
@@ -11,7 +11,6 @@ import save1_76_0 from './1.76.0/save';
 import save1_89_0 from './1.89.0/save';
 import save1_92_1 from './1.92.1/save';
 import save1_93_0 from './1.93.0/save';
-import save1_93_2 from './1.93.2/save';
 
 const blockAttributes = {
 	bgColor: {
@@ -72,7 +71,7 @@ const blockAttributes = {
 	},
 	borderColor: {
 		type: 'string',
-		default: '#fff',
+		default: '#000',
 	},
 	borderRadius: {
 		type: 'number',
@@ -133,52 +132,32 @@ const blockAttributes4 = {
 	...blockAttributes3,
 	levelSettingPerDevice: {
 		type: 'boolean',
-		default: false
 	},
 	upper_level_mobile: {
 		type: 'number',
-		default: 0
 	},
 	upper_level_tablet: {
 		type: 'number',
-		default: 0
 	},
 	upper_level_pc: {
 		type: 'number',
-		default: 0
 	},
 	lower_level_mobile: {
 		type: 'number',
-		default: 0
 	},
 	lower_level_tablet: {
 		type: 'number',
-		default: 0
 	},
 	lower_level_pc: {
 		type: 'number',
-		default: 0
 	},
 };
 
 // 1.64.0 から attributes を変更
 const blockAttributes5 = {
 	...blockAttributes4,
-	minHeightValuePC: {
-		type: 'number',
-		default: 0
-	},
-	minHeightValueTablet: {
-		type: 'number',
-		default: 0
-	},
-	minHeightValueMobile: {
-		type: 'number',
-		default: 0
-	},
-	minHeightUnit: {
-		type: 'string',
-		default: 'px'
+	minHeight: {
+		type: 'object',
 	},
 };
 
@@ -207,49 +186,21 @@ const blockAttributes7 = {
 	},
 };
 
-/*
-// save1_89_0 から attributes を変更
-const blockAttributes8 = {
-	...blockAttributes7,
-	bgFocalPointPC: {
-		type: 'object',
-		default: { 'x': 0.5, 'y': 0.5 }
-	},
-	bgFocalPointTablet: {
-		type: 'object',
-		default: { 'x': 0.5, 'y': 0.5 }
-	},
-	bgFocalPointMobile: {
-		type: 'object',
-		default: { 'x': 0.5, 'y': 0.5 }
-	},
-	enableFocalPointPC: {
-	  type: 'boolean',
-	  default: false
-	},
-	enableFocalPointTablet: {
-	  type: 'boolean',
-	  default: false
-	},
-	enableFocalPointMobile: {
-	  type: 'boolean',
-	  default: false
-	},
-};
-*/
-
 const deprecated = [
-	{
-		attributes: blockAttributes7,
-		save: save1_93_2,
-	},
 	{
 		attributes: blockAttributes7,
 		save: save1_93_0,
 	},
 	{
-		attributes: blockAttributes7,
+		attributes: blockAttributes6,
 		save: save1_92_1,
+		migrate: (attributes) => {
+			return {
+				...attributes,
+				relAttribute: attributes.relAttribute ?? '',
+				linkDescription: attributes.linkDescription ?? '',
+			};
+		},
 	},
 	{
 		attributes: blockAttributes6,

--- a/src/blocks/_pro/outer/deprecated/save/index.js
+++ b/src/blocks/_pro/outer/deprecated/save/index.js
@@ -241,6 +241,10 @@ const blockAttributes8 = {
 const deprecated = [
 	{
 		attributes: blockAttributes7,
+		save: save1_93_2,
+	},
+	{
+		attributes: blockAttributes7,
 		save: save1_93_0,
 	},
 	{

--- a/src/blocks/_pro/outer/deprecated/save/index.js
+++ b/src/blocks/_pro/outer/deprecated/save/index.js
@@ -11,6 +11,7 @@ import save1_76_0 from './1.76.0/save';
 import save1_89_0 from './1.89.0/save';
 import save1_92_1 from './1.92.1/save';
 import save1_93_0 from './1.93.0/save';
+import save1_93_2 from './1.93.2/save';
 
 const blockAttributes = {
 	bgColor: {
@@ -71,7 +72,7 @@ const blockAttributes = {
 	},
 	borderColor: {
 		type: 'string',
-		default: '#000',
+		default: '#fff',
 	},
 	borderRadius: {
 		type: 'number',
@@ -132,32 +133,52 @@ const blockAttributes4 = {
 	...blockAttributes3,
 	levelSettingPerDevice: {
 		type: 'boolean',
+		default: false
 	},
 	upper_level_mobile: {
 		type: 'number',
+		default: 0
 	},
 	upper_level_tablet: {
 		type: 'number',
+		default: 0
 	},
 	upper_level_pc: {
 		type: 'number',
+		default: 0
 	},
 	lower_level_mobile: {
 		type: 'number',
+		default: 0
 	},
 	lower_level_tablet: {
 		type: 'number',
+		default: 0
 	},
 	lower_level_pc: {
 		type: 'number',
+		default: 0
 	},
 };
 
 // 1.64.0 から attributes を変更
 const blockAttributes5 = {
 	...blockAttributes4,
-	minHeight: {
-		type: 'object',
+	minHeightValuePC: {
+		type: 'number',
+		default: 0
+	},
+	minHeightValueTablet: {
+		type: 'number',
+		default: 0
+	},
+	minHeightValueMobile: {
+		type: 'number',
+		default: 0
+	},
+	minHeightUnit: {
+		type: 'string',
+		default: 'px'
 	},
 };
 
@@ -185,6 +206,37 @@ const blockAttributes7 = {
 		default: '',
 	},
 };
+
+/*
+// save1_89_0 から attributes を変更
+const blockAttributes8 = {
+	...blockAttributes7,
+	bgFocalPointPC: {
+		type: 'object',
+		default: { 'x': 0.5, 'y': 0.5 }
+	},
+	bgFocalPointTablet: {
+		type: 'object',
+		default: { 'x': 0.5, 'y': 0.5 }
+	},
+	bgFocalPointMobile: {
+		type: 'object',
+		default: { 'x': 0.5, 'y': 0.5 }
+	},
+	enableFocalPointPC: {
+	  type: 'boolean',
+	  default: false
+	},
+	enableFocalPointTablet: {
+	  type: 'boolean',
+	  default: false
+	},
+	enableFocalPointMobile: {
+	  type: 'boolean',
+	  default: false
+	},
+};
+*/
 
 const deprecated = [
 	{


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/pull/2418#issuecomment-2621158662

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->
<!-- [ プログラムの不具合修正の場合、再発防止の情報共有 & レビューしやすいように、簡単で良いので何が原因で不具合が発生し、対策としてどういう処理をしたのかを記載してください ] -->

書き直してみました。コードの内容の確認のため、お手数ですが @mthaichi さんにご確認いただけたらと思います。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2025-01-30 12 27 59](https://github.com/user-attachments/assets/8bf4db53-045e-44bd-b9b0-d0fea6c172c1)

#### 変更後 After
![スクリーンショット 2025-01-30 12 27 20](https://github.com/user-attachments/assets/7795e89c-040c-42d7-902f-7e0d116171a2)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ →内部のためスキップ
- [ ] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？ →内部のためスキップ
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？ →スキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. `ad71a2e` のブランチ(Ver.1.92.0)を`npm run build`し、リンク付きのOuterを設置し公開。
2. `2268679` のブランチ(Ver.1.93.0)に切り替え、以下のコードをコピーしてコードエディターツールで`/src/blocks/_pro/outer/deprecated/save/index.js`に貼り付ける。
```
import save1_0_13 from './1.0.13/save';
import save1_26_0 from './1.26.0/save';
import save1_34_1 from './1.34.1/save';
import save1_36_2 from './1.36.2/save';
import save1_50_1 from './1.50.1/save';
import save1_60_0 from './1.60.0/save';
import save1_61_2 from './1.61.2/save';
import save1_64_0 from './1.64.0/save';
import save1_71_0 from './1.71.0/save';
import save1_76_0 from './1.76.0/save';
import save1_89_0 from './1.89.0/save';
import save1_92_1 from './1.92.1/save';

const blockAttributes = {
	bgColor: {
		type: 'string',
		default: '#f3f4f5',
	},
	bgImage: {
		type: 'string',
		default: null,
	},
	outerWidth: {
		type: 'string',
		default: 'normal',
	},
	bgPosition: {
		type: 'string',
		default: 'normal',
	},
	padding_left_and_right: {
		type: 'string',
		default: '0',
	},
	padding_top_and_bottom: {
		type: 'string',
		default: '1',
	},
	opacity: {
		type: 'number',
		default: 0.5,
	},
	upper_level: {
		type: 'number',
		default: 0,
	},
	lower_level: {
		type: 'number',
		default: 0,
	},
	dividerType: {
		type: 'string',
		default: 'tilt',
	},
	upperDividerBgColor: {
		type: 'string',
		default: '#fff',
	},
	lowerDividerBgColor: {
		type: 'string',
		default: '#fff',
	},
	borderWidth: {
		type: 'number',
		default: 0,
	},
	borderStyle: {
		type: 'string',
		default: 'none',
	},
	borderColor: {
		type: 'string',
		default: '#000',
	},
	borderRadius: {
		type: 'number',
		default: 0,
	},
	defaultBgColor: {
		type: 'string',
		default: '#f3f4f5',
	},
	bgImageTablet: {
		type: 'string',
		default: null,
	},
	bgImageMobile: {
		type: 'string',
		default: null,
	},
	clientId: {
		type: 'string',
		default: null,
	},
};

const blockAttributes2 = {
	...blockAttributes,
	innerSideSpaceValuePC: {
		type: "number",
		default: 0
	},
	innerSideSpaceValueTablet: {
		type: "number",
		default: 0
	},
	innerSideSpaceValueMobile: {
		type: "number",
		default: 0
	},
	innerSideSpaceUnit: {
		type: "string",
		default: "px"
	},
};


// 1.34.1 から attributes を変更
const blockAttributes3 = {
	...blockAttributes2,
	clientId: {
		type: 'string',
	},
	blockId: {
		type: 'string',
	},
};

// 1.61.2 から attributes を変更
const blockAttributes4 = {
	...blockAttributes3,
	levelSettingPerDevice: {
		type: 'boolean',
	},
	upper_level_mobile: {
		type: 'number',
	},
	upper_level_tablet: {
		type: 'number',
	},
	upper_level_pc: {
		type: 'number',
	},
	lower_level_mobile: {
		type: 'number',
	},
	lower_level_tablet: {
		type: 'number',
	},
	lower_level_pc: {
		type: 'number',
	},
};

// 1.64.0 から attributes を変更
const blockAttributes5 = {
	...blockAttributes4,
	minHeight: {
		type: 'object',
	},
};

// 1.71.0 から attributes を変更
const blockAttributes6 = {
	...blockAttributes5,
	linkUrl: {
		type: 'string',
	},
	linkTarget: {
		type: 'string',
		default: ''
	},
};

/*
// 1.76.0 から attributes を変更
const blockAttributes7 = {
	...blockAttributes6,
	relAttribute: {
		type: 'string',
		default: '',
	},
	linkDescription: {
		type: 'string',
		default: '',
	},
};
*/

const deprecated = [
	{
		attributes: blockAttributes6,
		save: save1_92_1,
		migrate: (attributes) => {
			return {
				...attributes,
				relAttribute: attributes.relAttribute ?? '',
				linkDescription: attributes.linkDescription ?? '',
			};
		},
	},
	{
		attributes: blockAttributes6,
		save: save1_89_0,
	},
	{
		attributes: blockAttributes6,
		save: save1_76_0,
	},
	{
		attributes: blockAttributes5,
		save: save1_71_0,
	},
	{
		attributes: blockAttributes4,
		save: save1_64_0,
	},
	{
		attributes: blockAttributes3,
		save: save1_61_2,
	},
	{
		attributes: blockAttributes3,
		save: save1_60_0,
	},
	{
		attributes: blockAttributes3,
		save: save1_50_1,
	},
	//ブロックテンプレート用のdeprecated
	{
		attributes: blockAttributes3,
		save: save1_36_2,
	},
	{
		attributes: blockAttributes2,
		save: save1_34_1,
	},
	{
		attributes: blockAttributes2,
		save: save1_26_0,
	},
	{
		attributes: blockAttributes,
		save: save1_0_13,
	},
];

export default deprecated;

```
3. `npm run build`し、1の編集ページを再読み込みしたところ、変更後のスクショのようになっていることを確認。
4. このブランチ(`fix/outer/deprecated`)に移動し、`npm run build`し、1の編集ページを再読み込みしたところ、変更後のスクショのようになっていることを確認。

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認、また、コードの確認をお願いいたします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
