### PR TITLE
[ 不具合修正 ][ フロー ] ブロック選択時に選択状態がわからなくなる問題を修正（編集画面でフローブロックの矢印がCSSではなくHTMLで出力されるように変更）

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ e.g.
 == Changelog ==
 
 [ Add function ][ Dynamic Text (Pro) ] When you set a link URL in the custom field display, you can now specify the link text.
+[ Bug Fix ][ Flow ] Fixed issue where block selection outline was not visible. The arrow indicator for flow blocks is now rendered via HTML instead of CSS to avoid conflicts with core styles.
 
 = 1.99.0 =
 [ Add function ][ Dynamic Text (Pro) ] Add "Post Slug" as a display element

--- a/readme.txt
+++ b/readme.txt
@@ -110,7 +110,7 @@ e.g.
 
 [ Add function ][ Dynamic Text (Pro) ] When you set a link URL in the custom field display, you can now specify the link text.
 [ Specification change ][ Dynamic Text (Pro) ] Disable link on edit screen.
-[ Bug Fix ][ Flow ] Fixed issue where block selection outline was not visible. The arrow indicator for flow blocks is now rendered via HTML instead of CSS to avoid conflicts with core styles.
+[ Bug Fix ][ Flow ] Fix selection state not visible when block is selected (change arrow from CSS to HTML in editor)
 
 = 1.99.0 =
 [ Add function ][ Dynamic Text (Pro) ] Add "Post Slug" as a display element

--- a/src/blocks/flow/edit.js
+++ b/src/blocks/flow/edit.js
@@ -94,6 +94,9 @@ export default function FlowEdit({ attributes, setAttributes, clientId }) {
 						/>
 					</div>
 				</div>
+				{arrowFlag === 'vk_flow-arrow-on' && (
+					<div className={'vk_flow_frame_arrow'}></div>
+				)}
 			</div>
 		</>
 	);

--- a/src/blocks/flow/style.scss
+++ b/src/blocks/flow/style.scss
@@ -97,6 +97,11 @@ $xxl-min: 1200px;
 // コア側のcssで矢印(after要素)の位置がおかしくなるので上書き
 .editor-styles-wrapper {
 	.vk_flow-arrow-on::after {
-		display: none;
+		background: none;
+		display: unset;
+		height: unset;
+		width: unset;
+		margin: unset;
+		overflow: unset;
 	}
 }

--- a/src/blocks/flow/style.scss
+++ b/src/blocks/flow/style.scss
@@ -68,7 +68,8 @@ $xxl-min: 1200px;
 		}
 	}
 
-	&.vk_flow-arrow-on::after {
+	&.vk_flow-arrow-on::after,
+	> .vk_flow_frame_arrow {
 		position: relative;
 		content: "";
 		background: var(--vk_flow-arrow) center 50% no-repeat;
@@ -95,14 +96,7 @@ $xxl-min: 1200px;
 // 編集画面
 // コア側のcssで矢印(after要素)の位置がおかしくなるので上書き
 .editor-styles-wrapper {
-	.block-editor-block-list__layout .block-editor-block-list__block:not([contenteditable=true]):focus:after, // lightning用
-	.is-outline-mode .block-editor-block-list__block:not(.rich-text):not([contenteditable=true]).is-selected.vk_flow-arrow-on:after,//選択中のブロック
-	.is-outline-mode .block-editor-block-list__block.is-hovered.vk_flow-arrow-on:not(.is-selected):after,//ホバーしているが未選択のブロック
-	.is-outline-mode .block-editor-block-list__block:not(.rich-text):not([contenteditable=true]).vk_flow-arrow-on:after{ // 通常状態のブロック
-			position: relative;
-			outline-style: unset;
-			top:unset;
-			bottom:unset;
-		}
-	
+	.vk_flow-arrow-on::after {
+		display: none;
+	}
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#2530 

## どういう変更をしたか？

フローブロックの矢印で`:after`を使用していたことにより、エディターではブロックの選択時に表示される青の枠線が表示されなくなっておりました。
しかし、CSSだけで上記と #2492 対応のCSSを共存させるのが難しかったため、編集画面では「矢印を表示する」の時だけ表示される矢印用のHTMLを追加して対応しました。

### スクリーンショットまたは動画

#### 変更前 Before
https://github.com/user-attachments/assets/2d49e52d-8d32-4f97-8cea-0954fc0631ad

#### 変更後 After
https://github.com/user-attachments/assets/9509d527-ee3a-487c-9009-1b83b59e7185

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形を含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？ → editer内にHTMLを追加しCSSを調整しただけなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- 固定ページの編集画面で適当に幾つかのブロックを配置し、ブロックを選択したときに、青枠が表示されることを確認
- フローの矢印が「矢印を表示する」の時だけ表示することを確認
- Lightning、X-T9、TT5で確認

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

<!-- [ レビュワーがどういう手順で何を確認して欲しいかを記載してください。 ] -->

実装者と同じ確認を行ってください。
他にも気になるところがありましたらご確認ください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
