### PR TITLE
[ アニメーション / 固定表示 / Outer ] X-T9で フル幅／ワイド配置を可能にし、全幅や幅広のブロックを該当ブロックでラップしたときに編集画面で全幅や幅広にならないのを修正しました

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,7 @@ e.g.
 
 == Changelog ==
 
-[ Add function ][ Animation (Pro) / Fixed Display (Pro) / Outer (Pro) / Slider ] Added support for layout.allowJustification: false to allow full/wide align
+[ Add function ][ Animation (Pro) / Fixed Display (Pro) / Outer (Pro) / Slider ] Added support for layout.allowJustification: false to allow full/wide align for block themes.
 [ Bug fix ] [ Icon ] Fixed an unwanted bottom margin appearing.
 [ Specification change ] Fixed the zoom-out toggle not always displaying in the editor toolbar (updated blocks.json API version from 2 to 3).
 

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,7 @@ e.g.
 
 == Changelog ==
 
+[ Add function ][ Animation (Pro) / Fixed Display (Pro) / Outer (Pro) / Slider ] Added support for layout.allowJustification: false to allow full/wide align
 [ Bug fix ] [ Icon ] Fixed an unwanted bottom margin appearing.
 [ Specification change ] Fixed the zoom-out toggle not always displaying in the editor toolbar (updated blocks.json API version from 2 to 3).
 

--- a/readme.txt
+++ b/readme.txt
@@ -108,8 +108,8 @@ e.g.
 
 == Changelog ==
 
-[ Add function ][ Animation (Pro) / Fixed Display (Pro) / Outer (Pro) / Slider ] Added support for layout.allowJustification: false to allow full/wide align for block themes.
-[ Bug fix ] [ Icon ] Fixed an unwanted bottom margin appearing.
+[ Add function ][ Animation (Pro) / Fixed Display (Pro) / Outer (Pro) / Slider ] Added support for layout.allowJustification: false, allowing full-width/wide alignment in block themes where wrapped blocks previously did not appear as full-width or wide in the editor.
+[ Bug fix ][ Icon ] Fixed an unwanted bottom margin appearing.
 [ Specification change ] Fixed the zoom-out toggle not always displaying in the editor toolbar (updated blocks.json API version from 2 to 3).
 
 = 1.95.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,7 @@ e.g.
 
 == Changelog ==
 
-[ Add function ][ Animation (Pro) / Fixed Display (Pro) / Outer (Pro) / Slider ] Added support for layout.allowJustification: false, allowing full-width/wide alignment in block themes where wrapped blocks previously did not appear as full-width or wide in the editor.
+[ Add function ][ Animation (Pro) / Fixed Display (Pro) / Outer (Pro) ] Added support for layout.allowJustification: false, allowing full-width/wide alignment in block themes where wrapped blocks previously did not appear as full-width or wide in the editor.
 [ Bug fix ][ Icon ] Fixed an unwanted bottom margin appearing.
 [ Specification change ] Fixed the zoom-out toggle not always displaying in the editor toolbar (updated blocks.json API version from 2 to 3).
 

--- a/src/blocks/_pro/animation/block.json
+++ b/src/blocks/_pro/animation/block.json
@@ -33,6 +33,9 @@
 	"textdomain": "vk-blocks-pro",
 	"supports": {
 		"html": false,
-		"className": true
+		"className": true,
+		"layout": {
+			"allowJustification": false
+		}
 	}
 }

--- a/src/blocks/_pro/fixed-display/block.json
+++ b/src/blocks/_pro/fixed-display/block.json
@@ -63,6 +63,9 @@
 		"html": false,
 		"className": true,
 		"anchor": true,
+		"layout": {
+			"allowJustification": false
+		},
 		"color": {
 			"gradients": true,
 			"link": true,

--- a/src/blocks/_pro/outer/block.json
+++ b/src/blocks/_pro/outer/block.json
@@ -192,12 +192,12 @@
 		"html": false,
 		"className": true,
 		"anchor": true,
+		"layout": {
+			"allowJustification": false
+		},
 		"color": {
 			"text": true,
 			"background": false
-		},
-		"layout": {
-			"allowJustification": false
 		}
 	}
 }

--- a/src/blocks/_pro/outer/block.json
+++ b/src/blocks/_pro/outer/block.json
@@ -195,6 +195,9 @@
 		"color": {
 			"text": true,
 			"background": false
+		},
+		"layout": {
+			"allowJustification": false
 		}
 	}
 }

--- a/src/blocks/slider-item/block.json
+++ b/src/blocks/slider-item/block.json
@@ -69,6 +69,9 @@
 		"className": true,
 		"spacing": {
 			"padding": true
+		},
+		"layout": {
+			"allowJustification": false
 		}
 	}
 }

--- a/src/blocks/slider-item/block.json
+++ b/src/blocks/slider-item/block.json
@@ -69,9 +69,6 @@
 		"className": true,
 		"spacing": {
 			"padding": true
-		},
-		"layout": {
-			"allowJustification": false
 		}
 	}
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#2384

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->
<!-- [ プログラムの不具合修正の場合、再発防止の情報共有 & レビューしやすいように、簡単で良いので何が原因で不具合が発生し、対策としてどういう処理をしたのかを記載してください ] -->

ブロックテーマでは、親ブロックが layout を適切にサポートしていないと、子ブロック（core/cover）で wide/full を選択できなくなる 仕様になってました。
そのため、ブロックごとにlayoutをサポートすることになります。サポートをすると「コンテント幅を使用するインナーブロック」というトグルが出てくるのでそれをONにすると設定可能なためそのようにしました。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2025-02-05 16 35 08](https://github.com/user-attachments/assets/dc023e2d-3335-4c98-ac2a-4bcefbf0441c)

#### 変更後 After
![スクリーンショット 2025-02-05 16 30 14](https://github.com/user-attachments/assets/3020df8c-6f27-41a4-a679-ede614e275ba)
![スクリーンショット 2025-02-05 16 30 23](https://github.com/user-attachments/assets/9056257f-3d9e-44a0-a1ad-57e52f445ad5)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？→ layoutをサポートしただけなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

X-T9とLightiningで確認しました。
- 以下のブロックで全幅やワイド幅にしたカバーブロックやOuterを囲った場合、変更後 Afterのスクショのように全幅やワイド幅が選べるようになりました。
   * アニメーション
   * 固定表示
   * Outer
- フロントエンドでも適切に対応されておりました。

TT5ではデフォルトテーマ用のCSSの対応が必要そうですが、このプルリクによる影響は良い意味でも悪い意味でも見受けられないため、ひとまずWPの機能サポートのみにしました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

<!-- [ レビュワーがどういう手順で何を確認して欲しいかを記載してください。 ] -->

実装者と同じ確認を行ってください。
他にも対応した方がいいブロックがありましたらご連絡ください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
