### PR TITLE
[ 仕様変更 ][ ダイナミックテキスト ] カスタムフィールドのリンクテキストのエスケープ処理でiタグを許可するように修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -107,7 +107,7 @@ e.g.
 1. VK Blocks examples.
 
 == Changelog ==
-
+[ update ][ Dynamic Text (Pro) ] Allows i-tags in custom field link text.
 [ Bug Fix ][ Step (Pro) ] Fix it so that leaving the starting number for a step blank does not result in an error.
 
 = 1.100.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -107,7 +107,8 @@ e.g.
 1. VK Blocks examples.
 
 == Changelog ==
-[ update ][ Dynamic Text (Pro) ] Allows i-tags in custom field link text.
+
+[ Specification change ][ Dynamic Text (Pro) ] Allows i-tags in custom field link text.
 [ Bug Fix ][ Step (Pro) ] Fix it so that leaving the starting number for a step blank does not result in an error.
 
 = 1.100.0 =

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -59,7 +59,7 @@ function vk_blocks_dynamic_text_custom_field_render( $attributes, $content, $blo
 	} elseif ( 'url' === $attributes['fieldType'] ) {
 		$custom_field_url = esc_url( get_post_meta( $block->context['postId'], $attributes['customFieldName'], true ) );
 		if ( $attributes['isLinkSet'] ) {
-			$link_text = ! empty( $attributes['customFieldLinkText'] ) ? esc_html( $attributes['customFieldLinkText'] ) : $custom_field_url;
+			$link_text = ! empty( $attributes['customFieldLinkText'] ) ? wp_kses( $attributes['customFieldLinkText'] , array( 'i' => array( 'class' => array() ) ) ) : $custom_field_url;
 			if ( $attributes['isLinkTarget'] ) {
 				$custom_field_content = '<a href="' . $custom_field_url . '" target="_blank" rel="noreferrer noopener">' . $link_text . '</a>';
 			} else {

--- a/src/blocks/_pro/dynamic-text/index.php
+++ b/src/blocks/_pro/dynamic-text/index.php
@@ -59,7 +59,7 @@ function vk_blocks_dynamic_text_custom_field_render( $attributes, $content, $blo
 	} elseif ( 'url' === $attributes['fieldType'] ) {
 		$custom_field_url = esc_url( get_post_meta( $block->context['postId'], $attributes['customFieldName'], true ) );
 		if ( $attributes['isLinkSet'] ) {
-			$link_text = ! empty( $attributes['customFieldLinkText'] ) ? wp_kses( $attributes['customFieldLinkText'] , array( 'i' => array( 'class' => array() ) ) ) : $custom_field_url;
+			$link_text = ! empty( $attributes['customFieldLinkText'] ) ? wp_kses( $attributes['customFieldLinkText'], array( 'i' => array( 'class' => array() ) ) ) : $custom_field_url;
 			if ( $attributes['isLinkTarget'] ) {
 				$custom_field_content = '<a href="' . $custom_field_url . '" target="_blank" rel="noreferrer noopener">' . $link_text . '</a>';
 			} else {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/issues/assigned?issue=vektor-inc%7Cvk-blocks-pro%7C2537

## どういう変更をしたか？
カスタムフィールドのリンクテキストのエスケープ処理でiタグを許可するように修正しました。

### スクリーンショットまたは動画

#### 変更前 Before
![image](https://github.com/user-attachments/assets/5b886d2f-5a64-4b4c-9aa1-56c317717613)

#### 変更後 After
![image](https://github.com/user-attachments/assets/c8b57fa8-e67f-4e27-b294-4f397f06560f)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形を含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合
- [x] 書けそうなテストは書いたか？
省略します。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
リンクテキストの部分に
```
<i class="fa-solid fa-circle-right"></i>テスト
```
と入れて、アイコンフォントが表示されることを確認しました。
また、他のHTMLタグは表示されないことを確認しました。


## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など
実装者と同じ
---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
