### PR TITLE
【お一人でOK / 確認待ち】[ 不具合修正 ][ ボタン ] Twenty Twenty-Fiveを使用している時ボタンのデフォルト色に色がつかないのを修正

### DIFF
--- a/editor-css/_editor_before_button.scss
+++ b/editor-css/_editor_before_button.scss
@@ -21,7 +21,7 @@ $vk-color-dark:#343a40;
 
 .vk_button{ // ← V2以降に編集画面用CSSファイルに移植すること
 	.btn.has-vk-color-primary-background-color {
-		background-color: var(--wp--preset--color--vk-color-primary);
+		background-color: var(--wp--preset--color--vk-color-primary, #337ab7)
 	}
 	.btn.has-vk-color-secondary-background-color {
 		background-color: $vk-color-secondary;
@@ -46,7 +46,7 @@ $vk-color-dark:#343a40;
 		background-color: $vk-color-dark;
 	}
 	.btn.has-vk-color-primary-color {
-		color: var(--wp--preset--color--vk-color-primary);
+		color: var(--wp--preset--color--vk-color-primary, #337ab7);
 	}
 	.btn.has-vk-color-secondary-color {
 		color: $vk-color-secondary;

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ e.g.
 == Changelog ==
 
 [ Add function ][ Slider ] Added zoom animation feature.
+[ Bug fix ][ Button ] Add fallback to vk color primary.
 [ Bug fix ][ Core List ] Fixed an issue where list items were not applying colors selected from Japanese-named color palettes and semi-transparent colors.
 
 = 1.105.1 =

--- a/src/blocks/button/style.scss
+++ b/src/blocks/button/style.scss
@@ -52,7 +52,7 @@ a.vk_button_link {
 		background-color: $vk-color-dark;
 	}
 	.has-vk-color-primary-color {
-		color: var(--wp--preset--color--vk-color-primary);
+		color: var(--wp--preset--color--vk-color-primary, #337ab7);
 	}
 	.has-vk-color-secondary-color {
 		color: $vk-color-secondary;
@@ -188,7 +188,7 @@ a.vk_button_link {
 		&:hover {
 			/* 応急処置：規定カラー */
 			&.has-vk-color-primary-color {
-				background-color: var(--wp--preset--color--vk-color-primary);
+				background-color: var(--wp--preset--color--vk-color-primary, #337ab7);
 			}
 			&.has-vk-color-secondary-color {
 				background-color: $vk-color-secondary;
@@ -250,7 +250,7 @@ a.vk_button_link {
 			}
 			/* 応急処置：カラーパレットVK */
 			&.has-vk-color-primary-color {
-				background-color: var(--wp--preset--color--vk-color-primary);
+				background-color: var(--wp--preset--color--vk-color-primary, #337ab7);
 			}
 			&.has-vk-color-primary-dark-color {
 				background-color: var(--wp--preset--color--vk-color-primary-dark);

--- a/src/blocks/button/style.scss
+++ b/src/blocks/button/style.scss
@@ -52,7 +52,7 @@ a.vk_button_link {
 		background-color: $vk-color-dark;
 	}
 	.has-vk-color-primary-color {
-		color: var(--wp--preset--color--vk-color-primary, #337ab7);
+		color: var(--wp--preset--color--vk-color-primary);
 	}
 	.has-vk-color-secondary-color {
 		color: $vk-color-secondary;
@@ -188,7 +188,7 @@ a.vk_button_link {
 		&:hover {
 			/* 応急処置：規定カラー */
 			&.has-vk-color-primary-color {
-				background-color: var(--wp--preset--color--vk-color-primary, #337ab7);
+				background-color: var(--wp--preset--color--vk-color-primary);
 			}
 			&.has-vk-color-secondary-color {
 				background-color: $vk-color-secondary;
@@ -250,7 +250,7 @@ a.vk_button_link {
 			}
 			/* 応急処置：カラーパレットVK */
 			&.has-vk-color-primary-color {
-				background-color: var(--wp--preset--color--vk-color-primary, #337ab7);
+				background-color: var(--wp--preset--color--vk-color-primary);
 			}
 			&.has-vk-color-primary-dark-color {
 				background-color: var(--wp--preset--color--vk-color-primary-dark);

--- a/src/blocks/button/style.scss
+++ b/src/blocks/button/style.scss
@@ -401,7 +401,6 @@ a.vk_button_link {
 			// .btn指定がないと編集画面で標準の .btn の指定に負ける
 			// X-T9で .has-background に対して padding:0; 指定しているので、左右余白が 0 にならないように上書き
 			padding: 0.6em 1.5rem;
-			-webkit-user-select: text;
 			user-select: text;
 			text-decoration: none;
 			font-size: calc( 1rem * 1 );

--- a/src/blocks/button/style.scss
+++ b/src/blocks/button/style.scss
@@ -401,6 +401,7 @@ a.vk_button_link {
 			// .btn指定がないと編集画面で標準の .btn の指定に負ける
 			// X-T9で .has-background に対して padding:0; 指定しているので、左右余白が 0 にならないように上書き
 			padding: 0.6em 1.5rem;
+			-webkit-user-select: text;
 			user-select: text;
 			text-decoration: none;
 			font-size: calc( 1rem * 1 );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
#2554

## どういう変更をしたか？

<!-- [ このプルリクで変更した事を記載してください ] -->
<!-- [ プログラムの不具合修正の場合、再発防止の情報共有 & レビューしやすいように、簡単で良いので何が原因で不具合が発生し、対策としてどういう処理をしたのかを記載してください ] -->

vk-color-primary の CSS カスタムプロパティにフォールバック値 #337ab7 を追加し、カラーパレットが未設定の環境でもボタンなどの配色が適切に表示されるように修正しました。
ご確認はお一人でOKです。

### スクリーンショットまたは動画

#### 変更前 Before
![スクリーンショット 2025-07-01 16 35 50](https://github.com/user-attachments/assets/3a3ab5f0-e70f-4c48-a300-e37423e65146)

#### 変更後 After
![スクリーンショット 2025-07-01 16 51 08](https://github.com/user-attachments/assets/d822c702-123f-441a-88b3-906a8b3efa86)

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] 機能追加・不具合修正のプルリクなのに worklows の変更などを含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] 本プルリクの意図と関係ないコード整形を含んでいないか？  （含んでいる場合はその変更を別でプルリクにして先にマージしてください。）
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] readme.txt に記載の変更内容はエンドユーザーが見て変更の概要がわかるように書かれているか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

<!-- テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。 -->

- [ ] 書けそうなテストは書いたか？ → CSSのみなのでスキップ

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

<!-- [ 実装者が確認した手順を箇条書きで記載してください。予備知識のないレビュワーが見て再現しやすい手順で記載してください。 ] -->

1. テーマをTT5に設定
2. 固定ページでボタンブロックを挿入した時にボタンの色がつくことを確認
3. ボタンスタイルを変更しても適切な箇所に色がつくことを確認
4. 保存後、フロントエンドでも色がつくことを確認
5. 編集画面に戻り、色を設定した時に適切に色がつくことを確認
6. 保存後、フロントエンドでも色がつくことを確認

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

実装者と同じ確認を行ってください。

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
