### PR TITLE
[ 不具合修正 ] 有料版を有効化したら無料版を無効化するように再調整

### DIFF
--- a/.github/workflows/develop-test.yml
+++ b/.github/workflows/develop-test.yml
@@ -72,7 +72,7 @@ jobs:
       run: npm run build
     - name: Install VK Blocks
       run: |
-       npm run wp-env run cli --env-cwd='wp-content/plugins/vk-blocks-pro' wp plugin install vk-blocks
+        npm run wp-env run tests-cli --env-cwd='wp-content/plugins/vk-blocks-pro' wp plugin install vk-blocks
     # PHPUnit
     - name: PHP Unit Test
       run: npm run phpunit

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,8 @@ e.g.
 
 == Changelog ==
 
+[ Bug Fix ][ Pro ] When VK Blocks Pro is activated, VK Blocks should be automatically deactivated.
+
 = 1.101.0 =
 [ Specification change ][ Dynamic Text (Pro) ] Allows i-tags in custom field link text.
 [ Bug Fix ][ Step (Pro) ] Fix it so that leaving the starting number for a step blank does not result in an error.

--- a/test/phpunit/pro/test-activate.php
+++ b/test/phpunit/pro/test-activate.php
@@ -6,18 +6,27 @@
  */
 
 class ActivationTest extends VK_UnitTestCase {
-    /**
-	 * Test Block
-	 *
-	 * @return void
-	 */
-	public function test_vk_blocks_activation() {
-		
+        /**
+         * Test Block
+         *
+         * @return void
+         */
+        public function test_vk_blocks_activation() {
+                
         require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        update_option( 'active_plugins', array(
+                'vk-blocks/vk-blocks.php'
+        ) );
+        update_option( 'active_plugins', array(
+                'vk-blocks-pro/vk-blocks.php'
+        ) );
+        $this->assertTrue( is_plugin_active( 'vk-blocks-pro/vk-blocks.php' ) );
+        /*
         deactivate_plugins( 'vk-blocks/vk-blocks.php' );
         deactivate_plugins( 'vk-blocks-pro/vk-blocks.php' );
         activate_plugins( 'vk-blocks/vk-blocks.php' );
         activate_plugins( 'vk-blocks-pro/vk-blocks.php' );
         $this->assertTrue( is_plugin_active( 'vk-blocks-pro/vk-blocks.php' ) );
-	}
+        */
+        }
 }

--- a/test/phpunit/pro/test-activate.php
+++ b/test/phpunit/pro/test-activate.php
@@ -13,20 +13,20 @@ class ActivationTest extends VK_UnitTestCase {
          */
         public function test_vk_blocks_activation() {
                 
-        require_once ABSPATH . 'wp-admin/includes/plugin.php';
-        update_option( 'active_plugins', array(
-                'vk-blocks/vk-blocks.php'
-        ) );
-        update_option( 'active_plugins', array(
-                'vk-blocks-pro/vk-blocks.php'
-        ) );
-        $this->assertTrue( is_plugin_active( 'vk-blocks-pro/vk-blocks.php' ) );
-        /*
-        deactivate_plugins( 'vk-blocks/vk-blocks.php' );
-        deactivate_plugins( 'vk-blocks-pro/vk-blocks.php' );
-        activate_plugins( 'vk-blocks/vk-blocks.php' );
-        activate_plugins( 'vk-blocks-pro/vk-blocks.php' );
-        $this->assertTrue( is_plugin_active( 'vk-blocks-pro/vk-blocks.php' ) );
-        */
+                require_once ABSPATH . 'wp-admin/includes/plugin.php';
+                update_option( 'active_plugins', array(
+                        'vk-blocks/vk-blocks.php'
+                ) );
+                update_option( 'active_plugins', array(
+                        'vk-blocks-pro/vk-blocks.php'
+                ) );
+                $this->assertTrue( is_plugin_active( 'vk-blocks-pro/vk-blocks.php' ) );
+                /*
+                deactivate_plugins( 'vk-blocks/vk-blocks.php' );
+                deactivate_plugins( 'vk-blocks-pro/vk-blocks.php' );
+                activate_plugins( 'vk-blocks/vk-blocks.php' );
+                activate_plugins( 'vk-blocks-pro/vk-blocks.php' );
+                $this->assertTrue( is_plugin_active( 'vk-blocks-pro/vk-blocks.php' ) );
+                */
         }
 }

--- a/vk-blocks.php
+++ b/vk-blocks.php
@@ -413,4 +413,3 @@ if ( ! function_exists( 'vk_blocks_deactivate_function' ) ) {
 		delete_option( 'vk_blocks_checked_flags' );
 	}
 }
