### PR TITLE
[ その他 ][ 6.8対応 ] BoxControl を 6.6 ～ 6.8 準拠に対応 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,8 @@ e.g.
 
 == Changelog ==
 
+[ Specific Change ][ Some Block ] Compatible for WordPress 6.8
+
 = 1.99.0 =
 [ Add function ][ Dynamic Text (Pro) ] Add "Post Slug" as a display element
 [ Add function ][ Column / Cover ] Added noreferrer, nofollow, and link description options to the link feature.

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,7 @@ e.g.
 
 == Changelog ==
 
-[ Specific Change ][ Some Block ] Compatible for WordPress 6.8
+[ Other ][ Compatibility with 6.8 ] Updated to handle the deprecation of __experimentalBoxControl and use OldBoxControl or NewBoxControl accordingly.
 
 = 1.99.0 =
 [ Add function ][ Dynamic Text (Pro) ] Add "Post Slug" as a display element

--- a/readme.txt
+++ b/readme.txt
@@ -109,7 +109,7 @@ e.g.
 == Changelog ==
 
 [ Add function ][ Dynamic Text (Pro) ] When you set a link URL in the custom field display, you can now specify the link text.
-[ Other ][ Compatibility with 6.8 ] Updated to handle the deprecation of __experimentalBoxControl and use OldBoxControl or NewBoxControl accordingly.
+[ Other ][ Some Block ] Compatible for WordPress 6.8
 
 = 1.99.0 =
 [ Add function ][ Dynamic Text (Pro) ] Add "Post Slug" as a display element

--- a/src/blocks/_pro/gridcolcard/edit-common.js
+++ b/src/blocks/_pro/gridcolcard/edit-common.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import {
-	// eslint-disable-next-line
-	__experimentalBoxControl as BoxControl,
+	__experimentalBoxControl as OldBoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	BoxControl as NewBoxControl,
 	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	ComboboxControl,
 	ToggleControl,
@@ -11,6 +11,8 @@ import {
 } from '@wordpress/components';
 import { AdvancedColorPalette } from '@vkblocks/components/advanced-color-palette';
 import { AdvancedColorGradientControl } from '@vkblocks/components/advanced-color-gradient-control';
+
+const BoxControl = OldBoxControl || NewBoxControl; // Fallback to the new BoxControl if the old one is not available
 
 const CommonItemControl = (props) => {
 	const { attributes, setAttributes } = props;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/2515

## どういう変更をしたか？

6.8 で __experimentalBoxControl が廃止され BoxControl になるようだが 6.7 では BoxControl は存在しないので

```
import {
	__experimentalBoxControl as OldBoxControl, 
	BoxControl as NewBoxControl,
} from '@wordpress/components';

const BoxControl = OldBoxControl || NewBoxControl; 
```

という形で対応

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形を含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？ ⇒ 編集画面のコンポーネントの変更なので省略

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

WordPress 6.7 / 6.8 で グリッドカラムカードを配置してもブロックでエラーがおきないことを確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

WordPress 6.7 / 6.8 で グリッドカラムカードを配置してもブロックでエラーがおきないことを確認お願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
