### PR TITLE
ResizeObserverの誤ったインポートを修正し、ESLintのWarningを解消

### DIFF
--- a/src/components/code-mirror-css/index.js
+++ b/src/components/code-mirror-css/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { transformStyles } from '@wordpress/block-editor';
 import { useState, useRef, useEffect } from '@wordpress/element';
-import { Tooltip, Icon, ResizeObserver } from '@wordpress/components';
+import { Tooltip, Icon } from '@wordpress/components';
 import { info } from '@wordpress/icons';
 
 /**
@@ -62,7 +62,7 @@ export const CodeMirrorCss = (props) => {
 	// リサイズ検知して高さを動的に調整
 	useEffect(() => {
 		if (wrapperRef.current) {
-			const observer = new ResizeObserver(() => {
+			const observer = new window.ResizeObserver(() => {
 				if (isInitialLoad) {
 					wrapperRef.current.style.setProperty(
 						'height',
@@ -82,7 +82,7 @@ export const CodeMirrorCss = (props) => {
 		if (wrapperRef.current) {
 			const gutters = wrapperRef.current.querySelector('.cm-gutters');
 			if (gutters) {
-				const observer = new ResizeObserver(() => {
+				const observer = new window.ResizeObserver(() => {
 					const guttersHeight = gutters.offsetHeight;
 					if (guttersHeight < 200) {
 						gutters.style.setProperty(


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

Lintで import/named のwarningが発生していました。

## どういう変更をしたか？

- ResizeObserver の誤ったインポートを削除
- ResizeObserver を window.ResizeObserver に変更

お一人でOKです。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/946a59e2-b744-4239-b412-aa92dfb0e1c6)

#### 変更後 After
Warningが消えました。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？ 
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ →内部なのでスキップ
- [ ] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？ →内部なのでスキップ
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？  →スキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. developで`php run lint`をしたら変更前のようなWarningが出てくることを確認。
2. `fix/ESLint/warning`に切り替え`php run lint`をしたらWarningが消えていることを確認。
3. 編集画面で適当なブロックを配置し、右パネルに出てくるカスタムCSSのテキストエリアを縦方向に伸縮できることを確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

同じ確認を行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
