### PR TITLE
[ その他 ] phpcs:ignoreコメントで抑制してWordPressコーディングスタンダードに準拠

### DIFF
--- a/inc/vk-blocks/class-vk-blocks-block-loader.php
+++ b/inc/vk-blocks/class-vk-blocks-block-loader.php
@@ -139,7 +139,7 @@ class VK_Blocks_Block_Loader {
 		// ↑の 編集画面の wp_register_style( 'vk-blocks-build-editor-css' だけだとテーマエディタの iframe でCSSが反映されないのでインラインで追加登録 .
 		$style_path = wp_normalize_path( VK_BLOCKS_DIR_PATH . '/build/block-build-editor.css' );
 		if ( file_exists( $style_path ) ) {
-			$dynamic_css = file_get_contents( $style_path );
+			$dynamic_css = file_get_contents( $style_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			wp_add_inline_style( 'wp-edit-blocks', $dynamic_css );
 		}
 

--- a/inc/vk-blocks/helpers.php
+++ b/inc/vk-blocks/helpers.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function vk_blocks_is_lightning() {
 	// テーマがLightning系の場合読み込まない
-	$current_template = ! empty( $_GET['wp_theme_preview'] ) ? sanitize_text_field( wp_unslash( $_GET['wp_theme_preview'] ) ) : get_template();
+	$current_template = ! empty( $_GET['wp_theme_preview'] ) ? sanitize_text_field( wp_unslash( $_GET['wp_theme_preview'] ) ) : get_template(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( 'lightning' === $current_template || 'lightning-pro' === $current_template || 'katawara' === $current_template ) {
 		return true;
 	}

--- a/inc/vk-blocks/load-bootstrap.php
+++ b/inc/vk-blocks/load-bootstrap.php
@@ -40,7 +40,7 @@ function vk_blocks_load_bootstrap_for_site_editor() {
 		if ( wp_is_block_theme() && is_admin() ) {
 			$style_path = wp_normalize_path( VK_BLOCKS_DIR_PATH . '/build/bootstrap_vk_using.css' );
 			if ( file_exists( $style_path ) ) {
-				$dynamic_css = file_get_contents( $style_path );
+				$dynamic_css = file_get_contents( $style_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 				wp_add_inline_style( 'wp-edit-blocks', $dynamic_css );
 			}
 		}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#2566 

## どういう変更をしたか？

プッシュ時に発生していたPHPCS（PHP CodeSniffer）のwarningの行に`phpcs:ignore`によるコメントを追加して対応しました。この対応により、`git push`した時にこれらのwarningが出なくなりました。
- `inc/vk-blocks/load-bootstrap.php:43`
- `inc/vk-blocks/class-vk-blocks-block-loader.php:142`
- `inc/vk-blocks/helpers.php:19`

コメントアウトに留めた理由は以下のためです。
- `file_get_contents()`：ローカルCSSファイルの読み込みに使用されており、リモートURL取得ではないためセキュリティ上問題なし
- `$_GET['wp_theme_preview']`：WordPressのテーマプレビュー機能で使用される読み取り専用パラメータで、nonceチェックは不要

おそらくお一人で大丈夫かと思います。

### スクリーンショットまたは動画

#### 変更前 Before

#### 変更後 After

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形を含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ → 内部的なもののためスキップ
- [ ] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？ → 内部的なもののためスキップ
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？ → 内部的なもののためスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

このブランチでターミナルに以下のコマンドを打ち、warningが出ない事を確認。
```
npm run build
composer phpcs
```

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行なってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