-

--- a/vk-blocks.php
+++ b/vk-blocks.php
@@ -128,19 +128,24 @@ if ( ! function_exists( 'vk_blocks_is_pro' ) ) {
  * Start VK Blocks
  * 無料版を無効化した後に書かないと関数の二重宣言などになるので注意
  */
+if ( ! function_exists( 'vk_blocks_loaded' ) ) {
 
-// Composer のファイルを読み込み ( composer install --no-dev ).
-require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
-// Set plugin dir path.
-if ( ! defined( 'VK_BLOCKS_DIR_PATH' ) ) {
-	define( 'VK_BLOCKS_DIR_PATH', plugin_dir_path( __FILE__ ) );
+	function vk_blocks_loaded() {
+		// Composer のファイルを読み込み ( composer install --no-dev ).
+		require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+		// Set plugin dir path.
+		if ( ! defined( 'VK_BLOCKS_DIR_PATH' ) ) {
+			define( 'VK_BLOCKS_DIR_PATH', plugin_dir_path( __FILE__ ) );
+		}
+		// Set Plugin Dir URL.
+		if ( ! defined( 'VK_BLOCKS_DIR_URL' ) ) {
+			define( 'VK_BLOCKS_DIR_URL', plugin_dir_url( __FILE__ ) );
+		}
+		// Load VK Blocks
+		require_once plugin_dir_path( __FILE__ ) . 'inc/vk-blocks-config.php';
+	}
+	add_action( 'plugins_loaded', 'vk_blocks_loaded' );
 }
-// Set Plugin Dir URL.
-if ( ! defined( 'VK_BLOCKS_DIR_URL' ) ) {
-	define( 'VK_BLOCKS_DIR_URL', plugin_dir_url( __FILE__ ) );
-}
-// Load VK Blocks
-require_once plugin_dir_path( __FILE__ ) . 'inc/vk-blocks-config.php';
 
 
 /****************************************************************************************
@@ -398,11 +403,14 @@ if ( function_exists( 'register_deactivation_hook' ) ) {
 	register_deactivation_hook( __FILE__, 'vk_blocks_deactivate_function' );
 }
 
-/**
- * Deactivate function
- *
- * @return void
- */
-function vk_blocks_deactivate_function() {
-	delete_option( 'vk_blocks_checked_flags' );
+if ( ! function_exists( 'vk_blocks_deactivate_function' ) ) {
+	/**
+	 * Deactivate function
+	 *
+	 * @return void
+	 */
+	function vk_blocks_deactivate_function() {
+		delete_option( 'vk_blocks_checked_flags' );
+	}
 }
+

--- a/vk-blocks.php
+++ b/vk-blocks.php
@@ -129,7 +129,11 @@ if ( ! function_exists( 'vk_blocks_is_pro' ) ) {
  * 無料版を無効化した後に書かないと関数の二重宣言などになるので注意
  */
 if ( ! function_exists( 'vk_blocks_loaded' ) ) {
-
+	/**
+	 * Load VK Blocks
+	 *
+	 * @return void
+	 */
 	function vk_blocks_loaded() {
 		// Composer のファイルを読み込み ( composer install --no-dev ).
 		require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

VK Blocks が有効化しているときに VK Blocks Pro を有効化するとエラーになっていた

## どういう変更をしたか？

- 関数等の重複読み込みを ```function_exists``` や ``function``` で囲むことで対処
- 有効化テストを追加
- テストのコメントアウトしている部分は現在は通らないのでリリース後に復活予定です。
-  diff が乱れていても ```function_exists``` や ``function``` で囲んだだけなので diff の乱れはスルー推奨です。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。
⇒ GitHub Action 実行中の PHP Unit Test の環境を現実と合わせました
- [x] 本プルリクの意図と関係ないコード整形を含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

- ```npm run wp-env run tests-cli --env-cwd='wp-content/plugins/vk-blocks-pro' wp plugin install vk-blocks``` を実行したあとに ```npm run phpunit```
- vk-blocks.php において有料版と無料版の双方に同様の変更を行って有料版を有効化したら無料版を無効化される

上記を確認しました。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- ```npm run wp-env run tests-cli --env-cwd='wp-content/plugins/vk-blocks-pro' wp plugin install vk-blocks``` を実行したあとに ```npm run phpunit```
- vk-blocks.php において有料版と無料版の双方に同様の変更を行って有料版を有効化したら無料版を無効化される

上記を確認お願いします。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
