### PR TITLE
テキストドメイン置換不良対応

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,11 +20,11 @@ gulp.task('text-domain-free', (done) => {
 		.pipe(replace("wp_set_script_translations( 'vk-blocks-build-js', 'vk-blocks-pro', VK_BLOCKS_DIR_PATH . 'languages' );", "wp_set_script_translations( 'vk-blocks-build-js', 'vk-blocks' );"))
 		.pipe(gulp.dest('./inc/'));
 	gulp.src(['./src/**'])
-		.pipe(replace(/__\(\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gm, "__( $1, 'vk-blocks' )"))
-		.pipe(replace(/_e\(\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gm, "_e( $1, 'vk-blocks' )"))
-		.pipe(replace(/_n_noop\(\s*?(['"`].*?['"`]),\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gm, "_n_noop( $1, $2, 'vk-blocks' )"))
-		.pipe(replace(/_x\(\s*?(['"`].*?['"`]),\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gm, "_x( $1, $2, 'vk-blocks' )"))
-		.pipe(replace('"textdomain": "vk-blocks-pro"', '"textdomain": "vk-blocks"'))
+		.pipe(replace(/__\(\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gsm, "__( $1, 'vk-blocks' )"))
+		.pipe(replace(/_e\(\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gsm, "_e( $1, 'vk-blocks' )"))
+		.pipe(replace(/_n_noop\(\s*?(['"`].*?['"`]),\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gsm, "_n_noop( $1, $2, 'vk-blocks' )"))
+		.pipe(replace(/_x\(\s*?(['"`].*?['"`]),\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gsm, "_x( $1, $2, 'vk-blocks' )"))
+		.pipe(replace(/"textdomain":\s*?["']vk-blocks-pro["']/gsm, '"textdomain": "vk-blocks"'))
 		.pipe(gulp.dest('./src/'));
 	gulp.src(['./test/**'])
 		.pipe(replace(/__\(\s*?(['"`].*?['"`]),\s*?['"`]vk-blocks-pro['"`]\s*?\)/gm, "__( $1, 'vk-blocks' )"))


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

vk-blocks-pro から vk-blocks へのテキストドメイン置換において、
自動整形で vk-blocks-pro', のあとで改行されたりすると置換が動作しないため修正