### PR TITLE
Fix vertical highlighter support

### DIFF
--- a/src/extensions/common/highlighter/index.js
+++ b/src/extensions/common/highlighter/index.js
@@ -42,7 +42,7 @@ export const highlighterOnApply = ({ color, value, onChange }) => {
 			type: name,
 			attributes: {
 				data: color,
-				style: `background: linear-gradient(transparent 60%,${hex2rgba(
+				style: `--vk-highlighter-color:${color};background: linear-gradient(transparent 60%,${hex2rgba(
 					color,
 					alpha
 				)} 0);`,

--- a/src/extensions/common/highlighter/style.scss
+++ b/src/extensions/common/highlighter/style.scss
@@ -1,0 +1,13 @@
+.vk_highlighter {
+  --vk-highlighter-color: #fffd6b;
+}
+
+[style*='writing-mode:vertical'],
+.is-vertical {
+  .vk_highlighter {
+    background: none !important;
+    border-left: 0.25em solid var(--vk-highlighter-color);
+    padding-left: 0.1em;
+    margin-left: -0.1em;
+  }
+}


### PR DESCRIPTION
## Summary
- allow vertical text direction by setting `--vk-highlighter-color` and updating inline style
- style highlighter when a parent uses vertical writing mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68427d3082448332b737eaf7029f0a19