### PR TITLE
[ デザイン不具合修正 ][ 吹き出し ] 枠線の色でカラーパレットを使った際、吹き出しブロック内のテキストが意図せず枠線の色を引き継いでしまう問題を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,7 @@ e.g.
 
 == Changelog ==
 
-[ Design Bug Fix ][ Balloon ] Prevented text inside balloon blocks from unintentionally inheriting the balloon’s color when using a color palette.
+[ Design Bug Fix ][ Balloon ] Fixed an issue where text inside balloon blocks unintentionally inherited the border color when using a color palette.
 
 = 1.102.0 =
 [ Design Bug Fix ][ Outer (Pro) ] Fixed unexpected margin affecting background color display due to layout flow styles in WordPress 6.8.

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,8 @@ e.g.
 
 == Changelog ==
 
+[ Design Bug Fix ][ Balloon ] Prevented unintended text color inheritance inside balloon blocks caused by `.has-text-color` class styles when using color palettes.
+
 = 1.102.0 =
 [ Design Bug Fix ][ Outer (Pro) ] Fixed unexpected margin affecting background color display due to layout flow styles in WordPress 6.8.
 [ Design Bug Fix ][ Outer ] Removed unintended borders above and below separators.

--- a/readme.txt
+++ b/readme.txt
@@ -108,7 +108,7 @@ e.g.
 
 == Changelog ==
 
-[ Design Bug Fix ][ Balloon ] Prevented unintended text color inheritance inside balloon blocks caused by `.has-text-color` class styles when using color palettes.
+[ Design Bug Fix ][ Balloon ] Prevented text inside balloon blocks from unintentionally inheriting the balloon’s color when using a color palette.
 
 = 1.102.0 =
 [ Design Bug Fix ][ Outer (Pro) ] Fixed unexpected margin affecting background color display due to layout flow styles in WordPress 6.8.

--- a/src/blocks/balloon/style.scss
+++ b/src/blocks/balloon/style.scss
@@ -7,7 +7,7 @@
 		margin: 0;
 	}
 
-	p {
+	> * {
 		color: initial; // カラーパレットのcolorがあたってしまうので初期化する
 		&:first-of-type{
 			margin-top: 0;

--- a/src/blocks/balloon/style.scss
+++ b/src/blocks/balloon/style.scss
@@ -7,7 +7,7 @@
 		margin: 0;
 	}
 
-	> * {
+	&_content > * {
 		color: initial; // カラーパレットのcolorがあたってしまうので初期化する
 		&:first-of-type{
 			margin-top: 0;


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#2561 

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->
<!-- [ プログラムの不具合修正の場合、再発防止の情報共有 & レビューしやすいように、簡単で良いので何が原因で不具合が発生し、対策としてどういう処理をしたのかを記載してください ] -->

吹き出しブロックに枠線の色をつけると`.has-vivid-red-color`などカラーパレットとクラス名が結びついた色が枠線の色として適用されます。
`.has-vivid-red-color`は`color`を指定しているため内包する見出しやリストなどの要素が意図せず文字色を継承してしまう現象が発生していました。

すでに吹き出しブロック内の`p`には `color: initial;`と書いてあったので段落ブロックが枠線の色と同じになることはありませんでした。
その部分を拡張し、vk_balloon_contentの中の直下全て `color: initial;`を適用するようにしました。

おそらくお一人で大丈夫かと思います。

### スクリーンショットまたは動画

#### 変更前 Before
フロントエンド
![スクリーンショット 2025-04-22 11 55 19](https://github.com/user-attachments/assets/5189aec5-7d5b-4288-8829-704bda5509fd)

ブロックエディタ
![スクリーンショット 2025-04-22 11 56 30](https://github.com/user-attachments/assets/db8cd24c-0300-41d3-bf4c-380583751e23)

#### 変更後 After
フロントエンド
![スクリーンショット 2025-04-22 11 55 28](https://github.com/user-attachments/assets/dbf57b9e-f42d-465d-8290-101ad0311a35)

ブロックエディタ
![スクリーンショット 2025-04-22 11 55 48](https://github.com/user-attachments/assets/6a934ac9-a886-454e-8b41-7534eea5098b)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形を含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？ → CSSのみなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど
  
Lightning、X-T9、TT5 にて以下を確認しました。

1. `develop`ブランチで 吹き出しブロックを追加し、枠線の色をカラーパレットから選択(X-T9の場合はX-T9独自の色でご確認ください。)
2. 吹き出し内に見出しやリストブロックを追加(このときは枠線の色に合わせて文字色が変わる事を確認)
3. 見出しをもう一つ作りツールバーから変換機能で段落ブロックに変換(このときは枠線の色に合わせて文字色が変わる事を確認)
4. 保存しフロントエンドで状態を確認
5. `fix/balloon/initial-color`にブランチを切り替え`npm run build`
6. フロントエンドや編集画面で、手順2の見出しやリスト、(編集画面内でのみ)手順3の段落ブロック文字色が枠線の色の影響を受けなくなった事を確認。
7. 新規追加で新たに手順2〜4をした時に文字色が枠線の色の影響を受けなくなった事を確認。
8. テーマをLightning、X-T9、TT5 に切り替えても文字色が枠線の色の影響を受けなくなった事を確認。

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
