### PR TITLE
[ 不具合修正 ][ ブログカード ] 'clearCache' キー欠落によるPHP 8.xの警告を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug fix ][ Blog Card (Pro) ] Fix PHP 8.x warning caused by missing 'clearCache' key.
+
 = 1.98.0 =
 [ Specification change ][ Slider ] Changed slider height minimum from 40px to 24px.
 

--- a/src/blocks/_pro/blog-card/api/fetch-url-data.js
+++ b/src/blocks/_pro/blog-card/api/fetch-url-data.js
@@ -57,7 +57,7 @@ const fetchUrlData = async (url, options = { clearCache: false }) => {
 		method: 'POST',
 		data: {
 			url,
-			clearCache: options.clearCache,
+			clearCache: !!options.clearCache,
 		},
 		// ...options,
 	}).then((res) => {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#2491 

## どういう変更をしたか？

JS 側から clearCache キーを boolean（true/false）で必ず送信するように修正しました。
これにより、API受信側のPHPコードで $_POST['clearCache'] を安全に参照できるようになり、PHP 8以降での警告が解消されるようになったかと思います。

`!!`をつけただけなのでお一人確認で大丈夫かと思いますが、気になることがありましたら二人確認にしてください。
また、こちらの環境だけかもしれないので、発生するかどうかからご確認いただけたらと思います。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2025-03-21 10 45 40](https://github.com/user-attachments/assets/6c2a383b-63ca-4dc8-8059-09f33c6d0220)

#### 変更後 After
![スクリーンショット 2025-03-21 10 54 48](https://github.com/user-attachments/assets/3c30f432-74f6-4b39-9ef9-7a83c48b264b)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？ → editor内のみのためスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. `develop` ブランチの状態で、固定ページ編集画面でブログカードを設置しリンク設定し保存
2. ページをリロードし、PHPのエラーログに Undefined array key "clearCache" のWarningが出ることを確認
3. `fix/blog-card/php-warning-clearCache-key` ブランチに切り替えて`npm run build`
4. 同様の手順でブログカードを設置・リロード時にPHPエラーログを確認し、Warningが出なくなったことを確認
5. キャッシュクリアボタンをクリックし、ローディング後にブログカードが正常に表示され、エラーログが出ないことを確認
6. developブランチで作成してブログカードでもエラーが出なくなったことを確認
7. フロントエンドでブログカードの表示、リンクが機能していることを確認

PHPのエラーログはLocalなら`/Local Sites/SITENAME/logs/php/error.log` 、wp-envなら`.wp-env/docker/wordpress/php-errors.log`で確認できるかと思います。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

同じ手順でご確認ください。
他にも気になることがありましたらご確認ください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
